### PR TITLE
Update default API URL

### DIFF
--- a/config/app-config.js
+++ b/config/app-config.js
@@ -8,7 +8,7 @@
   const config = {
     API_URL:
       source.API_URL ||
-      'https://script.google.com/macros/s/AKfycbxeGlIDj_uA-uKH_Mza4Nkrf_xer0q-WiBHiesVN6pDEc_ow-77Buk7Qqxa7AeDFvDP/exec',
+      'https://script.google.com/macros/s/AKfycbzg0XHsW_fYiVhEcmp0WB3zmqQ9hV-usT0EDsnhwBlD8CSat3Gc_-lDOhMyGIUMjbcq/exec',
     REQUEST_TIMEOUT_MS: Number.isFinite(source.REQUEST_TIMEOUT_MS)
       ? source.REQUEST_TIMEOUT_MS
       : 45000,

--- a/index.html
+++ b/index.html
@@ -4011,7 +4011,7 @@
   <script>
   // —— Datos desde Google Sheets ——
   const appConfig = window.ReLeadConfig || {};
-  const API_URL = appConfig.API_URL || 'https://script.google.com/macros/s/AKfycbxeGlIDj_uA-uKH_Mza4Nkrf_xer0q-WiBHiesVN6pDEc_ow-77Buk7Qqxa7AeDFvDP/exec';
+  const API_URL = appConfig.API_URL || 'https://script.google.com/macros/s/AKfycbzg0XHsW_fYiVhEcmp0WB3zmqQ9hV-usT0EDsnhwBlD8CSat3Gc_-lDOhMyGIUMjbcq/exec';
   const REQUEST_TIMEOUT_MS = Number.isFinite(appConfig.REQUEST_TIMEOUT_MS) ? appConfig.REQUEST_TIMEOUT_MS : 45000;
   const SESSION_HEARTBEAT_INTERVAL_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_INTERVAL_MS)
     ? Math.max(60000, appConfig.SESSION_HEARTBEAT_INTERVAL_MS)


### PR DESCRIPTION
## Summary
- update the default Apps Script API URL used by the configuration and frontend fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4385a1ef0832ca86a73e4b3adb412