### PR TITLE
Organizar integraciones por pestañas y flujo para desarrolladores

### DIFF
--- a/index.html
+++ b/index.html
@@ -2028,6 +2028,18 @@
     .small{ font-size:12px; line-height:1.5 }
     .settings-card{ display:flex; flex-direction:column; gap:var(--space); }
     .integration-layout{ display:flex; flex-direction:column; gap:var(--space); }
+    .integration-content{ display:flex; flex-direction:column; gap:var(--space); flex:1; }
+    .integration-tabs{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .integration-tabs__list{ display:flex; align-items:center; flex-wrap:wrap; gap:var(--space-xs); }
+    .integration-tab{ border:none; border-radius:999px; background:rgba(var(--panel-base-rgb),0.12); color:var(--muted); font-weight:700; letter-spacing:.2px; padding:8px 18px; cursor:pointer; transition:background .2s ease, color .2s ease, box-shadow .2s ease; }
+    .integration-tab:is(:hover,:focus-visible){ background:rgba(var(--panel-base-rgb),0.2); color:var(--text); outline:none; box-shadow:0 0 0 3px rgba(var(--panel-base-rgb),0.24); }
+    .integration-tab.is-active{ background:rgba(var(--panel-base-rgb),0.28); color:var(--text); box-shadow:inset 0 1px 0 rgba(255,255,255,0.18); }
+    html[data-theme="light"] .integration-tab{ background:rgba(var(--panel-base-rgb),0.1); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 40%, #475569 60%); }
+    html[data-theme="light"] .integration-tab.is-active{ background:rgba(var(--panel-base-rgb),0.16); box-shadow:inset 0 1px 0 rgba(255,255,255,0.7); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 20%, #0f172a 80%); }
+    .integration-tab[hidden]{ display:none !important; }
+    .integration-tabs__panels{ display:flex; flex-direction:column; gap:var(--space); }
+    .integration-tabpanel{ display:none; }
+    .integration-tabpanel.is-active{ display:block; }
     .integration-grid{ display:grid; gap:var(--space); grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); }
     .integration-card{ background:var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); padding:calc(var(--space)*0.9); box-shadow:inset 0 1px 0 rgba(255,255,255,0.04); display:flex; flex-direction:column; gap:var(--space-sm); position:relative; overflow:hidden; }
     html[data-theme="light"] .integration-card{ border-color:rgba(15,23,42,0.08); box-shadow:inset 0 1px 0 rgba(255,255,255,0.8); }
@@ -2041,6 +2053,12 @@
     .integration-card__body{ color:var(--muted); font-size:0.95rem; display:flex; flex-direction:column; gap:var(--space-sm); }
     .integration-card__actions{ display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; }
     .integration-card__meta{ font-size:0.8rem; color:var(--muted); }
+    .integration-empty{ margin:var(--space-sm) 0 0; font-size:0.9rem; color:var(--muted); }
+    .integration-dev-controls{ margin-top:auto; padding-top:var(--space-sm); border-top:1px dashed rgba(var(--panel-base-rgb),0.32); display:flex; flex-direction:column; gap:var(--space-xs); font-size:0.85rem; color:var(--muted); }
+    .integration-dev-controls__status{ font-weight:600; color:var(--text); }
+    .integration-dev-controls__actions{ display:flex; flex-wrap:wrap; gap:var(--space-xs); }
+    html[data-theme="light"] .integration-dev-controls{ border-color:rgba(var(--panel-base-rgb),0.24); }
+    html[data-theme="light"] .integration-dev-controls__status{ color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 22%, #0f172a 78%); }
     .integration-help{ background:rgba(var(--panel-base-rgb),0.14); border-radius:var(--radius); padding:calc(var(--space)*0.9); border:1px solid rgba(var(--panel-base-rgb),0.28); box-shadow:0 12px 30px rgba(var(--panel-base-rgb),0.18); }
     html[data-theme="light"] .integration-help{ background:color-mix(in srgb, var(--card) 84%, var(--panel-base-soft) 16%); border-color:rgba(var(--panel-base-rgb),0.24); box-shadow:0 16px 34px rgba(var(--panel-base-rgb),0.12); }
     .integration-help h4{ margin:0 0 var(--space-sm); font-size:1.05rem; }
@@ -3435,92 +3453,138 @@
             <p class="muted">Conecta los servicios que usas a diario para centralizar conversaciones, llamadas y flujos operativos sin salir de ReLead EDU. Cada vínculo se realiza con tus credenciales personales y puede revocarse en cualquier momento.</p>
           </div>
           <div class="panel-section integration-layout">
-            <div class="integration-grid" role="list">
-              <article class="integration-card" role="listitem" aria-labelledby="integration-whatsapp-title">
-                <div class="integration-card__header">
-                  <div>
-                    <div class="integration-card__title" id="integration-whatsapp-title"><i class="bi bi-whatsapp" aria-hidden="true"></i> <span>WhatsApp Web personal</span></div>
-                    <div class="integration-card__status integration-status--beta"><i class="bi bi-dash-circle" aria-hidden="true"></i> <span>Sin conexión activa</span></div>
-                  </div>
-                  <span class="integration-tag">Sesión manual</span>
+            <div class="integration-content">
+              <div class="integration-tabs" id="integrationTabs">
+                <div class="integration-tabs__list" role="tablist" aria-label="Categorías de integraciones">
+                  <button type="button" class="integration-tab is-active" data-integration-tab="general" role="tab" aria-selected="true" aria-controls="integration-panel-general" id="integration-tab-general">Integraciones activas</button>
+                  <button type="button" class="integration-tab" data-integration-tab="developer" role="tab" aria-selected="false" aria-controls="integration-panel-developer" id="integration-tab-developer" hidden>Desarrollador</button>
                 </div>
-                <div class="integration-card__body">
-                  <p>Escanea el código QR desde tu teléfono para responder mensajes desde el panel de leads sin perder el historial institucional.</p>
-                  <div class="integration-card__actions">
-                    <button type="button" class="btn primary"><i class="bi bi-qr-code-scan"></i> Iniciar emparejamiento</button>
-                    <button type="button" class="btn outline"><i class="bi bi-box-arrow-up-right"></i> Abrir WhatsApp Web</button>
+                <div class="integration-tabs__panels">
+                  <div id="integration-panel-general" class="integration-tabpanel is-active" data-integration-panel="general" role="tabpanel" aria-labelledby="integration-tab-general">
+                    <div class="integration-grid" id="integrationGridGeneral" role="list">
+                      <article class="integration-card" role="listitem" aria-labelledby="integration-whatsapp-title">
+                        <div class="integration-card__header">
+                          <div>
+                            <div class="integration-card__title" id="integration-whatsapp-title" data-integration-title><i class="bi bi-whatsapp" aria-hidden="true"></i> <span>WhatsApp Web personal</span></div>
+                            <div class="integration-card__status integration-status--beta"><i class="bi bi-dash-circle" aria-hidden="true"></i> <span>Sin conexión activa</span></div>
+                          </div>
+                          <span class="integration-tag">Sesión manual</span>
+                        </div>
+                        <div class="integration-card__body">
+                          <p>Escanea el código QR desde tu teléfono para responder mensajes desde el panel de leads sin perder el historial institucional.</p>
+                          <div class="integration-card__actions">
+                            <button type="button" class="btn primary"><i class="bi bi-qr-code-scan"></i> Iniciar emparejamiento</button>
+                            <button type="button" class="btn outline"><i class="bi bi-box-arrow-up-right"></i> Abrir WhatsApp Web</button>
+                          </div>
+                          <p class="integration-card__meta">La sesión expira automáticamente al cerrar el navegador o después de 14&nbsp;horas de inactividad.</p>
+                        </div>
+                      </article>
+                    </div>
+                    <p class="integration-empty hidden" id="integrationGeneralEmpty">No hay integraciones disponibles en esta categoría.</p>
                   </div>
-                  <p class="integration-card__meta">La sesión expira automáticamente al cerrar el navegador o después de 14&nbsp;horas de inactividad.</p>
-                </div>
-              </article>
-              <article class="integration-card" role="listitem" aria-labelledby="integration-aircall-title">
-                <div class="integration-card__header">
-                  <div>
-                    <div class="integration-card__title" id="integration-aircall-title"><i class="bi bi-telephone" aria-hidden="true"></i> <span>Aircall Workspace</span></div>
-                    <div class="integration-card__status integration-status--beta"><i class="bi bi-plug" aria-hidden="true"></i> <span>Pendiente de vincular</span></div>
+                  <div id="integration-panel-developer" class="integration-tabpanel" data-integration-panel="developer" role="tabpanel" aria-labelledby="integration-tab-developer" hidden>
+                    <div class="integration-grid" id="integrationGridDeveloper" role="list">
+                      <article class="integration-card" role="listitem" aria-labelledby="integration-aircall-title" data-integration-id="aircall">
+                        <div class="integration-card__header">
+                          <div>
+                            <div class="integration-card__title" id="integration-aircall-title" data-integration-title><i class="bi bi-telephone" aria-hidden="true"></i> <span>Aircall Workspace</span></div>
+                            <div class="integration-card__status integration-status--beta"><i class="bi bi-plug" aria-hidden="true"></i> <span>Pendiente de vincular</span></div>
+                          </div>
+                          <span class="integration-tag">VoIP</span>
+                        </div>
+                        <div class="integration-card__body">
+                          <p>Sincroniza tus llamadas y listas de contactos para marcar con un clic y registrar notas desde el tablero.</p>
+                          <div class="integration-card__actions">
+                            <button type="button" class="btn primary"><i class="bi bi-cloud-upload"></i> Conectar workspace</button>
+                            <a href="https://dashboard.aircall.io/" target="_blank" rel="noreferrer" class="btn outline"><i class="bi bi-box-arrow-up-right"></i> Abrir Aircall</a>
+                          </div>
+                          <p class="integration-card__meta">Requiere permisos de administrador en tu organización de Aircall para autorizar la aplicación.</p>
+                        </div>
+                        <div class="integration-dev-controls" data-dev-only>
+                          <span class="integration-dev-controls__status" data-dev-status>Disponible solo para revisión interna.</span>
+                          <div class="integration-dev-controls__actions">
+                            <button type="button" class="btn micro" data-action="publishIntegration" data-integration-id="aircall"><i class="bi bi-rocket-takeoff"></i> Publicar en Integraciones</button>
+                            <button type="button" class="btn micro outline" data-action="revertIntegration" data-integration-id="aircall" hidden><i class="bi bi-arrow-counterclockwise"></i> Retirar de integraciones</button>
+                          </div>
+                        </div>
+                      </article>
+                      <article class="integration-card" role="listitem" aria-labelledby="integration-gmail-title" data-integration-id="gmail">
+                        <div class="integration-card__header">
+                          <div>
+                            <div class="integration-card__title" id="integration-gmail-title" data-integration-title><i class="bi bi-envelope-at" aria-hidden="true"></i> <span>Gmail institucional</span></div>
+                            <div class="integration-card__status integration-status--beta"><i class="bi bi-shield-lock" aria-hidden="true"></i> <span>Autorización requerida</span></div>
+                          </div>
+                          <span class="integration-tag">OAuth</span>
+                        </div>
+                        <div class="integration-card__body">
+                          <p>Autoriza tu buzón institucional para enviar correos de seguimiento y registrar plantillas sin salir del panel.</p>
+                          <div class="integration-card__actions">
+                            <button type="button" class="btn primary"><i class="bi bi-unlock"></i> Vincular cuenta</button>
+                            <button type="button" class="btn"><i class="bi bi-arrow-clockwise"></i> Revisar autorizaciones</button>
+                          </div>
+                          <p class="integration-card__meta">Tu token se almacena cifrado y puedes revocarlo desde la consola de seguridad de Google Workspace.</p>
+                        </div>
+                        <div class="integration-dev-controls" data-dev-only>
+                          <span class="integration-dev-controls__status" data-dev-status>Disponible solo para revisión interna.</span>
+                          <div class="integration-dev-controls__actions">
+                            <button type="button" class="btn micro" data-action="publishIntegration" data-integration-id="gmail"><i class="bi bi-rocket-takeoff"></i> Publicar en Integraciones</button>
+                            <button type="button" class="btn micro outline" data-action="revertIntegration" data-integration-id="gmail" hidden><i class="bi bi-arrow-counterclockwise"></i> Retirar de integraciones</button>
+                          </div>
+                        </div>
+                      </article>
+                      <article class="integration-card" role="listitem" aria-labelledby="integration-neotel-title" data-integration-id="neotel">
+                        <div class="integration-card__header">
+                          <div>
+                            <div class="integration-card__title" id="integration-neotel-title" data-integration-title><i class="bi bi-broadcast" aria-hidden="true"></i> <span>Neotel</span></div>
+                            <div class="integration-card__status integration-status--beta"><i class="bi bi-bezier" aria-hidden="true"></i> <span>Programa beta</span></div>
+                          </div>
+                          <span class="integration-tag">Beta cerrada</span>
+                        </div>
+                        <div class="integration-card__body">
+                          <p>Activa la marcación automática y el registro de llamadas proveniente de la plataforma Neotel para agilizar la gestión.</p>
+                          <div class="integration-card__actions">
+                            <button type="button" class="btn primary"><i class="bi bi-rocket"></i> Solicitar acceso</button>
+                            <button type="button" class="btn outline"><i class="bi bi-card-checklist"></i> Ver requisitos</button>
+                          </div>
+                          <p class="integration-card__meta">La integración está disponible sólo para equipos piloto. Recibirás instrucciones personalizadas al aprobarse tu solicitud.</p>
+                        </div>
+                        <div class="integration-dev-controls" data-dev-only>
+                          <span class="integration-dev-controls__status" data-dev-status>Disponible solo para revisión interna.</span>
+                          <div class="integration-dev-controls__actions">
+                            <button type="button" class="btn micro" data-action="publishIntegration" data-integration-id="neotel"><i class="bi bi-rocket-takeoff"></i> Publicar en Integraciones</button>
+                            <button type="button" class="btn micro outline" data-action="revertIntegration" data-integration-id="neotel" hidden><i class="bi bi-arrow-counterclockwise"></i> Retirar de integraciones</button>
+                          </div>
+                        </div>
+                      </article>
+                      <article class="integration-card" role="listitem" aria-labelledby="integration-siie-title" data-integration-id="siie">
+                        <div class="integration-card__header">
+                          <div>
+                            <div class="integration-card__title" id="integration-siie-title" data-integration-title><i class="bi bi-mortarboard" aria-hidden="true"></i> <span>SIIE UNIDEP</span></div>
+                            <div class="integration-card__status integration-status--beta"><i class="bi bi-exclamation-circle" aria-hidden="true"></i> <span>En pruebas internas</span></div>
+                          </div>
+                          <span class="integration-tag">Beta</span>
+                        </div>
+                        <div class="integration-card__body">
+                          <p>Sincroniza expedientes académicos desde <a href="https://siie-unidep.csweb.mx/" target="_blank" rel="noreferrer">siie-unidep.csweb.mx</a> para validar inscripciones y estatus de seguimiento.</p>
+                          <div class="integration-card__actions">
+                            <button type="button" class="btn primary"><i class="bi bi-gear-wide-connected"></i> Configurar sandbox</button>
+                            <button type="button" class="btn"><i class="bi bi-clipboard-check"></i> Registrar credenciales</button>
+                          </div>
+                          <p class="integration-card__meta">Asegúrate de contar con un usuario de pruebas. Los datos reales permanecerán protegidos hasta el despliegue general.</p>
+                        </div>
+                        <div class="integration-dev-controls" data-dev-only>
+                          <span class="integration-dev-controls__status" data-dev-status>Disponible solo para revisión interna.</span>
+                          <div class="integration-dev-controls__actions">
+                            <button type="button" class="btn micro" data-action="publishIntegration" data-integration-id="siie"><i class="bi bi-rocket-takeoff"></i> Publicar en Integraciones</button>
+                            <button type="button" class="btn micro outline" data-action="revertIntegration" data-integration-id="siie" hidden><i class="bi bi-arrow-counterclockwise"></i> Retirar de integraciones</button>
+                          </div>
+                        </div>
+                      </article>
+                    </div>
+                    <p class="integration-empty hidden" id="integrationDeveloperEmpty">No hay integraciones en revisión interna.</p>
                   </div>
-                  <span class="integration-tag">VoIP</span>
                 </div>
-                <div class="integration-card__body">
-                  <p>Sincroniza tus llamadas y listas de contactos para marcar con un clic y registrar notas desde el tablero.</p>
-                  <div class="integration-card__actions">
-                    <button type="button" class="btn primary"><i class="bi bi-cloud-upload"></i> Conectar workspace</button>
-                    <a href="https://dashboard.aircall.io/" target="_blank" rel="noreferrer" class="btn outline"><i class="bi bi-box-arrow-up-right"></i> Abrir Aircall</a>
-                  </div>
-                  <p class="integration-card__meta">Requiere permisos de administrador en tu organización de Aircall para autorizar la aplicación.</p>
-                </div>
-              </article>
-              <article class="integration-card" role="listitem" aria-labelledby="integration-gmail-title">
-                <div class="integration-card__header">
-                  <div>
-                    <div class="integration-card__title" id="integration-gmail-title"><i class="bi bi-envelope-at" aria-hidden="true"></i> <span>Gmail institucional</span></div>
-                    <div class="integration-card__status integration-status--beta"><i class="bi bi-shield-lock" aria-hidden="true"></i> <span>Autorización requerida</span></div>
-                  </div>
-                  <span class="integration-tag">OAuth</span>
-                </div>
-                <div class="integration-card__body">
-                  <p>Autoriza tu buzón institucional para enviar correos de seguimiento y registrar plantillas sin salir del panel.</p>
-                  <div class="integration-card__actions">
-                    <button type="button" class="btn primary"><i class="bi bi-unlock"></i> Vincular cuenta</button>
-                    <button type="button" class="btn"><i class="bi bi-arrow-clockwise"></i> Revisar autorizaciones</button>
-                  </div>
-                  <p class="integration-card__meta">Tu token se almacena cifrado y puedes revocarlo desde la consola de seguridad de Google Workspace.</p>
-                </div>
-              </article>
-              <article class="integration-card" role="listitem" aria-labelledby="integration-neotel-title">
-                <div class="integration-card__header">
-                  <div>
-                    <div class="integration-card__title" id="integration-neotel-title"><i class="bi bi-broadcast" aria-hidden="true"></i> <span>Neotel</span></div>
-                    <div class="integration-card__status integration-status--beta"><i class="bi bi-bezier" aria-hidden="true"></i> <span>Programa beta</span></div>
-                  </div>
-                  <span class="integration-tag">Beta cerrada</span>
-                </div>
-                <div class="integration-card__body">
-                  <p>Activa la marcación automática y el registro de llamadas proveniente de la plataforma Neotel para agilizar la gestión.</p>
-                  <div class="integration-card__actions">
-                    <button type="button" class="btn primary"><i class="bi bi-rocket"></i> Solicitar acceso</button>
-                    <button type="button" class="btn outline"><i class="bi bi-card-checklist"></i> Ver requisitos</button>
-                  </div>
-                  <p class="integration-card__meta">La integración está disponible sólo para equipos piloto. Recibirás instrucciones personalizadas al aprobarse tu solicitud.</p>
-                </div>
-              </article>
-              <article class="integration-card" role="listitem" aria-labelledby="integration-siie-title">
-                <div class="integration-card__header">
-                  <div>
-                    <div class="integration-card__title" id="integration-siie-title"><i class="bi bi-mortarboard" aria-hidden="true"></i> <span>SIIE UNIDEP</span></div>
-                    <div class="integration-card__status integration-status--beta"><i class="bi bi-exclamation-circle" aria-hidden="true"></i> <span>En pruebas internas</span></div>
-                  </div>
-                  <span class="integration-tag">Beta</span>
-                </div>
-                <div class="integration-card__body">
-                  <p>Sincroniza expedientes académicos desde <a href="https://siie-unidep.csweb.mx/" target="_blank" rel="noreferrer">siie-unidep.csweb.mx</a> para validar inscripciones y estatus de seguimiento.</p>
-                  <div class="integration-card__actions">
-                    <button type="button" class="btn primary"><i class="bi bi-gear-wide-connected"></i> Configurar sandbox</button>
-                    <button type="button" class="btn"><i class="bi bi-clipboard-check"></i> Registrar credenciales</button>
-                  </div>
-                  <p class="integration-card__meta">Asegúrate de contar con un usuario de pruebas. Los datos reales permanecerán protegidos hasta el despliegue general.</p>
-                </div>
-              </article>
+              </div>
             </div>
             <aside class="integration-help" aria-label="Recomendaciones de seguridad">
               <h4><span aria-hidden="true">🛡️</span> Buenas prácticas al vincular servicios</h4>
@@ -5132,7 +5196,8 @@
     whatsappLastTemplate: 'pulseWhatsappLastTemplate',
     emailTemplates: 'pulseEmailTemplates',
     emailLastTemplate: 'pulseEmailLastTemplate',
-    advisorWhatsapp: 'pulseAdvisorWhatsapp'
+    advisorWhatsapp: 'pulseAdvisorWhatsapp',
+    integrationRelease: 'pulseIntegrationRelease'
   };
   const DEFAULT_PASSWORD_REQUEST = {
     status: 'idle',
@@ -5143,6 +5208,18 @@
     completedAt: 0,
     completedBy: ''
   };
+  const INTEGRATION_DEFAULT_STAGE = {
+    aircall: 'developer',
+    gmail: 'developer',
+    neotel: 'developer',
+    siie: 'developer'
+  };
+  const INTEGRATION_GENERAL_TAB = 'general';
+  const INTEGRATION_DEVELOPER_TAB = 'developer';
+  let integrationReleaseState = null;
+  const integrationDeveloperCards = new Map();
+  const integrationPublicCards = new Map();
+  let integrationTabsReady = false;
   const DEFAULT_LOGIN_HINT = '';
   const DEFAULT_RESET_HINT = 'La contraseña temporal se muestra una sola vez. Cámbiala desde Configuración después de entrar.';
   const DEFAULT_PROFILE = {
@@ -5205,7 +5282,7 @@
     exportar: ['admin','coordinador','viewer'],
     sistema: ['admin','coordinador','viewer'],
     permisos: ['admin'],
-    integraciones: ['admin','coordinador','asesor','viewer'],
+    integraciones: ['admin','coordinador','asesor','viewer','developer'],
     configuracion: ['admin','coordinador','asesor','viewer'],
     ayuda: ['admin','coordinador','asesor','viewer']
   };
@@ -5224,7 +5301,8 @@
     admin: 'Administrador',
     coordinador: 'Coordinador',
     asesor: 'Asesor',
-    viewer: 'Consulta'
+    viewer: 'Consulta',
+    developer: 'Desarrollador'
   };
   const ROLE_ORDER = ['admin','coordinador','asesor','viewer'];
   const PERMISSION_REFERENCE = {
@@ -8760,6 +8838,7 @@
         fallbackLink = link;
       }
     });
