### PR TITLE
Improve WhatsApp Web launch reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -10583,14 +10583,39 @@
 
   function openWhatsappWebWindow(){
     try{
-      const popup = window.open(WHATSAPP_WEB_URL, '_blank', 'noopener');
-      if(!popup){
-        alert('No se pudo abrir WhatsApp Web. Desactiva el bloqueador de ventanas emergentes e inténtalo de nuevo.');
-        return false;
+      const popup = window.open(WHATSAPP_WEB_URL, '_blank', 'noopener,noreferrer');
+      if(popup){
+        if(typeof popup.focus === 'function'){
+          popup.focus();
+        }
+        return true;
       }
-      if(typeof popup.focus === 'function'){
-        popup.focus();
+      const body = document.body;
+      if(body){
+        const link = document.createElement('a');
+        link.href = WHATSAPP_WEB_URL;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.style.position = 'absolute';
+        link.style.width = '1px';
+        link.style.height = '1px';
+        link.style.overflow = 'hidden';
+        link.style.clip = 'rect(0 0 0 0)';
+        body.appendChild(link);
+        link.click();
+        const cleanup = () => {
+          if(link.parentNode){
+            link.parentNode.removeChild(link);
+          }
+        };
+        if(typeof window.requestAnimationFrame === 'function'){
+          window.requestAnimationFrame(cleanup);
+        }else{
+          setTimeout(cleanup, 0);
+        }
+        return true;
       }
+      window.location.assign(WHATSAPP_WEB_URL);
       return true;
     }catch(err){
       console.error('No se pudo abrir WhatsApp Web.', err);


### PR DESCRIPTION
## Summary
- update the WhatsApp Web opener to request a popup with `noopener,noreferrer`
- add fallbacks that fire a hidden anchor or navigate the window when popups are blocked
- ensure temporary anchors are cleaned up after triggering the navigation

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f7ac28ec832c94e08becbf975f34