### PR TITLE
Fix reassignment state initialization to restore CRM view

### DIFF
--- a/index.html
+++ b/index.html
@@ -6651,6 +6651,9 @@
   const normalizeDigits = value => String(value || '').replace(/\D/g, '');
 
   const assignmentIsUnassigned = value => !normalizeAssignmentKey(value);
+  const assignmentCache = new Map();
+  let assignmentMode = 'single';
+  let assignmentPreview = null;
 
   function setAssignmentStatus(message, tone = 'info'){
     const statusEl = el('#assignmentStatus');


### PR DESCRIPTION
## Summary
- define the assignment cache, mode and preview state before binding handlers so reassignment utilities load correctly
- prevent the ReferenceError that was stopping the authenticated dashboard from rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a3b8c5f8832c942b25f56bc5b463