### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -8686,8 +8686,25 @@
     "link[rel='apple-touch-icon']",
   ];
 
+  // Allows only http(s) URLs and data:image URIs as favicon sources
+  function sanitizeFaviconUrl(url) {
+    if (typeof url !== 'string' || !url) return DEFAULT_FAVICON_URL;
+    url = url.trim();
+    try {
+      // Allow data:image/*, http(s) and relative URLs; block javascript: and others
+      if (/^data:image\//i.test(url)) return url;
+      // Skip dangerous schemes (like javascript:)
+      const urlObj = new URL(url, window.location.origin);
+      if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') return urlObj.href;
+    } catch(e) {
+      // Could not parse as a valid URL, possibly a relative path
+      if (url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) return url;
+    }
+    return DEFAULT_FAVICON_URL;
+  }
+
   function updateDocumentFavicons(src){
-    const href = src || DEFAULT_FAVICON_URL;
+    const href = sanitizeFaviconUrl(src || DEFAULT_FAVICON_URL);
     FAVICON_LINK_SELECTORS.forEach(selector => {
       const linkEl = document.head && document.head.querySelector(selector);
       if(linkEl){
@@ -8720,7 +8737,8 @@
 
   function getFaviconSource(){
     if(!brandImg) return DEFAULT_FAVICON_URL;
-    return brandImg.dataset.faviconSrc || brandImg.getAttribute('data-favicon-src') || DEFAULT_FAVICON_URL;
+    const src = brandImg.dataset.faviconSrc || brandImg.getAttribute('data-favicon-src') || DEFAULT_FAVICON_URL;
+    return sanitizeFaviconUrl(src);
   }
 
   function applyBrandLogoState(){


### PR DESCRIPTION
Potential fix for [https://github.com/ricardomartinezh-code/CRM/security/code-scanning/9](https://github.com/ricardomartinezh-code/CRM/security/code-scanning/9)

**General fix:**  
Strictly validate and sanitize the value extracted from the DOM (`data-favicon-src`) before assigning it to the `href` property of any link element. The favicon should only ever be set to a safe, allowed image URL—preferably only those for which the protocol is `http:`, `https:`, or `data:image/`. Arbitrary values, especially those starting with `javascript:`, `data:text/html`, or similar, must not be allowed.

**Best way to fix:**  
1. Create a utility function (e.g., `sanitizeFaviconUrl`) that:
   - Ensures the URL protocol is one of the allowed image protocols.
   - Rejects or defaults to the safe image if the above checks do not pass.
2. Use this sanitizer in the flow:  
   - In `getFaviconSource()`, before returning `brandImg.dataset.faviconSrc` and `brandImg.getAttribute('data-favicon-src')`, sanitize these values.
   - In `updateDocumentFavicons()`, ensure the URL passed is sanitized.
   - Alternatively, sanitize once at the entry point (in `getFaviconSource`).
3. Minimal change: Add a `sanitizeFaviconUrl` function *above* its first use, and ensure all favicon URLs are routed through it.

**What to add:**  
- The utility method (`sanitizeFaviconUrl`), possibly at or above line 8688 (where the favicon routines start).
- Update `getFaviconSource()` to return a sanitized URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