+    applyIntegrationRoleVisibility();
     const activeLink = links.find(link => link.classList.contains('active') && !link.classList.contains('hidden'));
     const targetLink = activeLink && canAccessView(activeLink.dataset.nav) ? activeLink : fallbackLink;
     if(targetLink){
@@ -9564,6 +9643,272 @@
     }catch(err){
       console.warn('No se pudo guardar', key, err);
     }
+  }
+  function normalizeIntegrationId(id){
+    return String(id || '').trim().toLowerCase();
+  }
+  function getIntegrationDefaultStage(id){
+    const normalized = normalizeIntegrationId(id);
+    return INTEGRATION_DEFAULT_STAGE[normalized] || 'general';
+  }
+  function loadIntegrationReleaseState(){
+    const stored = readStorageJSON(STORAGE_KEYS.integrationRelease);
+    if(!stored || typeof stored !== 'object') return {};
+    const state = {};
+    Object.entries(stored).forEach(([key, value]) => {
+      const normalized = normalizeIntegrationId(key);
+      if(!normalized) return;
+      state[normalized] = value === 'general' ? 'general' : 'developer';
+    });
+    return state;
+  }
+  function persistIntegrationReleaseState(){
+    if(!integrationReleaseState) return;
+    const payload = {};
+    Object.entries(integrationReleaseState).forEach(([key, value]) => {
+      if(!key) return;
+      const normalizedStage = value === 'general' ? 'general' : 'developer';
+      const defaultStage = getIntegrationDefaultStage(key);
+      if(normalizedStage !== defaultStage){
+        payload[key] = normalizedStage;
+      }
+    });
+    if(Object.keys(payload).length){
+      writeStorageJSON(STORAGE_KEYS.integrationRelease, payload);
+    }else{
+      removeStorageKey(STORAGE_KEYS.integrationRelease);
+    }
+  }
+  function getIntegrationStage(id){
+    const normalized = normalizeIntegrationId(id);
+    if(!normalized) return 'general';
+    if(integrationReleaseState && Object.prototype.hasOwnProperty.call(integrationReleaseState, normalized)){
+      return integrationReleaseState[normalized] === 'general' ? 'general' : 'developer';
+    }
+    return getIntegrationDefaultStage(normalized);
+  }
+  function setIntegrationStage(id, stage){
+    const normalized = normalizeIntegrationId(id);
+    if(!normalized) return;
+    if(!integrationReleaseState){
+      integrationReleaseState = {};
+    }
+    const nextStage = stage === 'general' ? 'general' : 'developer';
+    const defaultStage = getIntegrationDefaultStage(normalized);
+    if(nextStage === defaultStage){
+      delete integrationReleaseState[normalized];
+    }else{
+      integrationReleaseState[normalized] = nextStage;
+    }
+    persistIntegrationReleaseState();
+    refreshIntegrationCard(normalized);
+  }
+  function refreshIntegrationCard(id){
+    updateDeveloperCardState(id);
+    syncPublicCard(id);
+    updateIntegrationEmptyStates();
+  }
+  function refreshIntegrationCards(){
+    integrationDeveloperCards.forEach((_card, id) => {
+      refreshIntegrationCard(id);
+    });
+  }
+  function updateDeveloperCardState(id){
+    const card = integrationDeveloperCards.get(id);
+    if(!card) return;
+    const stage = getIntegrationStage(id);
+    card.dataset.integrationStage = stage;
+    const publishBtn = card.querySelector('[data-action="publishIntegration"]');
+    const revertBtn = card.querySelector('[data-action="revertIntegration"]');
+    if(publishBtn){
+      publishBtn.hidden = stage === 'general';
+      publishBtn.disabled = stage === 'general';
+    }
+    if(revertBtn){
+      revertBtn.hidden = stage !== 'general';
+      revertBtn.disabled = stage !== 'general';
+    }
+    const statusLabel = card.querySelector('[data-dev-status]');
+    if(statusLabel){
+      statusLabel.textContent = stage === 'general'
+        ? 'Visible para todos los roles desde Integraciones.'
+        : 'Disponible solo para revisión interna.';
+    }
+  }
+  function cloneIntegrationForPublic(card, id){
+    if(!card) return null;
+    const clone = card.cloneNode(true);
+    clone.dataset.integrationClone = 'public';
+    clone.querySelectorAll('[data-dev-only]').forEach(node => node.remove());
+    const title = clone.querySelector('[data-integration-title]');
+    const originalTitleId = title ? title.id : '';
+    const publicId = originalTitleId ? `${originalTitleId}-public` : `integration-${id}-title-public`;
+    if(title){
+      title.id = publicId;
+    }
+    const labelledBy = clone.getAttribute('aria-labelledby') || '';
+    if(labelledBy){
+      const tokens = labelledBy.split(/\s+/).filter(Boolean).map(token => token === originalTitleId ? publicId : token);
+      clone.setAttribute('aria-labelledby', tokens.length ? tokens.join(' ') : publicId);
+    }else if(publicId){
+      clone.setAttribute('aria-labelledby', publicId);
+    }
+    return clone;
+  }
+  function syncPublicCard(id){
+    const stage = getIntegrationStage(id);
+    const generalGrid = document.getElementById('integrationGridGeneral');
+    if(!generalGrid) return;
+    const existing = integrationPublicCards.get(id);
+    if(stage === 'general'){
+      if(existing && generalGrid.contains(existing)) return;
+      const sourceCard = integrationDeveloperCards.get(id);
+      if(!sourceCard) return;
+      const clone = cloneIntegrationForPublic(sourceCard, id);
+      if(!clone) return;
+      clone.dataset.integrationId = id;
+      generalGrid.appendChild(clone);
+      integrationPublicCards.set(id, clone);
+    }else if(existing){
+      existing.remove();
+      integrationPublicCards.delete(id);
+    }
+  }
+  function updateIntegrationEmptyStates(){
+    const generalGrid = document.getElementById('integrationGridGeneral');
+    const generalEmpty = document.getElementById('integrationGeneralEmpty');
+    if(generalGrid && generalEmpty){
+      const hasItems = generalGrid.querySelectorAll('.integration-card').length > 0;
+      generalEmpty.classList.toggle('hidden', hasItems);
+    }
+    const developerGrid = document.getElementById('integrationGridDeveloper');
+    const developerEmpty = document.getElementById('integrationDeveloperEmpty');
+    if(developerGrid && developerEmpty){
+      const hasItems = developerGrid.querySelectorAll('.integration-card').length > 0;
+      developerEmpty.classList.toggle('hidden', hasItems);
+    }
+  }
+  function activateIntegrationTab(tab){
+    const section = document.getElementById('view-integraciones');
+    if(!section) return;
+    const targetTab = section.querySelector(`[data-integration-tab="${tab}"]`);
+    const targetPanel = section.querySelector(`[data-integration-panel="${tab}"]`);
+    if(!targetTab || !targetPanel || targetTab.hidden || targetTab.disabled){
+      if(tab !== INTEGRATION_GENERAL_TAB){
+        activateIntegrationTab(INTEGRATION_GENERAL_TAB);
+      }
+      return;
+    }
+    const tabs = Array.from(section.querySelectorAll('[data-integration-tab]'));
+    tabs.forEach(button => {
+      const isActive = button === targetTab;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.setAttribute('tabindex', isActive ? '0' : '-1');
+    });
+    const panels = Array.from(section.querySelectorAll('.integration-tabpanel'));
+    panels.forEach(panel => {
+      const isActive = panel === targetPanel;
+      panel.classList.toggle('is-active', isActive);
+      if(isActive){
+        panel.removeAttribute('hidden');
+        panel.setAttribute('aria-hidden', 'false');
+      }else{
+        panel.setAttribute('hidden', '');
+        panel.setAttribute('aria-hidden', 'true');
+      }
+    });
+    section.dataset.activeTab = tab;
+  }
+  function applyIntegrationRoleVisibility(){
+    const section = document.getElementById('view-integraciones');
+    if(!section) return;
+    const role = getUserRole();
+    const isDeveloper = role === 'developer';
+    const developerTab = section.querySelector(`[data-integration-tab="${INTEGRATION_DEVELOPER_TAB}"]`);
+    const developerPanel = section.querySelector(`[data-integration-panel="${INTEGRATION_DEVELOPER_TAB}"]`);
+    if(developerTab){
+      developerTab.hidden = !isDeveloper;
+      developerTab.setAttribute('aria-hidden', isDeveloper ? 'false' : 'true');
+      developerTab.disabled = !isDeveloper;
+      if(!isDeveloper){
+        developerTab.classList.remove('is-active');
+        developerTab.setAttribute('aria-selected', 'false');
+        developerTab.setAttribute('tabindex', '-1');
+      }
+    }
+    if(developerPanel){
+      if(isDeveloper){
+        developerPanel.removeAttribute('hidden');
+        developerPanel.setAttribute('aria-hidden', 'false');
+      }else{
+        developerPanel.setAttribute('hidden', '');
+        developerPanel.setAttribute('aria-hidden', 'true');
+      }
+    }
+    const devOnlyElements = section.querySelectorAll('[data-dev-only]');
+    devOnlyElements.forEach(node => {
+      node.hidden = !isDeveloper;
+    });
+    if(!isDeveloper && section.dataset.activeTab === INTEGRATION_DEVELOPER_TAB){
+      activateIntegrationTab(INTEGRATION_GENERAL_TAB);
+    }
+  }
+  function setupIntegrationTabs(){
+    if(integrationTabsReady) return;
+    const section = document.getElementById('view-integraciones');
+    if(!section) return;
+    integrationReleaseState = loadIntegrationReleaseState();
+    const developerGrid = section.querySelector('#integrationGridDeveloper');
+    if(developerGrid){
+      const cards = Array.from(developerGrid.querySelectorAll('.integration-card[data-integration-id]'));
+      cards.forEach(card => {
+        const id = normalizeIntegrationId(card.dataset.integrationId);
+        if(!id) return;
+        integrationDeveloperCards.set(id, card);
+        const publishBtn = card.querySelector('[data-action="publishIntegration"]');
+        const revertBtn = card.querySelector('[data-action="revertIntegration"]');
+        if(publishBtn){
+          publishBtn.addEventListener('click', () => setIntegrationStage(id, 'general'));
+        }
+        if(revertBtn){
+          revertBtn.addEventListener('click', () => setIntegrationStage(id, 'developer'));
+        }
+      });
+    }
+    const tabButtons = Array.from(section.querySelectorAll('[data-integration-tab]'));
+    const handleKeydown = event => {
+      const key = event.key;
+      if(key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return;
+      const visibleTabs = tabButtons.filter(btn => !btn.hidden && !btn.disabled);
+      const current = event.currentTarget;
+      const index = visibleTabs.indexOf(current);
+      if(index === -1 || !visibleTabs.length) return;
+      event.preventDefault();
+      let nextIndex = index;
+      if(key === 'ArrowRight'){
+        nextIndex = (index + 1) % visibleTabs.length;
+      }else if(key === 'ArrowLeft'){
+        nextIndex = (index - 1 + visibleTabs.length) % visibleTabs.length;
+      }else if(key === 'Home'){
+        nextIndex = 0;
+      }else if(key === 'End'){
+        nextIndex = visibleTabs.length - 1;
+      }
+      const nextTab = visibleTabs[nextIndex];
+      if(nextTab){
+        nextTab.focus();
+        nextTab.click();
+      }
+    };
+    tabButtons.forEach(btn => {
+      btn.addEventListener('click', () => activateIntegrationTab(btn.dataset.integrationTab));
+      btn.addEventListener('keydown', handleKeydown);
+    });
+    activateIntegrationTab(INTEGRATION_GENERAL_TAB);
+    refreshIntegrationCards();
+    applyIntegrationRoleVisibility();
+    integrationTabsReady = true;
   }
   const QUICK_ACCESS_FAVORITES_LIMIT = 20;
   const QUICK_ACCESS_RECENTS_LIMIT = 10;
@@ -14203,6 +14548,7 @@
       const hideSidebar = window.innerWidth <= 900;
       sidebarNav.setAttribute('aria-hidden', hideSidebar ? 'true' : 'false');
     }
+    setupIntegrationTabs();
     const navLinks = getNavigationLinks();
     const handleNavClick = event => {
       event.preventDefault();


### PR DESCRIPTION
## Summary
- reorganize the Integraciones view with tabs to separate activas y Desarrollador
- agregar controles para publicar o retirar integraciones desde la pestaña de desarrollador sin modificar código
- ajustar permisos y persistencia local para soportar el rol Desarrollador y recordar el estado de publicación

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d1a3eb7410832c92b6ecec00350589