### PR TITLE
Add base CRM page without integrations

### DIFF
--- a/docs/base_page_sin_integraciones.html
+++ b/docs/base_page_sin_integraciones.html
@@ -1,0 +1,13466 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="theme-color" content="#0b1220" />
+  <title>ReLead CRM</title>
+  <link rel="icon" type="image/png" href="./assets/Favicon.png?v=3" />
+  <link rel="apple-touch-icon" href="./assets/Favicon.png?v=3" />
+  <link rel="shortcut icon" type="image/png" href="./assets/Favicon.png?v=3" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
+  <meta name="color-scheme" content="light dark" />
+  <style>
+    :root {
+      --color-primary: #003a5f; /* azul del logo */
+      --color-secondary: #8a9ca3;
+      --bg: #0b1220;
+      --bg-soft: #0f172a;
+      --card: #0f192f;
+      --card-2: #121c34;
+      --elev: rgba(255,255,255,0.06);
+      --text: #e6ebf3;
+      --muted: #9fb0cc;
+      --accent: var(--color-primary);
+      --accent-2: var(--color-secondary);
+      --ok: #22c55e; --warn: #f59e0b; --bad: #ef4444; --info:#60a5fa;
+      --panel-base-rgb: 37,99,235;
+      --panel-base-color: rgb(var(--panel-base-rgb));
+      --panel-base-strong: color-mix(in srgb, rgb(var(--panel-base-rgb)) 82%, #050b1b 18%);
+      --panel-base-soft: color-mix(in srgb, rgb(var(--panel-base-rgb)) 54%, #0b1220 46%);
+      --panel-base-bright: color-mix(in srgb, rgb(var(--panel-base-rgb)) 68%, #f8fafc 32%);
+      --panel-stage-text: #f8fafc;
+      --etapa-nuevo: color-mix(in srgb, var(--accent) 90%, #0b1220 10%);
+      --etapa-contactado: color-mix(in srgb, #0ea5e9 70%, var(--accent) 30%);
+      --etapa-no-contactado: color-mix(in srgb, #f59e0b 60%, var(--accent) 40%);
+      --etapa-inscrito: color-mix(in srgb, #22c55e 70%, var(--accent) 30%);
+      --etapa-descartado: color-mix(in srgb, #f87171 68%, var(--accent) 32%);
+      --radius: 14px;
+      --shadow: 0 10px 30px rgba(2,10,28,0.45);
+      --ring: 0 0 0 3px rgba(0,58,95,.35);
+      --font: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      --font-size-base: 15px;
+      --space:16px;
+      --space-sm:8px;
+      --space-xs:4px;
+      --avatar-size:120px;
+      --view-transition-duration: 320ms;
+      --view-transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
+      --view-transition-distance: 18px;
+      --view-transition-exit-distance: 12px;
+    }
+    html[data-theme="light"]{
+      --bg: #f6f8fb;
+      --bg-soft:#eef2f7;
+      --card:#ffffff;
+      --card-2:#f8fafc;
+      --elev: rgba(2,10,28,0.06);
+      --text:#0f172a;
+      --muted:#5b6b86;
+      --shadow: 0 10px 24px rgba(15,23,42,0.08);
+      --ring: 0 0 0 3px rgba(0,58,95,.25);
+      --accent: var(--color-primary);
+      --accent-2: var(--color-secondary);
+      --panel-base-strong: color-mix(in srgb, rgb(var(--panel-base-rgb)) 70%, #1e293b 30%);
+      --panel-base-soft: color-mix(in srgb, rgb(var(--panel-base-rgb)) 30%, #ffffff 70%);
+      --panel-base-bright: color-mix(in srgb, rgb(var(--panel-base-rgb)) 42%, #ffffff 58%);
+      --panel-stage-text: #0f172a;
+      --etapa-nuevo: color-mix(in srgb, var(--accent) 70%, #ffffff 30%);
+      --etapa-contactado: color-mix(in srgb, #38bdf8 56%, var(--accent) 44%);
+      --etapa-no-contactado: color-mix(in srgb, #f59e0b 52%, var(--accent) 48%);
+      --etapa-inscrito: color-mix(in srgb, #4ade80 58%, var(--accent) 42%);
+      --etapa-descartado: color-mix(in srgb, #fb7185 60%, var(--accent) 40%);
+    }
+    html[data-theme="light"] .nav-footer{ border-top:1px solid rgba(15,23,42,0.08); }
+    html[data-theme="light"] .nav-footer__meta{ border-color:rgba(15,23,42,0.08); color:#475569; }
+    html[data-theme="light"] .nav-footer__rights{ color:#475569; }
+    html[data-theme="light"] .view-controls .filters label{
+      background: linear-gradient(155deg, color-mix(in srgb, #ffffff 86%, rgba(var(--panel-base-rgb),0.12) 14%), color-mix(in srgb, rgba(var(--panel-base-rgb),0.22) 48%, #f1f5ff 52%));
+      border-color: color-mix(in srgb, rgba(var(--panel-base-rgb),0.42) 70%, transparent 30%);
+      color: color-mix(in srgb, #0f172a 88%, rgba(var(--panel-base-rgb),0.32) 12%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.8), 0 18px 42px color-mix(in srgb, rgba(var(--panel-base-rgb),0.2) 32%, rgba(15,23,42,0.08));
+      backdrop-filter: blur(16px);
+    }
+    html[data-theme="light"] .view-controls .filters label select{
+      background-color: color-mix(in srgb, #ffffff 92%, rgba(var(--panel-base-rgb),0.1) 8%);
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%23264963' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+      border-color: color-mix(in srgb, rgba(var(--panel-base-rgb),0.45) 68%, rgba(15,23,42,0.1) 32%);
+      color: color-mix(in srgb, #0f172a 90%, rgba(var(--panel-base-rgb),0.28) 10%);
+      box-shadow: inset 0 1px 2px color-mix(in srgb, rgba(var(--panel-base-rgb),0.24) 40%, rgba(15,23,42,0.12));
+    }
+    html[data-theme="light"] .view-controls .filters label select.is-multiple{
+      background:#ffffff;
+    }
+    html[data-theme="light"] .kpi-group{
+      background: color-mix(in srgb, var(--card) 90%, var(--panel-base-soft) 10%);
+      border-color: color-mix(in srgb, var(--panel-base-color) 22%, transparent);
+      box-shadow: 0 18px 42px color-mix(in srgb, var(--panel-base-color) 14%, rgba(15,23,42,0.08));
+    }
+    html[data-theme="light"] .kpi-metric{
+      background: color-mix(in srgb, var(--card) 94%, var(--panel-base-bright) 6%);
+      border-color: color-mix(in srgb, var(--panel-base-color) 18%, transparent);
+      box-shadow: inset 0 1px 2px color-mix(in srgb, var(--panel-base-bright) 30%, rgba(255,255,255,0.6)), 0 14px 30px color-mix(in srgb, var(--panel-base-color) 12%, rgba(15,23,42,0.08));
+    }
+    html[data-theme="light"] .kpi-metric .metric-name{ color:color-mix(in srgb, var(--panel-base-color) 32%, #5b6b86 68%); }
+    html[data-theme="light"] .kpi-metric .metric-icon{ background: color-mix(in srgb, var(--panel-base-bright) 42%, rgba(255,255,255,0.4)); color: color-mix(in srgb, var(--panel-base-color) 18%, var(--panel-stage-text) 82%); box-shadow: inset 0 1px 2px rgba(255,255,255,0.6); }
+    * { box-sizing: border-box }
+    body {
+      margin: 0;
+      background: radial-gradient(1200px 600px at 80% -10%, rgba(138,156,163,0.14), transparent 60%), radial-gradient(900px 500px at -10% 10%, rgba(0,58,95,0.18), transparent 60%), var(--bg);
+      color: var(--text);
+      font-family: var(--font);
+      font-size: var(--font-size-base);
+      line-height: 1.5;
+      letter-spacing:.2px;
+    }
+    body.sidebar-open{ overflow:hidden; }
+    @keyframes spin{ to{ transform: rotate(360deg); } }
+    @keyframes fadeUp{
+      from{ opacity:0; transform:translate3d(0,var(--view-transition-distance),0); }
+      to{ opacity:1; transform:translate3d(0,0,0); }
+    }
+    @keyframes floatCard{
+      0%{ transform:translate3d(0,8px,0); }
+      50%{ transform:translate3d(0,0,0); }
+      100%{ transform:translate3d(0,8px,0); }
+    }
+    .loading-overlay{
+      position:fixed;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      background: rgba(11,18,32,0.6);
+      backdrop-filter: blur(12px);
+      z-index:120;
+      opacity:0;
+      pointer-events:none;
+      transition: opacity .24s ease;
+    }
+    .loading-overlay.active{
+      opacity:1;
+      pointer-events:auto;
+    }
+    .loading-card{
+      background: var(--card);
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: calc(var(--space) * 1.25);
+      min-width:220px;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      gap:var(--space-sm);
+      animation: floatCard 3.2s ease-in-out infinite;
+    }
+    html[data-theme="light"] .loading-card{ border-color: rgba(15,23,42,0.12); }
+    .loading-spinner{
+      width:32px;
+      height:32px;
+      border-radius:50%;
+      border:3px solid rgba(255,255,255,0.25);
+      border-top-color: var(--accent);
+      animation: spin .8s linear infinite;
+    }
+    html[data-theme="light"] .loading-spinner{
+      border-color: rgba(15,23,42,0.16);
+      border-top-color: var(--accent);
+    }
+    .loading-message{
+      margin:0;
+      text-align:center;
+      font-weight:600;
+      letter-spacing:.3px;
+      color:var(--text);
+    }
+    .login-screen{
+      position:fixed;
+      inset:0;
+      z-index:100;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:clamp(calc(var(--space) * 2.5), 12vh, calc(var(--space) * 5));
+      padding-top:clamp(calc(var(--space) * 2.5 + constant(safe-area-inset-top)), 12vh, calc(var(--space) * 5 + constant(safe-area-inset-top)));
+      padding-top:clamp(calc(var(--space) * 2.5 + env(safe-area-inset-top)), 12vh, calc(var(--space) * 5 + env(safe-area-inset-top)));
+      padding-bottom:clamp(calc(var(--space) * 2 + constant(safe-area-inset-bottom)), 8vh, calc(var(--space) * 4 + constant(safe-area-inset-bottom)));
+      padding-bottom:clamp(calc(var(--space) * 2 + env(safe-area-inset-bottom)), 8vh, calc(var(--space) * 4 + env(safe-area-inset-bottom)));
+      overflow-y:auto;
+      background: radial-gradient(1200px 620px at 50% -20%, rgba(148,163,184,0.24), transparent 65%), radial-gradient(900px 540px at 10% 20%, rgba(2,12,29,0.55), transparent 70%), linear-gradient(160deg, rgba(6,12,24,0.95), rgba(15,23,42,0.88));
+      backdrop-filter: blur(8px);
+    }
+    .login-panel{
+      width:min(100%, 420px);
+      margin-inline:auto;
+    }
+    .login-card{
+      width:100%;
+      background:color-mix(in srgb, var(--card) 92%, rgba(96,165,250,0.08) 8%);
+      border:1px solid rgba(255,255,255,0.14);
+      border-radius:28px;
+      box-shadow:0 32px 64px rgba(8,15,28,0.38);
+      padding:calc(var(--space) * 1.75);
+      display:flex;
+      flex-direction:column;
+      gap:calc(var(--space) * 1.15);
+      align-items:stretch;
+      text-align:center;
+    }
+    html[data-theme="light"] .login-card{
+      background:color-mix(in srgb, #ffffff 96%, rgba(37,99,235,0.08) 4%);
+      border-color:rgba(15,23,42,0.1);
+      box-shadow:0 28px 60px rgba(15,23,42,0.18);
+    }
+    .login-brand{
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      gap:var(--space-sm);
+    }
+    .login-brand__image{
+      width:152px;
+      max-width:62vw;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      padding:22px;
+      border-radius:32px;
+      background:rgba(15,23,42,0.55);
+      box-shadow:0 32px 64px rgba(6,12,24,0.55);
+      font-size:1.35rem;
+      font-weight:700;
+      letter-spacing:.08em;
+      text-transform:uppercase;
+      color:var(--accent);
+    }
+    html[data-theme="light"] .login-brand__image{
+      background:rgba(255,255,255,0.92);
+      box-shadow:0 28px 60px rgba(71,85,105,0.32);
+      color:var(--accent);
+    }
+    .login-title{
+      margin:0;
+      font-size:1.25rem;
+      font-weight:700;
+      letter-spacing:.45px;
+      color:var(--text);
+    }
+    .login-form{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+      text-align:left;
+    }
+    .login-form label{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      font-size:13px;
+      font-weight:600;
+      color:var(--muted);
+    }
+    .login-actions{
+      margin-top:var(--space-sm);
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+    }
+    .login-actions .btn.primary{
+      font-size:1.05rem;
+      font-weight:700;
+      padding:14px 18px;
+      letter-spacing:.5px;
+      box-shadow:0 20px 44px rgba(0,58,95,0.32);
+      transition:transform .18s ease, box-shadow .2s ease;
+    }
+    .login-actions .btn.primary:hover{
+      transform:translateY(-1px);
+      box-shadow:0 24px 52px rgba(0,58,95,0.36);
+    }
+    .login-actions .btn.primary:focus-visible{
+      outline:none;
+      box-shadow:var(--ring), 0 24px 52px rgba(0,58,95,0.38);
+    }
+    .login-support{
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+      align-items:center;
+      margin-top:var(--space-xs);
+    }
+    .login-support__label{
+      margin:0;
+      font-size:.85rem;
+      letter-spacing:.3px;
+      color:var(--muted);
+    }
+    .link-button{
+      background:none;
+      border:none;
+      color:var(--accent);
+      font:inherit;
+      font-weight:600;
+      padding:0;
+      cursor:pointer;
+      text-decoration:underline;
+    }
+    .link-button:hover,
+    .link-button:focus-visible{
+      color:var(--text);
+      outline:none;
+      text-decoration:none;
+    }
+    .login-message{
+      margin:0;
+      font-size:13px;
+      text-align:center;
+      min-height:1.2em;
+    }
+    .login-error{ color:var(--bad); }
+    .login-success{ color:var(--ok); }
+    .login-info{ color:var(--info); }
+    .login-hint{
+      margin:var(--space-xs) 0 0;
+      font-size:12px;
+      text-align:center;
+      color:var(--muted);
+    }
+    .login-meta{
+      margin-top:calc(var(--space) * 1.25);
+      padding-top:var(--space-sm);
+      border-top:1px solid rgba(255,255,255,0.12);
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+      font-size:12px;
+      text-align:center;
+      color:var(--muted);
+      letter-spacing:.35px;
+    }
+    .login-meta__version{ font-weight:700; color:var(--accent); }
+    .login-meta__rights{ font-weight:600; font-size:11px; letter-spacing:.35px; }
+    .login-meta__rights sup,
+    .nav-footer__rights sup,
+    .site-footer__rights sup{
+      font-size:.65em;
+      line-height:1;
+      margin-left:1px;
+    }
+    html[data-theme="light"] .login-meta{
+      border-color:rgba(15,23,42,0.12);
+      color:#475569;
+    }
+    html[data-theme="light"] .login-meta__rights{ color:#475569; }
+    @media (max-width: 768px){
+      :root{
+        --font-size-base: 14px;
+        --space: 14px;
+        --space-sm: 10px;
+        --space-xs: 6px;
+        --radius: 12px;
+      }
+      body{ line-height:1.55; }
+      .login-screen{ padding-inline:max(var(--space), 6vw); }
+      .login-card{ padding:calc(var(--space) * 1.5); }
+      .login-brand__image{ width:140px; }
+    }
+    @media (max-width: 720px){
+      .login-screen{
+        justify-content:flex-start;
+        padding-block:clamp(calc(var(--space) * 2), 12vh, calc(var(--space) * 4));
+        padding-inline:clamp(calc(var(--space) * 0.75), 6vw, calc(var(--space) * 2));
+      }
+      .login-card{ border-radius:24px; }
+    }
+    @media (max-width: 540px){
+      .login-card{ padding:calc(var(--space) * 1.3); }
+      .login-brand__image{ width:128px; }
+      .login-title{ font-size:1.15rem; }
+    }
+    @media (max-width: 480px){
+      .login-card{ padding:calc(var(--space) * 1.2); border-radius:22px; }
+      .login-brand__image{ width:118px; }
+      .login-title{ font-size:1.1rem; }
+    }
+    /* Layout */
+    .app {
+      --sidebar-width: 280px;
+      display:grid;
+      grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+      min-height: 100dvh;
+      position:relative;
+    }
+    .sidebar { position: sticky; top:0; align-self:start; height:100dvh; padding:calc(var(--space) + 12px) var(--space) var(--space); background: var(--card); border-right:1px solid rgba(255,255,255,.12); box-shadow: 6px 0 24px rgba(2,10,28,0.32); display:flex; flex-direction:column; overflow-y:auto; overscroll-behavior:contain; }
+    html[data-theme="light"] .sidebar{ background:#ffffff; border-color:rgba(15,23,42,0.08); box-shadow: 8px 0 30px rgba(15,23,42,0.08); }
+    .brand { display:flex; align-items:center; gap:var(--space-sm); margin:6px 6px var(--space); padding:8px 12px; border-radius:16px; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); box-shadow: inset 0 1px 0 rgba(255,255,255,0.06); }
+    .brand-logo{ width:44px; height:44px; border-radius:14px; background:rgba(4,12,30,0.65); box-shadow: var(--shadow); display:flex; align-items:center; justify-content:center; font-weight:800; font-size:1.05rem; letter-spacing:.08em; text-transform:uppercase; color:var(--accent); }
+    .brand-logo--avatar{ background:rgba(4,12,30,0.4); }
+    html[data-theme="light"] .brand{ background:rgba(15,23,42,0.06); border-color:rgba(15,23,42,0.08); box-shadow:none; }
+    html[data-theme="light"] .brand-logo{ background:#fff; border:1px solid rgba(15,23,42,0.08); box-shadow:0 12px 26px rgba(15,23,42,0.16); color:var(--accent); }
+    html[data-theme="light"] .brand-logo--avatar{ background:rgba(15,23,42,0.1); border:none; box-shadow:0 12px 26px rgba(15,23,42,0.16); }
+    .brand-name{ font-size:1.1rem; font-weight:800; letter-spacing:.42px; color:var(--text); text-transform:none; }
+    .app.collapsed .brand{ justify-content:center; padding:0; background:transparent; border:none; box-shadow:none; margin:6px auto var(--space); }
+    .nav { display:flex; flex-direction:column; gap:var(--space-sm); margin-top:var(--space-sm); flex:1; }
+    .nav-header{ display:flex; align-items:center; gap:var(--space-sm); margin-bottom:var(--space-sm); }
+    .menu-toggle{ display:flex; align-items:center; justify-content:center; padding:4px; border-radius:999px; border:none; background:none; color:inherit; cursor:pointer; transition:transform .2s ease; }
+    .menu-toggle:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+    .menu-toggle__icon{ width:46px; height:46px; border-radius:50%; box-shadow: var(--shadow); background: var(--card); border:1px solid rgba(255,255,255,.12); display:flex; align-items:center; justify-content:center; overflow:hidden; transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease; }
+    .menu-toggle:hover .menu-toggle__icon{ border-color: var(--accent); transform:translateY(-1px); }
+    html[data-theme="light"] .menu-toggle__icon{ background:#fff; border-color:rgba(15,23,42,0.08); box-shadow: 0 10px 24px rgba(15,23,42,0.08); }
+    .menu-toggle__bars{ display:flex; flex-direction:column; gap:6px; width:18px; }
+    .menu-toggle__bars span{ display:block; width:100%; height:2px; border-radius:999px; background: var(--accent); }
+    .menu-toggle[aria-expanded="true"] .menu-toggle__bars,
+    .app:not(.collapsed) .menu-toggle__bars,
+    .app.show-sidebar .menu-toggle__bars{ display:none; }
+    .menu-trigger[aria-expanded="true"] .bi-list{ display:none; }
+    .menu-toggle__avatar{ width:100%; height:100%; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:1.05rem; text-transform:uppercase; color:var(--accent); }
+    .menu-toggle.has-avatar .menu-toggle__bars{ display:none; }
+    .menu-toggle.has-avatar .menu-toggle__avatar{ color:var(--accent); }
+    .nav-header .menu-toggle{ display:none; }
+    .nav-user{ display:inline-flex; align-items:center; justify-content:flex-start; gap:8px; padding:8px 12px; border-radius:12px; font-weight:700; font-size:15px; letter-spacing:.4px; color:var(--text); background:rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.12); box-shadow: inset 0 1px 0 rgba(255,255,255,0.06); }
+    html[data-theme="light"] .nav-user{ background:rgba(15,23,42,0.06); border-color:rgba(15,23,42,0.12); }
+    .sidebar-close{ position:absolute; top:12px; right:12px; border:none; background:none; color:var(--muted); font-size:18px; line-height:1; padding:4px; cursor:pointer; transition:color .2s ease; z-index:5; }
+    .sidebar-close:hover{ color:var(--text); }
+    .sidebar-close:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; border-radius:6px; }
+    .nav-divider{ height:1px; background:rgba(255,255,255,0.12); margin:0; }
+    html[data-theme="light"] .nav-divider{ background:rgba(15,23,42,0.1); }
+    .nav-group { display:flex; flex-direction:column; gap:var(--space-sm); }
+    .nav-footer { margin-top:auto; padding-top:var(--space); border-top:1px solid rgba(255,255,255,.08); display:flex; flex-direction:column; gap:var(--space-sm); }
+    .nav-footer__meta{ margin-top:var(--space-sm); padding-top:var(--space-xs); border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:4px; font-size:12px; color:var(--muted); letter-spacing:.3px; }
+    .nav-footer__version{ font-weight:700; color:var(--accent); }
+    .nav-footer__rights{ font-weight:600; font-size:11px; letter-spacing:.35px; }
+    .nav a,
+    .nav button:not(.menu-toggle) { display:flex; align-items:center; gap:var(--space-sm); padding:10px var(--space-sm); border-radius:12px; color:var(--text); text-decoration:none; opacity:.9; border:1px solid transparent; }
+    .nav button.nav-link.is-busy{ opacity:.75; }
+    .nav button.nav-link:disabled{ cursor:wait; }
+    .nav-link__spinner{
+      width:16px;
+      height:16px;
+      border-radius:50%;
+      border:2px solid currentColor;
+      border-top-color: transparent;
+      animation: spin .8s linear infinite;
+      margin-left:auto;
+    }
+    .nav button:not(.menu-toggle) { background:none; cursor:pointer; font:inherit; text-align:left; width:100%; }
+    .nav a:hover,
+    .nav button:not(.menu-toggle):hover { background: var(--card-2); border-color: rgba(255,255,255,.08) }
+    .nav a.active,
+    .nav button:not(.menu-toggle).active { background: linear-gradient(180deg, rgba(0,58,95,.16), rgba(0,58,95,.06)); border-color: rgba(0,58,95,.35) }
+    .app.collapsed .nav-header{ align-items:center; justify-content:center; padding-right:0; }
+    .app.collapsed .nav-user{ display:none !important; }
+    .app.collapsed .sidebar-close{ display:none; }
+    .app.collapsed .nav-divider{ margin:var(--space-sm) auto; width:40px; }
+    .brand--interactive{ cursor:pointer; }
+    .brand--interactive:focus-visible{ outline:2px solid var(--accent); outline-offset:4px; border-radius:16px; }
+    .spacer { height:10px }
+    .badge { padding:2px 8px; border-radius:999px; font-size:12px; background:rgba(0,58,95,.15); color:var(--accent); }
+
+    .main { display:flex; flex-direction:column; min-width:0 }
+    .site-footer{ margin-top:auto; padding:calc(var(--space) * 1.5) var(--space) calc(var(--space) * 2.25); border-top:1px solid rgba(255,255,255,0.08); color:var(--muted); font-size:12px; letter-spacing:.3px; }
+    .site-footer__inner{ max-width:1200px; margin:0 auto; width:100%; display:flex; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:var(--space-sm); }
+    .site-footer__version{ font-weight:700; color:var(--accent); }
+    .site-footer__rights{ font-weight:600; font-size:11px; letter-spacing:.35px; }
+    html[data-theme="light"] .site-footer{ border-color:rgba(15,23,42,0.08); color:#475569; }
+    html[data-theme="light"] .site-footer__rights{ color:#475569; }
+    .view-section{
+      opacity:0;
+      transform:translate3d(0,var(--view-transition-distance),0);
+      transition: opacity var(--view-transition-duration) var(--view-transition-timing), transform var(--view-transition-duration) var(--view-transition-timing);
+      will-change: opacity, transform;
+    }
+    .view-section.is-visible{
+      opacity:1;
+      transform:translate3d(0,0,0);
+      animation: fadeUp var(--view-transition-duration) var(--view-transition-timing);
+    }
+    .view-section.is-exiting{
+      opacity:0;
+      transform:translate3d(0,var(--view-transition-exit-distance),0);
+    }
+    @media (prefers-reduced-motion: reduce){
+      :root{
+        --view-transition-duration: 0.001ms;
+      }
+      .view-section{
+        transition-duration: 0ms;
+        animation: none !important;
+      }
+    }
+    header.topbar { position: sticky; top:0; z-index:10; backdrop-filter: blur(10px); background: linear-gradient(180deg, rgba(255,255,255,.18), rgba(255,255,255,0)); border-bottom:1px solid rgba(255,255,255,.06); }
+    .topbar-inner { display:flex; align-items:center; gap:var(--space-sm); padding:var(--space) }
+    .menu-btn {
+      display:none;
+      border:none;
+      background: var(--card);
+      color: var(--text);
+      padding:8px;
+      border-radius:12px;
+      box-shadow: var(--shadow);
+      cursor:pointer;
+      line-height:0;
+      transition: transform .12s ease, box-shadow .12s ease;
+    }
+    .menu-btn:hover { box-shadow: var(--ring), var(--shadow); }
+    .menu-btn:active { transform: translateY(1px); }
+    .menu-btn:focus-visible { outline:none; box-shadow: var(--ring), var(--shadow); }
+    .mobile-topbar{ display:none; align-items:center; gap:var(--space-sm); padding:var(--space-sm) var(--space); position:sticky; top:0; z-index:70; backdrop-filter: blur(10px); background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0)); border-bottom:1px solid rgba(255,255,255,.06); }
+    html[data-theme="light"] .mobile-topbar{ background: linear-gradient(180deg, rgba(248,252,255,0.88), rgba(248,252,255,0.6)); border-bottom:1px solid rgba(15,23,42,0.08); }
+    .mobile-topbar__label{ font-weight:700; letter-spacing:.35px; text-transform:none; color:var(--muted); font-size:13px; }
+    .search { position:relative; flex:1 1 220px; min-width:0 }
+    .search input { width:100%; padding:10px 36px; border-radius:999px; border:1px solid rgba(255,255,255,.12); background: var(--card); color: var(--text); box-shadow: var(--shadow); outline:none }
+    .search input:focus { box-shadow: var(--ring), var(--shadow) }
+    .search .icon { position:absolute; left:12px; top:50%; transform:translateY(-50%); opacity:.6 }
+
+    .actions { display:flex; align-items:center; gap:10px; flex:0 0 auto }
+    .btn { display:inline-flex; align-items:center; gap:var(--space-sm); border:1px solid var(--accent-2); background: var(--card); color:var(--text); padding:10px 12px; border-radius:12px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,.2); transition:transform .1s ease, box-shadow .1s ease }
+    .btn.micro{ padding:6px 10px; font-size:12px; border-radius:10px; box-shadow:0 1px 2px rgba(0,0,0,0.18); }
+    .btn.micro i{ font-size:13px; }
+    .btn:hover { border-color: var(--accent) }
+    .btn:active { transform:translateY(1px); box-shadow:0 1px 2px rgba(0,0,0,.2) }
+    .btn.primary { background: linear-gradient(135deg, var(--accent), var(--color-primary)); border-color: transparent; color:#fff; box-shadow: var(--shadow) }
+    .btn.outline { background:#fff; color:#0b1220; border-color: var(--accent); box-shadow:0 2px 6px rgba(15,23,42,0.12); }
+    html[data-theme="light"] .btn.outline { background:#fff; }
+    .btn.outline:hover { border-color: var(--accent); box-shadow: var(--ring), 0 3px 10px rgba(15,23,42,0.2); color:#0b1220; }
+    .btn.outline:focus-visible { outline:none; box-shadow: var(--ring), 0 3px 10px rgba(15,23,42,0.2); color:#0b1220; }
+    .btn.outline:disabled { opacity:.6; color: rgba(15,23,42,0.65); border-color: rgba(0,58,95,0.35); box-shadow:none; }
+    .btn.danger { background: linear-gradient(135deg, #dc2626, #b91c1c); border-color: transparent; color:#fff; box-shadow: var(--shadow); }
+    .btn.danger:hover { filter: brightness(1.05); }
+    .btn.danger:active { transform:translateY(1px); box-shadow:0 1px 2px rgba(0,0,0,.2); }
+    select { padding:8px 10px; border:1px solid var(--accent-2); border-radius:var(--radius); background:var(--card); color:var(--text); box-shadow:inset 0 2px 4px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.12); transition:border-color .2s ease, box-shadow .2s ease, background .2s ease }
+    select:focus { outline:none; border-color: var(--accent); box-shadow: var(--ring) }
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
+    input[type="tel"],
+    textarea{
+      width:100%;
+      padding:10px 12px;
+      border-radius:12px;
+      border:1px solid rgba(255,255,255,0.12);
+      background: var(--card-2);
+      color: var(--text);
+      box-shadow: inset 0 1px 1px rgba(2,12,29,0.24);
+      font: 500 14px/1.4 var(--font);
+      transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
+    }
+    input[type="text"]:focus,
+    input[type="email"]:focus,
+    input[type="password"]:focus,
+    input[type="tel"]:focus,
+    textarea:focus{
+      outline:none;
+      border-color: var(--accent);
+      box-shadow: var(--ring);
+      background: var(--card);
+    }
+    textarea{ min-height:96px; resize:vertical; }
+    html[data-theme="light"] input[type="text"],
+    html[data-theme="light"] input[type="email"],
+    html[data-theme="light"] input[type="password"],
+    html[data-theme="light"] input[type="tel"],
+    html[data-theme="light"] textarea{
+      border-color: rgba(15,23,42,0.12);
+      background:#fff;
+      box-shadow: inset 0 1px 1px rgba(15,23,42,0.12);
+      color:#0f172a;
+    }
+    html[data-theme="light"] input[type="text"]:focus,
+    html[data-theme="light"] input[type="email"]:focus,
+    html[data-theme="light"] input[type="password"]:focus,
+    html[data-theme="light"] input[type="tel"]:focus,
+    html[data-theme="light"] textarea:focus{
+      background:#fff;
+    }
+    .panel-filters{ flex-wrap:wrap; align-items:stretch; gap:var(--space-sm); }
+    .panel-filters select{ min-width:160px; padding:10px 12px; }
+    .panel-section{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space) 0; border-top:1px solid rgba(255,255,255,.08); }
+    .panel-section:first-of-type{ border-top:none; padding-top:0; }
+    .panel-section h3{ margin:0; font-size:15px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:var(--muted); display:flex; align-items:center; gap:var(--space-sm); }
+    .panel-section p{ margin:2px 0 0; color:var(--muted); font-size:14px; }
+    html[data-theme="light"] .panel-section{ border-color: rgba(15,23,42,0.08); }
+    .panel-status{
+      margin:6px 0 0;
+      padding:12px;
+      border-radius:12px;
+      background:rgba(255,255,255,0.05);
+      color:var(--muted);
+      font-size:13px;
+      line-height:1.45;
+      transition:background .32s ease, color .32s ease;
+    }
+    html[data-theme="light"] .panel-status{
+      background:rgba(15,23,42,0.08);
+      color:#334155;
+    }
+    .panel-actions{ flex-wrap:wrap; justify-content:flex-start; }
+    .panel-preview{ margin-top:var(--space-sm); }
+    .panel-filters .date-filter{ display:flex; flex-direction:column; justify-content:center; gap:6px; padding:8px 12px; border-radius:var(--radius); background:var(--card-2); border:1px solid rgba(255,255,255,.12); min-width:170px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 4px 10px rgba(2,12,29,0.22); color: var(--muted); font-size:12px; letter-spacing:.4px; text-transform:uppercase; font-weight:600; }
+    html[data-theme="light"] .panel-filters .date-filter{ border-color: rgba(15,23,42,0.12); box-shadow: inset 0 1px 0 rgba(255,255,255,0.7), 0 6px 16px rgba(15,23,42,0.12); }
+    .panel-filters .date-filter input[type="date"]{ border:none; background:transparent; color: var(--text); font: 600 14px/1.2 var(--font); padding:0; margin:0; min-width:0; }
+    .panel-filters .date-filter input[type="date"]:focus{ outline:none; }
+    .panel-filters .date-filter:focus-within{ border-color: var(--accent); color: var(--accent); box-shadow: var(--ring), 0 4px 12px rgba(0,58,95,0.25); }
+    .panel-filters .date-filter input[type="date"]::-webkit-calendar-picker-indicator{ filter: invert(0.8); opacity:0.8; cursor:pointer; transition: opacity .2s ease; }
+    html[data-theme="light"] .panel-filters .date-filter input[type="date"]::-webkit-calendar-picker-indicator{ filter:none; opacity:0.7; }
+    .panel-filters .date-filter input[type="date"]::-webkit-calendar-picker-indicator:hover{ opacity:1; }
+    .file-input{ width:100%; min-width:220px; padding:12px 14px; border-radius:var(--radius); border:1px dashed rgba(148,163,184,0.35); background:var(--card-2); color:var(--muted); font:600 14px/1 var(--font); cursor:pointer; transition:border-color .2s ease, color .2s ease, box-shadow .2s ease, background .2s ease; }
+    html[data-theme="light"] .file-input{ border-color:rgba(148,163,184,0.5); background:#fff; }
+    .file-input:hover{ border-color:var(--accent); color:var(--accent); box-shadow:var(--ring), 0 4px 12px rgba(0,58,95,0.25); background:linear-gradient(180deg, rgba(0,58,95,0.08), rgba(0,58,95,0.02)); }
+    .file-input:focus{ outline:none; border-color:var(--accent); color:var(--accent); box-shadow:var(--ring), 0 4px 12px rgba(0,58,95,0.25); }
+    .file-input::file-selector-button,
+    .file-input::-webkit-file-upload-button{ margin-right:12px; padding:10px 16px; border-radius:10px; border:1px solid rgba(255,255,255,0.35); background:linear-gradient(135deg, var(--accent), rgba(0,58,95,0.9)); color:#fff; font:600 14px/1 var(--font); cursor:pointer; transition:filter .2s ease; }
+    html[data-theme="light"] .file-input::file-selector-button,
+    html[data-theme="light"] .file-input::-webkit-file-upload-button{ border-color:rgba(15,23,42,0.12); }
+    .file-input::file-selector-button:hover,
+    .file-input::-webkit-file-upload-button:hover{ filter:brightness(1.05); }
+    .cmd-panel { margin-top:16px; background: linear-gradient(160deg, rgba(8,13,25,0.92), rgba(3,7,18,0.96)); border-radius:14px; border:1px solid rgba(96,165,250,0.18); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04), 0 16px 40px rgba(3,10,25,0.55); padding:14px 18px; max-height:320px; overflow:auto; font-family:"JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .cmd-panel ul { list-style:none; margin:0; padding:0; }
+    .cmd-panel li { display:flex; align-items:flex-start; gap:10px; margin:0; padding:3px 0; color:#94a3b8; white-space:pre-wrap; word-break:break-word; }
+    .cmd-panel li::before { content:'>'; color:rgba(148,163,184,0.7); }
+    .cmd-panel ul ul { margin-left:18px; padding-left:12px; border-left:1px solid rgba(148,163,184,0.25); }
+    .cmd-panel ul ul li::before { content:'↳'; color:rgba(148,163,184,0.5); }
+    .dup-grid { display:grid; gap:var(--space); margin-top:var(--space-sm); grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); }
+    .dup-card { background: var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius: var(--radius); padding:16px; display:flex; flex-direction:column; gap:12px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .dup-card header { display:flex; flex-direction:column; gap:6px; }
+    .dup-card h3 { margin:0; font-size:16px; }
+    .dup-card .dup-counts { display:flex; flex-wrap:wrap; gap:8px; font-size:12px; }
+    .dup-card .dup-counts span { padding:2px 8px; border-radius:999px; background: rgba(245,158,11,0.15); border:1px solid rgba(245,158,11,0.35); color:#f59e0b; font-weight:600; letter-spacing:.3px; }
+    html[data-theme="light"] .dup-card .dup-counts span { background: rgba(245,158,11,0.18); border-color: rgba(245,158,11,0.45); }
+    .dup-card .dup-sample { font-size:13px; color: var(--muted); display:flex; flex-direction:column; gap:8px; }
+    .dup-card .dup-sample strong { color: var(--text); display:block; margin-bottom:2px; }
+    .dup-card ul { margin:0; padding-left:18px; }
+    .dup-card button { margin-top:auto; }
+    #dupStatus { margin-top:6px; }
+    .dev-grid{ display:grid; gap:var(--space); grid-template-columns:repeat(auto-fit, minmax(320px,1fr)); }
+    .dev-panel{ background: var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius: var(--radius); padding:var(--space); display:flex; flex-direction:column; gap:var(--space-sm); box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    html[data-theme="light"] .dev-panel{ border-color: rgba(15,23,42,0.08); box-shadow: inset 0 1px 0 rgba(255,255,255,0.6); }
+    .dev-panel__header{ display:flex; flex-wrap:wrap; align-items:flex-start; justify-content:space-between; gap:var(--space-sm); }
+    .dev-panel__title{ margin:0; font-size:17px; display:flex; align-items:center; gap:8px; }
+    .dev-panel__description{ margin:0; color: var(--muted); font-size:13px; }
+    .dev-panel__status{ margin:4px 0 0; font-size:13px; color: var(--muted); }
+    .dev-panel__log{ background: var(--bg-soft); border:1px solid rgba(255,255,255,0.08); border-radius: var(--radius); padding:12px; max-height:240px; overflow:auto; }
+    html[data-theme="light"] .dev-panel__log{ border-color: rgba(15,23,42,0.08); }
+    .dev-panel__log ul{ margin:0; padding-left:18px; display:flex; flex-direction:column; gap:6px; font-size:13px; }
+    .dev-actions{ display:flex; flex-wrap:wrap; gap:8px; }
+
+    /* Theme toggle */
+
+    /* Filters */
+    .view-controls {
+      display:flex;
+      align-items:center;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+      width:100%;
+    }
+    .preferences-callout{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-xs);
+      padding:var(--space);
+      border-radius:14px;
+      border:1px dashed rgba(255,255,255,0.2);
+      background: rgba(15,23,42,0.28);
+      color:var(--muted);
+      flex:1 1 280px;
+      min-width:260px;
+    }
+    html[data-theme="light"] .preferences-callout{
+      border-color: rgba(15,23,42,0.18);
+      background: rgba(226,232,240,0.55);
+      color:#1e293b;
+    }
+    .preferences-callout__heading{
+      font-size:12px;
+      font-weight:700;
+      text-transform:uppercase;
+      letter-spacing:.5px;
+      color:var(--accent);
+    }
+    .preferences-callout p{
+      margin:0 0 var(--space-sm);
+      font-size:13px;
+      line-height:1.5;
+      color:inherit;
+    }
+    .preferences-callout__action{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      padding:0;
+      border:none;
+      background:none;
+      color:var(--accent);
+      font-weight:700;
+      font-size:13px;
+      cursor:pointer;
+      text-decoration:underline;
+      text-underline-offset:4px;
+    }
+    .preferences-callout__action:focus-visible{
+      outline:none;
+      text-decoration:none;
+      box-shadow:0 0 0 3px rgba(0,58,95,0.35);
+      border-radius:8px;
+      padding:4px 8px;
+      margin:-4px -8px;
+    }
+    .view-controls .filters {
+      display:flex;
+      align-items:center;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+      flex:1 1 auto;
+    }
+    .view-controls .filters label {
+      position:relative;
+      display:flex;
+      flex-direction:column;
+      gap:8px;
+      font-size:13px;
+      font-weight:600;
+      color: color-mix(in srgb, #ffffff 92%, rgba(var(--panel-base-rgb),0.22) 8%);
+      flex:1 1 160px;
+      min-width:160px;
+      padding:14px 16px;
+      background: linear-gradient(160deg, rgba(var(--panel-base-rgb),0.28), rgba(8,19,45,0.68));
+      border:1px solid rgba(var(--panel-base-rgb),0.45);
+      border-radius:18px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 18px 38px rgba(2,10,28,0.34);
+      backdrop-filter: blur(18px);
+      transition: border-color .25s ease, box-shadow .25s ease, transform .25s ease;
+    }
+    .view-controls .filters label:hover,
+    .view-controls .filters label:focus-within {
+      border-color: rgba(148,193,255,0.85);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.16), 0 22px 46px rgba(2,10,28,0.42);
+      transform: translateY(-2px);
+    }
+    .view-controls .filters label select {
+      min-width:160px;
+      width:100%;
+      padding:12px 42px 12px 14px;
+      border-radius:12px;
+      border:1px solid rgba(148,193,255,0.55);
+      background-color: color-mix(in srgb, rgba(8,19,45,0.82) 85%, rgba(12,23,42,0.45) 15%);
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%23bcd4ff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+      background-repeat:no-repeat;
+      background-position:right 16px center;
+      background-size:14px;
+      color:#f4f8ff;
+      box-shadow: inset 0 1px 3px rgba(5,12,28,0.65);
+      transition: border-color .2s ease, box-shadow .2s ease, background-color .2s ease, transform .2s ease;
+      appearance:none;
+    }
+    .view-controls .filters label select.is-multiple{
+      min-height:140px;
+      padding:10px 12px;
+      background-image:none;
+      overflow:auto;
+    }
+    .view-controls .filters label select.is-multiple option{
+      white-space:normal;
+      line-height:1.35;
+      padding:4px 6px;
+    }
+    .view-controls .filters label select:focus {
+      outline:none;
+      border-color: rgba(148,193,255,0.9);
+      background-color: color-mix(in srgb, rgba(8,19,45,0.82) 70%, rgba(28,46,84,0.75) 30%);
+      box-shadow: inset 0 1px 3px rgba(2,10,28,0.78), 0 0 0 3px rgba(var(--panel-base-rgb),0.35);
+    }
+    .view-controls .filters .page-size {
+      margin-left:auto;
+    }
+    .chip { display:inline-flex; align-items:center; gap:8px; padding:8px 10px; border:1px solid rgba(255,255,255,.12); background: var(--card); border-radius:999px; cursor:pointer; user-select:none }
+    .chip input { appearance:none; width:12px; height:12px; border-radius:3px; border:1px solid rgba(255,255,255,.25); display:inline-block; position:relative }
+    .chip input:checked { background: var(--accent); border-color: var(--accent) }
+    .daily-shortcuts{
+      width:100%;
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+    }
+    .daily-shortcuts__header{
+      font-size:11px;
+      font-weight:700;
+      letter-spacing:.5px;
+      text-transform:uppercase;
+      color:rgba(248,252,255,0.78);
+    }
+    .daily-shortcuts__group{
+      display:flex;
+      flex-wrap:wrap;
+      gap:8px;
+      align-items:center;
+    }
+    .daily-shortcuts__label{
+      font-size:12px;
+      font-weight:600;
+      color:var(--muted);
+    }
+    .daily-shortcuts__btn{
+      display:flex;
+      align-items:center;
+      gap:6px;
+      padding:8px 12px;
+      border-radius:999px;
+      border:1px solid rgba(var(--panel-base-rgb),0.35);
+      background:rgba(var(--panel-base-rgb),0.18);
+      color:var(--text);
+      font-weight:600;
+      font-size:13px;
+      cursor:pointer;
+      transition: border-color .2s ease, background .2s ease, transform .2s ease;
+    }
+    .daily-shortcuts__btn span{ font-size:12px; font-weight:500; color:var(--muted); }
+    .daily-shortcuts__btn:hover,
+    .daily-shortcuts__btn:focus{
+      outline:none;
+      transform:translateY(-1px);
+      border-color:rgba(148,193,255,0.65);
+      background:rgba(var(--panel-base-rgb),0.28);
+    }
+    .daily-shortcuts__btn.is-active{
+      border-color:rgba(34,197,94,0.55);
+      background:rgba(34,197,94,0.2);
+      color:var(--text);
+    }
+    .daily-shortcuts__btn.is-active span{ color:rgba(34,197,94,0.85); }
+    .daily-shortcuts__empty{
+      font-size:12px;
+      color:var(--muted);
+      font-style:italic;
+    }
+    html[data-theme="light"] .daily-shortcuts__header{ color:#334155; }
+    html[data-theme="light"] .daily-shortcuts__btn{
+      background:rgba(var(--panel-base-rgb),0.12);
+      border-color:rgba(var(--panel-base-rgb),0.28);
+      color:#0f172a;
+    }
+    html[data-theme="light"] .daily-shortcuts__btn span{ color:#475569; }
+    html[data-theme="light"] .daily-shortcuts__btn.is-active{
+      background:rgba(34,197,94,0.16);
+      border-color:rgba(34,197,94,0.5);
+      color:#065f46;
+    }
+    .contact-scripts{
+      margin-top:12px;
+      padding:var(--space-sm);
+      border-radius:var(--radius);
+      border:1px solid rgba(var(--panel-base-rgb),0.28);
+      background:rgba(var(--panel-base-rgb),0.12);
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+    }
+    .contact-scripts__header{
+      font-size:14px;
+      font-weight:700;
+      color:var(--text);
+      display:flex;
+      align-items:center;
+      gap:6px;
+    }
+    .contact-scripts__grid{
+      display:grid;
+      gap:var(--space-sm);
+      grid-template-columns:repeat(auto-fit, minmax(220px,1fr));
+    }
+    .contact-script{
+      background:var(--card);
+      border-radius:12px;
+      border:1px solid rgba(255,255,255,0.08);
+      padding:12px;
+      display:flex;
+      flex-direction:column;
+      gap:10px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+    }
+    .contact-script header{
+      display:flex;
+      align-items:center;
+      gap:8px;
+      font-weight:700;
+      color:var(--text);
+    }
+    .contact-script textarea{
+      width:100%;
+      min-height:96px;
+      resize:vertical;
+      border-radius:10px;
+      border:1px solid rgba(var(--panel-base-rgb),0.3);
+      background:var(--card-2);
+      color:var(--text);
+      padding:10px;
+      font-family:var(--font);
+      font-size:13px;
+      line-height:1.5;
+    }
+    .contact-script textarea:focus{
+      outline:none;
+      border-color:rgba(var(--panel-base-rgb),0.55);
+      box-shadow:var(--ring);
+    }
+    .contact-script__actions{
+      display:flex;
+      flex-wrap:wrap;
+      gap:8px;
+    }
+    .contact-scripts__status{
+      font-size:12px;
+      color:var(--muted);
+    }
+    .contact-scripts__status.hidden{ display:none; }
+    html[data-theme="light"] .contact-scripts{
+      border-color:rgba(var(--panel-base-rgb),0.22);
+      background:rgba(var(--panel-base-rgb),0.08);
+    }
+    html[data-theme="light"] .contact-script{
+      border-color:rgba(148,163,184,0.28);
+      box-shadow:none;
+    }
+    html[data-theme="light"] .contact-script textarea{
+      background:#f8fafc;
+      border-color:rgba(148,163,184,0.35);
+      color:#0f172a;
+    }
+    .pill { padding:8px 12px; border:1px solid color-mix(in srgb, var(--panel-tone-bright) 36%, #1e293b 64%); border-radius:12px }
+    .pill.priority-pill{
+      font-size:12px;
+      font-weight:700;
+      letter-spacing:.3px;
+    }
+    .pill.priority-alta{
+      background:rgba(34,197,94,0.2);
+      border-color:rgba(34,197,94,0.45);
+      color:var(--ok);
+    }
+    .pill.priority-media{
+      background:rgba(234,179,8,0.18);
+      border-color:rgba(234,179,8,0.45);
+      color:var(--warn);
+    }
+    .pill.priority-baja{
+      background:rgba(96,165,250,0.18);
+      border-color:rgba(96,165,250,0.45);
+      color:var(--info);
+    }
+    html[data-theme="light"] .contact-script header{ color:#0f172a; }
+    html[data-theme="light"] .pill.priority-alta{ color:#15803d; }
+    html[data-theme="light"] .pill.priority-media{ color:#b45309; }
+    html[data-theme="light"] .pill.priority-baja{ color:#1d4ed8; }
+
+    /* KPIs */
+    .kpi-groups{ display:flex; flex-direction:column; gap:calc(var(--space) * 0.75); padding:0 var(--space) var(--space-sm); }
+    .kpi-group{ background: color-mix(in srgb, var(--card) 82%, var(--panel-base-soft) 18%); border:1px solid color-mix(in srgb, var(--panel-base-color) 34%, transparent); border-radius: var(--radius); padding:var(--space); box-shadow: 0 18px 42px color-mix(in srgb, var(--panel-base-color) 18%, rgba(2,10,28,0.22)); }
+    .kpi-group header{ display:flex; flex-direction:column; gap:4px; margin-bottom:var(--space-sm); }
+    .kpi-group h4{ margin:0; font-size:1rem; letter-spacing:.4px; }
+    .kpi-group p{ margin:0; color:var(--muted); font-size:13px; }
+    .kpi-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap:var(--space-sm); align-items:stretch; }
+    .kpi-metric{ background: color-mix(in srgb, var(--card) 86%, var(--panel-base-soft) 14%); border:1px solid color-mix(in srgb, var(--panel-base-color) 38%, transparent); border-radius: var(--radius); padding:var(--space-sm); display:flex; flex-direction:column; gap:6px; min-height:120px; box-shadow: inset 0 1px 2px color-mix(in srgb, var(--panel-base-bright) 26%, transparent), 0 8px 16px color-mix(in srgb, var(--panel-base-color) 20%, rgba(2,10,28,0.28)); }
+    .kpi-metric .metric-header{ display:flex; align-items:center; gap:var(--space-sm); }
+    .kpi-metric .metric-icon{ width:40px; height:40px; border-radius:50%; display:grid; place-items:center; background: color-mix(in srgb, var(--panel-base-bright) 28%, transparent); color: var(--panel-stage-text); font-size:18px; box-shadow: inset 0 1px 2px color-mix(in srgb, var(--panel-base-bright) 18%, transparent); }
+    .kpi-metric .metric-name{ font:600 11px var(--font); letter-spacing:.6px; text-transform:uppercase; color:color-mix(in srgb, var(--panel-base-bright) 54%, var(--muted) 46%); }
+    .kpi-metric .metric-value{ font-size:26px; font-weight:800; letter-spacing:.2px; color:var(--text); }
+    .kpi-metric .metric-extra{ font-size:12px; color:var(--muted); font-weight:600; }
+    .kpi-metric .metric-desc{ margin-top:auto; font-size:12px; color:var(--muted); line-height:1.4; }
+    .kpi-metric .metric-note{ margin-top:auto; font-size:12px; color:var(--muted); font-style:italic; line-height:1.4; }
+    .kpi-metric ul{ margin:0; padding-left:18px; font-size:12px; color:var(--muted); line-height:1.4; }
+    .kpi-metric ul li{ margin:2px 0; }
+    .critical-summary{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .critical-summary > p{ margin:0; color:var(--muted); font-size:13px; max-width:640px; }
+    .critical-kpis{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+    .critical-kpis .kpi-metric{ padding:var(--space); gap:var(--space-sm); background: color-mix(in srgb, var(--card) 78%, var(--panel-base-soft) 22%); border-color: color-mix(in srgb, var(--panel-base-color) 46%, transparent); box-shadow: inset 0 1px 2px color-mix(in srgb, var(--panel-base-bright) 26%, transparent), 0 16px 36px color-mix(in srgb, var(--panel-base-color) 24%, rgba(2,10,28,0.28)); }
+    .critical-kpis .kpi-metric .metric-value{ font-size:32px; }
+    html[data-theme="light"] .critical-kpis .kpi-metric{ background: color-mix(in srgb, var(--card) 88%, var(--panel-base-bright) 12%); border-color: color-mix(in srgb, var(--panel-base-color) 30%, transparent); box-shadow: inset 0 1px 2px color-mix(in srgb, var(--panel-base-bright) 32%, rgba(255,255,255,0.6)), 0 18px 38px color-mix(in srgb, var(--panel-base-color) 18%, rgba(15,23,42,0.08)); }
+    .kpi-empty{ padding:var(--space); text-align:center; color:var(--muted); font-size:13px; }
+    .card { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: var(--radius); padding:14px; box-shadow: var(--shadow) }
+    .spark { height:36px; margin-top:10px }
+
+    /* View switcher */
+    .seg { background: var(--card); border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:4px; display:flex; gap:4px }
+    .seg button { border:1px solid var(--accent-2); background:var(--card); color: var(--text); padding:8px 12px; border-radius:8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,.1); transition:transform .1s ease, box-shadow .1s ease }
+    .seg button[aria-pressed="true"]{ background: linear-gradient(180deg, rgba(0,58,95,.15), rgba(0,58,95,.05)); border:1px solid var(--accent); box-shadow:var(--shadow) }
+    .seg button:active{ transform:translateY(1px); box-shadow:0 1px 2px rgba(0,0,0,.1) }
+
+    /* Pagination */
+    .pagination{ display:flex; justify-content:center; gap:6px; padding:var(--space); }
+    .pagination.is-hidden{ display:none; }
+    .pagination button{ border:1px solid var(--accent-2); background:var(--card); color:var(--text); padding:6px 10px; border-radius:8px; cursor:pointer; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+    .pagination button.active{ background:var(--accent); color:#fff; }
+    .pagination button:disabled{ opacity:.5; cursor:default; }
+
+    /* Content views */
+    .content { display:flex; flex-direction:column; gap:var(--space-sm); }
+    .board {
+      display:grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap:var(--space-sm);
+      padding:var(--space-sm);
+      background: var(--card);
+      border:1px solid rgba(255,255,255,.08);
+      border-radius:16px;
+      max-height: clamp(320px, 65vh, 460px);
+      overflow-y:auto;
+      overflow-x:hidden;
+      width:min(100%, calc(100vw - var(--sidebar-width, 0px) - (var(--space) * 2)));
+      max-width:100%;
+      min-height:0;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+    }
+    html[data-board-density="compact"] .board{ grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+    html[data-board-density="expanded"] .board{ grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+    .column { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: 16px; min-height: 140px; display:flex; flex-direction:column; position:relative; overflow:hidden }
+    .column header { display:flex; align-items:center; justify-content:space-between; padding:10px 12px; border-bottom:1px solid rgba(255,255,255,.08); border-radius:14px 14px 0 0; gap:var(--space-xs); }
+    .column header .count { background: rgba(15,23,42,0.25); border:1px solid rgba(15,23,42,0.35); padding:2px 8px; border-radius:999px; font-size:12px; color:rgba(248,250,252,0.92); font-weight:600; }
+    .column-toggle{ border:none; background:none; color:inherit; display:none; align-items:center; justify-content:center; padding:4px; border-radius:8px; cursor:pointer; }
+    .column-toggle:focus-visible{ outline:none; box-shadow: var(--ring); }
+    .column-toggle-icon{ transition: transform .2s ease; }
+    .list { padding:6px; display:flex; flex-direction:column; gap:6px }
+    .column-load-more{ margin:8px; padding:6px 10px; border-radius:10px; border:1px solid rgba(255,255,255,0.18); background:rgba(var(--panel-base-rgb),0.12); color:var(--text); font-weight:600; cursor:pointer; transition: background .2s ease; align-self:center; }
+    .column-load-more:hover{ background:rgba(var(--panel-base-rgb),0.2); }
+    html[data-theme="light"] .column-load-more{ border-color:rgba(15,23,42,0.16); background:rgba(37,99,235,0.12); }
+    html[data-theme="light"] .board{ border-color:rgba(15,23,42,0.1); box-shadow: inset 0 1px 0 rgba(255,255,255,0.8); }
+    html[data-theme="light"] .column{ border-color:rgba(15,23,42,0.1); }
+    html[data-theme="light"] .column header{ border-bottom-color:rgba(15,23,42,0.14); box-shadow: inset 0 -1px 0 rgba(255,255,255,0.6); }
+    html[data-theme="light"] .column header .count{ background:rgba(255,255,255,0.9); border-color:rgba(15,23,42,0.16); color:rgba(15,23,42,0.82); }
+    html[data-theme="light"] .column[data-step] header{ color:color-mix(in srgb, #0f172a 88%, rgba(255,255,255,0.2) 12%); box-shadow:0 14px 34px color-mix(in srgb, var(--etapa-color) 26%, rgba(15,23,42,0.18)); }
+    html[data-theme="light"] .column[data-step] header .count{ background:color-mix(in srgb, rgba(255,255,255,0.9) 78%, transparent 22%); border-color:color-mix(in srgb, rgba(15,23,42,0.18) 62%, transparent 38%); color:color-mix(in srgb, #0f172a 78%, var(--etapa-color) 22%); }
+    html[data-board-density="compact"] .list{ gap:4px; }
+    html[data-board-density="expanded"] .list{ gap:10px; }
+    .card-lead { background: var(--card-2); border:1px solid rgba(255,255,255,.1); border-radius:14px; padding:8px; cursor:pointer; transition: transform .12s ease, box-shadow .12s ease; box-shadow: 0 1px 4px rgba(0,0,0,.06) }
+    html[data-board-density="compact"] .card-lead{ padding:6px; }
+    html[data-board-density="expanded"] .card-lead{ padding:12px; }
+    .card-lead:hover { transform: translateY(-2px) scale(1.01); border-color: rgba(0,58,95,.35); box-shadow: 0 4px 14px rgba(0,0,0,.12) }
+    .card-lead[data-priority="alta"]{ box-shadow: 0 6px 18px rgba(34,197,94,0.25); border-color: rgba(34,197,94,0.55); }
+    .card-lead[data-priority="media"]{ border-color: rgba(234,179,8,0.45); }
+    .card-lead[data-priority="baja"]{ border-color: rgba(96,165,250,0.45); }
+    .tag { padding:2px 8px; border-radius:999px; font-size:12px; border:1px solid rgba(255,255,255,.15); color: var(--muted) }
+    .tag.ok{ color: #065f46; background: rgba(16,185,129,.15); border-color: rgba(16,185,129,.25) }
+    .tag.bad{ color: #7f1d1d; background: rgba(239,68,68,.15); border-color: rgba(239,68,68,.25) }
+
+    /* Etapa colors */
+    .column[data-step]{ --etapa-color: var(--accent); }
+    .column[data-step] header{
+      background: linear-gradient(145deg, color-mix(in srgb, var(--etapa-color) 82%, rgba(15,23,42,0.2) 18%), color-mix(in srgb, var(--etapa-color) 62%, rgba(5,12,28,0.4) 38%));
+      color:color-mix(in srgb, #f8fafc 92%, rgba(148,163,184,0.18) 8%);
+      border-bottom:none;
+      box-shadow:0 12px 32px color-mix(in srgb, var(--etapa-color) 32%, rgba(5,12,28,0.45));
+    }
+    .column[data-step] header .count{
+      background:color-mix(in srgb, rgba(15,23,42,0.35) 60%, rgba(255,255,255,0.12) 40%);
+      border-color:color-mix(in srgb, rgba(15,23,42,0.45) 65%, transparent 35%);
+      color:inherit;
+    }
+    .column[data-step] header .muted{ color:color-mix(in srgb, currentColor 78%, rgba(15,23,42,0.2) 22%); }
+    .column[data-step="Nuevo"]{ --etapa-color: var(--etapa-nuevo); }
+    .column[data-step="Contactado"]{ --etapa-color: var(--etapa-contactado); }
+    .column[data-step="No Contactado"]{ --etapa-color: var(--etapa-no-contactado); }
+    .column[data-step="Inscrito"]{ --etapa-color: var(--etapa-inscrito); }
+    .column[data-step="Descartado"]{ --etapa-color: var(--etapa-descartado); }
+
+    .panel[data-etapa]{
+      background: linear-gradient(150deg, var(--panel-tone-strong), var(--panel-tone-soft));
+      border-color: var(--panel-tone-strong);
+      color: var(--panel-tone-text);
+      box-shadow: 0 32px 72px rgba(5,12,28,0.52);
+    }
+    .panel[data-etapa="nuevo"]{
+      --panel-tone-strong:#1d4f9c;
+      --panel-tone-soft:#112f63;
+      --panel-tone-bright:#3b7bea;
+      --panel-tone-text:#f9fbff;
+    }
+    .panel[data-etapa="contactado"]{
+      --panel-tone-strong:#156271;
+      --panel-tone-soft:#0b3b45;
+      --panel-tone-bright:#2e9fad;
+      --panel-tone-text:#f4feff;
+    }
+    .panel[data-etapa="no-contactado"]{
+      --panel-tone-strong:#b66a1e;
+      --panel-tone-soft:#7a4711;
+      --panel-tone-bright:#e88a2c;
+      --panel-tone-text:#fff9f3;
+    }
+    .panel[data-etapa="inscrito"]{
+      --panel-tone-strong:#1e7a52;
+      --panel-tone-soft:#0f4a31;
+      --panel-tone-bright:#32c381;
+      --panel-tone-text:#f6fff9;
+    }
+    .panel[data-etapa="descartado"]{
+      --panel-tone-strong:#a3323a;
+      --panel-tone-soft:#681c23;
+      --panel-tone-bright:#d3474f;
+      --panel-tone-text:#fff5f5;
+    }
+    html[data-theme="light"] .panel[data-etapa]{
+      box-shadow: 0 28px 58px rgba(15,23,42,0.16);
+    }
+    html[data-theme="light"] .panel[data-etapa="nuevo"]{
+      --panel-tone-strong:#90b4ff;
+      --panel-tone-soft:#e3ecff;
+      --panel-tone-bright:#4f7dff;
+      --panel-tone-text:#102041;
+    }
+    html[data-theme="light"] .panel[data-etapa="contactado"]{
+      --panel-tone-strong:#71d0d4;
+      --panel-tone-soft:#dcf7f8;
+      --panel-tone-bright:#3aa9b0;
+      --panel-tone-text:#0f2f33;
+    }
+    html[data-theme="light"] .panel[data-etapa="no-contactado"]{
+      --panel-tone-strong:#f4c076;
+      --panel-tone-soft:#fcebd1;
+      --panel-tone-bright:#e39b37;
+      --panel-tone-text:#3b1f05;
+    }
+    html[data-theme="light"] .panel[data-etapa="inscrito"]{
+      --panel-tone-strong:#84dcb3;
+      --panel-tone-soft:#e2f8ee;
+      --panel-tone-bright:#3fb67c;
+      --panel-tone-text:#0b3a22;
+    }
+    html[data-theme="light"] .panel[data-etapa="descartado"]{
+      --panel-tone-strong:#f3a1a5;
+      --panel-tone-soft:#fde5e7;
+      --panel-tone-bright:#d24e55;
+      --panel-tone-text:#4c1114;
+    }
+
+    .card-lead[data-step="Nuevo"]{ border-left:4px solid var(--etapa-nuevo); }
+    .card-lead[data-step="Contactado"]{ border-left:4px solid var(--etapa-contactado); }
+    .card-lead[data-step="No Contactado"]{ border-left:4px solid var(--etapa-no-contactado); }
+    .card-lead[data-step="Inscrito"]{ border-left:4px solid var(--etapa-inscrito); }
+    .card-lead[data-step="Descartado"]{ border-left:4px solid var(--etapa-descartado); }
+
+    .table-wrap { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: 16px; overflow:auto }
+    table { width:100%; border-collapse: collapse; font-size:14px }
+    thead th { position: sticky; top:0; background: linear-gradient(180deg, var(--card), var(--card-2)); text-align:left; padding:12px; border-bottom:1px solid rgba(255,255,255,.12); cursor:pointer }
+    thead th.is-sorted{ color: var(--accent); }
+    thead th.is-sorted::after{ content: attr(data-sort-dir); margin-left:6px; font-size:12px; }
+    thead .filter-row th{ padding:8px 12px; border-bottom:1px solid rgba(255,255,255,.12); }
+    .col-filter{ width:100%; padding:6px; border-radius:8px; border:1px solid rgba(255,255,255,.12); background:var(--card-2); color:var(--text); }
+    tbody td { padding:12px; border-bottom: 1px dashed rgba(255,255,255,.08) }
+    tbody tr:hover { background: rgba(0,58,95,.06) }
+    .table-empty{ text-align:center; padding:24px 12px; color:var(--muted); font-style:italic; }
+    .preview-box{ color: var(--text); font-size:14px; }
+    .preview-box .table-wrap{ margin-top:8px; }
+    .preview-summary{ color: var(--muted); font-size:13px; margin-bottom:6px; }
+    .modal-overlay{
+      position:fixed;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:var(--space);
+      background: rgba(11,18,32,0.72);
+      backdrop-filter: blur(12px);
+      z-index:140;
+      opacity:0;
+      pointer-events:none;
+      transition: opacity .24s ease;
+    }
+    .modal-overlay.active{
+      opacity:1;
+      pointer-events:auto;
+    }
+    .modal-card{
+      width:min(960px, 100%);
+      max-height:90vh;
+      overflow:hidden;
+      background: var(--card);
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius: calc(var(--radius) + 4px);
+      box-shadow: 0 30px 70px rgba(2,10,28,0.55);
+      display:flex;
+      flex-direction:column;
+      position:relative;
+    }
+    html[data-theme="light"] .modal-card{ border-color: rgba(15,23,42,0.1); box-shadow: 0 28px 60px rgba(15,23,42,0.18); }
+    .modal-close{
+      position:absolute;
+      top:16px;
+      right:16px;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:36px;
+      height:36px;
+      border-radius:50%;
+      border:none;
+      background: rgba(255,255,255,0.08);
+      color:var(--text);
+      cursor:pointer;
+      transition: background .2s ease, transform .2s ease;
+    }
+    .modal-close:hover{ background: rgba(255,255,255,0.16); transform: rotate(90deg); }
+    html[data-theme="light"] .modal-close{ background: rgba(15,23,42,0.08); color:#0f172a; }
+    html[data-theme="light"] .modal-close:hover{ background: rgba(15,23,42,0.16); }
+    .modal-header, .modal-footer{ padding: calc(var(--space) * 1.25); border-bottom:1px solid rgba(255,255,255,0.08); }
+    html[data-theme="light"] .modal-header, html[data-theme="light"] .modal-footer{ border-color: rgba(15,23,42,0.08); }
+    .modal-header h2{ margin:0; font-size:1.25rem; }
+    .modal-message{ margin:6px 0 0; color:var(--muted); }
+    .modal-body{ padding: var(--space); overflow:auto; display:flex; flex-direction:column; gap:var(--space); }
+    .modal-section{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .modal-validations{ display:grid; gap:var(--space); grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .modal-summary-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+    .modal-summary-list li{ display:flex; align-items:center; gap:10px; border-radius: var(--radius); padding:10px 12px; background: var(--card-2); border:1px solid rgba(255,255,255,0.08); font-weight:600; letter-spacing:.2px; }
+    .modal-summary-list.modal-errors li .badge{ background: rgba(239,68,68,0.18); color: var(--bad); }
+    .modal-summary-list.modal-warnings li .badge{ background: rgba(245,158,11,0.2); color: var(--warn); }
+    .modal-summary-list li .badge{ display:inline-flex; align-items:center; justify-content:center; min-width:32px; padding:4px 10px; border-radius:999px; font-size:13px; font-weight:700; }
+    html[data-theme="light"] .modal-summary-list li{ border-color: rgba(15,23,42,0.08); background:#ffffff; }
+    .modal-table{ width:100%; border-collapse:collapse; font-size:13px; }
+    .modal-table th, .modal-table td{ padding:8px 10px; text-align:left; border-bottom:1px solid rgba(255,255,255,0.08); }
+    .modal-table th{ font-weight:700; text-transform:uppercase; font-size:12px; letter-spacing:.3px; color:var(--muted); }
+    html[data-theme="light"] .modal-table th, html[data-theme="light"] .modal-table td{ border-color: rgba(15,23,42,0.08); }
+    .modal-table-wrap .table-wrap{ max-height:260px; }
+    .modal-actions{ display:flex; gap:var(--space-sm); justify-content:flex-end; flex-wrap:wrap; }
+    .modal-counters{ font-weight:600; color:var(--muted); display:flex; align-items:center; gap:var(--space); flex-wrap:wrap; }
+    .modal-footer{ display:flex; flex-direction:column; gap:var(--space); border-top:1px solid rgba(255,255,255,0.08); }
+    html[data-theme="light"] .modal-footer{ border-top-color: rgba(15,23,42,0.08); }
+    .modal-footnote{ margin-top:8px; font-size:12px; color:var(--muted); }
+    body.modal-open{ overflow:hidden; }
+    .template-modal{ width:min(880px, 100%); }
+    .template-modal__grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap:var(--space); align-items:flex-start; }
+    .template-modal__section{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .template-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+    .template-list__item{ display:flex; align-items:flex-start; gap:10px; justify-content:space-between; width:100%; border-radius:12px; border:1px solid rgba(255,255,255,0.1); padding:10px 12px; background:var(--card-2); color:var(--text); text-align:left; cursor:pointer; transition: transform .18s ease, box-shadow .18s ease; }
+    .whatsapp-web-modal{ width:min(1024px, 100%); height:min(88vh, 840px); }
+    .whatsapp-web-modal .modal-body{ padding:0; flex:1; display:flex; gap:0; }
+    .whatsapp-web-frame{ flex:1; width:100%; height:100%; border:0; background:#0b1220; border-radius:0; }
+    html[data-theme="light"] .whatsapp-web-frame{ background:#ffffff; }
+    .template-list__item:hover, .template-list__item:focus-visible{ transform:translateY(-1px); box-shadow:0 12px 28px rgba(5,12,28,0.32); outline:none; }
+    .template-list__meta{ font-size:12px; opacity:0.7; margin-top:4px; }
+    .template-list__empty{ font-size:12px; color:var(--muted); padding:10px 12px; border-radius:12px; border:1px dashed rgba(255,255,255,0.18); background:rgba(148,163,184,0.08); text-align:center; }
+    .template-list__actions{ display:flex; gap:6px; }
+    .template-list__actions button{ border:none; background:color-mix(in srgb, rgba(255,255,255,0.08) 60%, var(--panel-base-soft) 40%); color:var(--text); border-radius:10px; padding:6px 10px; cursor:pointer; font-size:12px; transition: background .18s ease; }
+    .template-list__actions button:hover, .template-list__actions button:focus-visible{ background:color-mix(in srgb, rgba(255,255,255,0.12) 50%, var(--panel-base-bright) 50%); outline:none; }
+    .template-field{ display:flex; flex-direction:column; gap:6px; }
+    .template-field input,
+    .template-field textarea{ width:100%; border-radius:12px; border:1px solid rgba(255,255,255,0.18); padding:10px 12px; background:var(--card-2); color:var(--text); font:inherit; }
+    .template-field textarea{ resize:vertical; min-height:120px; }
+    .template-field input:focus,
+    .template-field textarea:focus{ outline:none; box-shadow:0 0 0 3px rgba(var(--panel-base-rgb),0.35); border-color:rgba(var(--panel-base-rgb),0.45); }
+    .template-hint{ margin:0; font-size:12px; color:var(--muted); }
+    .template-hint code{ background:rgba(148,163,184,0.16); padding:2px 6px; border-radius:8px; font-size:11px; }
+    .template-modal__actions{ display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end; }
+    .template-form{ margin-top:var(--space); padding:var(--space); border-radius:16px; border:1px solid rgba(255,255,255,0.12); background:color-mix(in srgb, var(--card-2) 80%, rgba(15,23,42,0.22) 20%); display:flex; flex-direction:column; gap:var(--space-sm); }
+    .template-form.hidden{ display:none; }
+    html[data-theme="light"] .template-list__item{ background:#ffffff; border-color:rgba(15,23,42,0.08); }
+    html[data-theme="light"] .template-list__empty{ background:#f8fafc; border-color:rgba(15,23,42,0.16); color:#475569; }
+    html[data-theme="light"] .template-list__actions button{ background:rgba(15,23,42,0.08); color:#0f172a; }
+    html[data-theme="light"] .template-list__actions button:hover, html[data-theme="light"] .template-list__actions button:focus-visible{ background:rgba(37,99,235,0.16); }
+    html[data-theme="light"] .template-field input,
+    html[data-theme="light"] .template-field textarea{ background:#ffffff; border-color:rgba(15,23,42,0.12); color:#0f172a; }
+    html[data-theme="light"] .template-form{ background:#ffffff; border-color:rgba(15,23,42,0.12); }
+    @media (max-width: 720px){
+      .template-modal__grid{ grid-template-columns:1fr; }
+      .template-modal__actions{ justify-content:flex-start; }
+    }
+    /* Details panel */
+    .panel {
+      position: relative;
+      --panel-tone-strong: var(--panel-base-strong);
+      --panel-tone-soft: var(--panel-base-soft);
+      --panel-tone-bright: var(--panel-base-bright);
+      --panel-tone-text: var(--panel-stage-text);
+      background: linear-gradient(145deg, var(--panel-tone-strong), color-mix(in srgb, var(--panel-tone-strong) 35%, #050b1b 65%));
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 45%, #050b1b 55%);
+      border-radius:20px;
+      padding:28px;
+      min-height: 360px;
+      width:min(620px, calc(100vw - 96px));
+      max-height: min(88vh, 760px);
+      overflow:auto;
+      box-shadow: 0 28px 60px rgba(5,12,28,0.48);
+      opacity:0;
+      transform: translateY(18px) scale(0.95);
+      transition: transform .28s ease, opacity .28s ease;
+      font-family: 'Manrope', var(--font);
+      letter-spacing:.18px;
+      line-height:1.6;
+    }
+    .panel.show { opacity:1; transform: translateY(0) scale(1); }
+    .panel-header { margin-bottom:20px; display:flex; align-items:flex-start; gap:12px; justify-content:space-between; }
+    .panel-title { margin:0; display:flex; align-items:flex-start; gap:14px; font-size:26px; line-height:1.05; flex:1 1 auto; }
+    .panel-title span:first-child{ font-weight:800; font-size:1.04em; letter-spacing:.4px; flex:1 1 auto; min-width:0; }
+    .panel[data-etapa] .panel-title span:first-child{ color:var(--panel-tone-text); text-shadow:none; }
+    html[data-theme="light"] .panel{
+      background: linear-gradient(145deg, color-mix(in srgb, var(--panel-tone-strong) 25%, #ffffff 75%), #ffffff);
+      border-color: color-mix(in srgb, var(--panel-tone-strong) 30%, #dbe4f6 70%);
+      box-shadow: 0 24px 52px rgba(15,23,42,0.12);
+    }
+    .stage-pill {
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      padding:7px 16px;
+      border-radius:999px;
+      font-size:13px;
+      font-weight:700;
+      background: linear-gradient(135deg, var(--panel-tone-strong), var(--panel-tone-soft));
+      border:1px solid var(--panel-tone-strong);
+      color:var(--panel-tone-text);
+      letter-spacing:.4px;
+    }
+    .stage-pill i{ font-size:16px; }
+    .stage-pill.is-empty{ background: color-mix(in srgb, var(--panel-tone-bright) 25%, #1e293b 75%); border-color: color-mix(in srgb, var(--panel-tone-bright) 20%, #1f2937 80%); color: var(--muted); }
+    .panel-quick{
+      margin-top:24px;
+      padding:24px;
+      border-radius:18px;
+      background: color-mix(in srgb, var(--panel-tone-soft) 65%, rgba(5,12,28,0.45) 35%);
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 55%, #050b1b 45%);
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+    }
+    html[data-theme="light"] .panel-quick{
+      background: color-mix(in srgb, #ffffff 80%, var(--panel-tone-soft) 20%);
+      border-color: color-mix(in srgb, var(--panel-tone-strong) 25%, #e2e8f0 75%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.75);
+    }
+    .panel-quick__form{
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+    }
+    .panel-quick__header h4{
+      margin:0;
+      font-size:16px;
+      font-weight:800;
+      letter-spacing:.35px;
+      color:var(--panel-tone-text);
+    }
+    .panel-quick__header p{
+      margin:4px 0 0;
+      color:color-mix(in srgb, var(--panel-tone-text) 70%, rgba(226,232,240,0.9) 30%);
+      font-size:13px;
+      line-height:1.4;
+    }
+    html[data-theme="light"] .panel-quick__header p{
+      color:color-mix(in srgb, var(--panel-tone-strong) 40%, #1e293b 60%);
+    }
+    .panel-quick__grid{
+      display:flex;
+      flex-wrap:wrap;
+      gap:16px;
+    }
+    .panel-quick__field{
+      flex:1 1 200px;
+      display:flex;
+      flex-direction:column;
+      gap:10px;
+      font-size:12px;
+      font-weight:700;
+      text-transform:uppercase;
+      letter-spacing:.4px;
+      color:var(--panel-tone-text);
+    }
+    .panel-quick__field select{
+      border-radius:12px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-bright) 45%, var(--panel-tone-strong) 55%);
+      padding:12px 14px;
+      width:100%;
+      min-width:0;
+      background: var(--panel-tone-soft);
+      color:var(--panel-tone-text);
+      font:600 15px/1.25 'Manrope', var(--font);
+      letter-spacing:.2px;
+      text-transform:none;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+    }
+    .panel-quick__field select:focus{ outline:none; box-shadow:0 0 0 3px var(--panel-tone-bright); }
+    .panel-quick__comment textarea{
+      border-radius:12px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-bright) 45%, var(--panel-tone-strong) 55%);
+      padding:12px 14px;
+      background: var(--panel-tone-soft);
+      color:var(--panel-tone-text);
+      font:600 14px/1.4 'Manrope', var(--font);
+      min-height:96px;
+      resize:vertical;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+    }
+    .panel-quick__comment textarea:focus{ outline:none; box-shadow:0 0 0 3px var(--panel-tone-bright); }
+    .panel-quick__feedback{
+      border-radius:12px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 45%, rgba(2,6,23,0.55) 55%);
+      background: color-mix(in srgb, var(--panel-tone-soft) 70%, rgba(15,23,42,0.6) 30%);
+      padding:14px 16px;
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      color:var(--panel-tone-text);
+    }
+    .panel-quick__feedback strong{ font-size:14px; letter-spacing:.3px; }
+    .panel-quick__feedback p{ margin:0; font-size:13px; line-height:1.45; }
+    .panel-quick__feedback[data-tone="error"]{
+      border-color:rgba(239,68,68,0.55);
+      background: color-mix(in srgb, rgba(239,68,68,0.55) 58%, var(--panel-tone-soft) 42%);
+      color:#fecaca;
+    }
+    html[data-theme="light"] .panel-quick__feedback{
+      background: color-mix(in srgb, #ffffff 80%, var(--panel-tone-soft) 20%);
+      border-color: color-mix(in srgb, rgba(148,163,184,0.45) 55%, var(--panel-tone-strong) 45%);
+      color:#1e293b;
+    }
+    html[data-theme="light"] .panel-quick__feedback[data-tone="error"]{
+      background: rgba(254,226,226,0.92);
+      border-color: rgba(239,68,68,0.45);
+      color:#b91c1c;
+    }
+    .panel-quick__actions{
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+    }
+    .panel-quick__shortcuts{
+      display:flex;
+      flex-wrap:wrap;
+      gap:10px;
+    }
+    .panel-quick__shortcuts .btn{
+      flex:1 1 140px;
+      justify-content:center;
+    }
+    html[data-theme="light"] .stage-pill.is-empty{ background: color-mix(in srgb, #ffffff 60%, var(--panel-tone-bright) 40%); border-color: color-mix(in srgb, #e2e8f0 70%, var(--panel-tone-strong) 30%); }
+    .kv { display:grid; grid-template-columns: 140px 1fr; gap:12px 18px; font-size:15px }
+    .panel .kv-label {
+      color:var(--panel-tone-text);
+      font-size:12.5px;
+      font-weight:700;
+      letter-spacing:.45px;
+      text-transform:uppercase;
+      opacity:0.92;
+    }
+    .panel .actions { gap:10px; margin-top:14px }
+    .pill { padding:8px 12px; border:1px solid color-mix(in srgb, var(--panel-tone-bright) 36%, #1e293b 64%); border-radius:12px }
+    .id-pill{ font-weight:700; letter-spacing:.32px; background:var(--panel-tone-soft); border-color:var(--panel-tone-strong); color:var(--panel-tone-text); }
+
+    .panel .contact-btn{
+      background:var(--panel-tone-bright);
+      color:var(--panel-tone-text);
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 60%, var(--panel-tone-bright) 40%);
+      box-shadow: 0 16px 36px rgba(5,12,28,0.35);
+      font-weight:600;
+      letter-spacing:.24px;
+    }
+    .panel .contact-btn:hover{ box-shadow: 0 18px 40px rgba(5,12,28,0.4); }
+    .panel .contact-btn:focus-visible{ box-shadow: 0 0 0 3px var(--panel-tone-bright), 0 18px 40px rgba(5,12,28,0.4); }
+    .panel .contact-btn i{ font-size:18px; }
+    .panel .contact-call i{ color:#ef4444; }
+    .panel .contact-wa i{ color:#22c55e; }
+    .panel .contact-mail i{ color:#2563eb; }
+
+    .panel-tags{
+      margin:var(--space) 0;
+      padding:var(--space);
+      border-radius:var(--radius);
+      background:color-mix(in srgb, var(--card) 88%, var(--panel-base-soft) 12%);
+      border:1px solid rgba(255,255,255,0.08);
+    }
+    html[data-theme="light"] .panel-tags{
+      border-color:rgba(15,23,42,0.08);
+      background:color-mix(in srgb, #ffffff 92%, var(--panel-base-soft) 8%);
+    }
+    .panel-tags__header{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:var(--space);
+      margin-bottom:var(--space-sm);
+    }
+    .panel-tags__header h4{ margin:0; }
+    .panel-tags__hint{
+      margin:0 0 var(--space-sm);
+      color:var(--muted);
+      font-size:13px;
+    }
+    .panel-tags__list{
+      display:flex;
+      flex-wrap:wrap;
+      gap:8px;
+      margin:0;
+      padding:0;
+      list-style:none;
+    }
+    .panel-tags__list.is-empty{
+      color:var(--muted);
+      font-style:italic;
+    }
+    .panel-tags__chip{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      padding:6px 10px;
+      border-radius:999px;
+      background:color-mix(in srgb, var(--tag-color, var(--accent)) 22%, transparent);
+      border:1px solid color-mix(in srgb, var(--tag-color, var(--accent)) 36%, rgba(255,255,255,0.18));
+      color:var(--panel-stage-text);
+      font-size:13px;
+      line-height:1;
+    }
+    html[data-theme="light"] .panel-tags__chip{
+      background:color-mix(in srgb, var(--tag-color, var(--accent)) 20%, #ffffff 80%);
+      border-color:color-mix(in srgb, var(--tag-color, var(--accent)) 28%, rgba(15,23,42,0.12));
+      color:#1e293b;
+    }
+    .panel-tags__dot{
+      width:10px;
+      height:10px;
+      border-radius:50%;
+      background:var(--tag-color, var(--accent));
+      box-shadow:0 0 0 1px rgba(255,255,255,0.35);
+    }
+    html[data-theme="light"] .panel-tags__dot{
+      box-shadow:0 0 0 1px rgba(15,23,42,0.08);
+    }
+    .panel-tags__remove{
+      border:none;
+      background:none;
+      color:inherit;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:18px;
+      height:18px;
+      border-radius:50%;
+      cursor:pointer;
+      padding:0;
+    }
+    .panel-tags__remove:hover,
+    .panel-tags__remove:focus{
+      background:rgba(0,0,0,0.12);
+    }
+    html[data-theme="light"] .panel-tags__remove:hover,
+    html[data-theme="light"] .panel-tags__remove:focus{
+      background:rgba(15,23,42,0.08);
+    }
+    .panel-tags__form{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+      margin-top:var(--space);
+    }
+    .panel-tags__form-row{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space);
+    }
+    .panel-tags__form-row label{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      font-size:14px;
+      color:var(--muted);
+    }
+    .panel-tags__form-row input{
+      padding:8px 10px;
+      border-radius:10px;
+      border:1px solid rgba(255,255,255,0.16);
+      background:rgba(15,23,42,0.6);
+      color:var(--text);
+    }
+    .panel-tags__form-row input[type="color"]{
+      padding:0;
+      width:48px;
+      height:36px;
+      border-radius:12px;
+      cursor:pointer;
+    }
+    html[data-theme="light"] .panel-tags__form-row input{
+      border-color:rgba(15,23,42,0.16);
+      background:#ffffff;
+      color:#0f172a;
+    }
+    .panel-tags__form-actions{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+      align-items:center;
+    }
+    .panel-tags__feedback{
+      margin:0;
+      font-size:13px;
+      color:var(--muted);
+    }
+    .tag.tag-custom{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      padding:4px 10px;
+      border-radius:999px;
+      background:color-mix(in srgb, var(--tag-color, var(--accent)) 24%, transparent);
+      border:1px solid color-mix(in srgb, var(--tag-color, var(--accent)) 36%, rgba(255,255,255,0.18));
+      color:var(--panel-stage-text);
+      font-weight:600;
+    }
+    html[data-theme="light"] .tag.tag-custom{
+      background:color-mix(in srgb, var(--tag-color, var(--accent)) 18%, #ffffff 82%);
+      border-color:color-mix(in srgb, var(--tag-color, var(--accent)) 28%, rgba(15,23,42,0.12));
+      color:#1e293b;
+    }
+    .tag.tag-custom::before{
+      content:'';
+      width:8px;
+      height:8px;
+      border-radius:50%;
+      background:var(--tag-color, var(--accent));
+      box-shadow:0 0 0 1px rgba(255,255,255,0.35);
+    }
+    html[data-theme="light"] .tag.tag-custom::before{
+      box-shadow:0 0 0 1px rgba(15,23,42,0.08);
+    }
+    .card-tags{
+      display:flex;
+      flex-wrap:wrap;
+      gap:6px;
+      margin-top:8px;
+    }
+    .auto-reassign-badge{
+      margin-top:8px;
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      padding:6px 10px;
+      border-radius:12px;
+      background:rgba(37,99,235,0.14);
+      color:var(--panel-stage-text);
+      font-size:13px;
+    }
+    .auto-reassign-badge i{ font-size:14px; }
+    .auto-reassign-badge[data-status="applied"]{
+      background:rgba(34,197,94,0.18);
+      color:#34d399;
+    }
+    html[data-theme="light"] .auto-reassign-badge{
+      background:rgba(37,99,235,0.16);
+      color:#1e293b;
+    }
+    html[data-theme="light"] .auto-reassign-badge[data-status="applied"]{
+      background:rgba(34,197,94,0.18);
+      color:#166534;
+    }
+    .panel-hint{
+      margin-top:var(--space);
+      padding:14px;
+      border-radius:var(--radius);
+      border:1px solid rgba(37,99,235,0.35);
+      background:rgba(37,99,235,0.16);
+      color:var(--panel-stage-text);
+    }
+    .panel-hint strong{ display:block; margin-bottom:6px; }
+    .panel-hint__actions{
+      margin-top:10px;
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+    }
+    .panel-hint[data-tone="success"]{
+      border-color:rgba(34,197,94,0.35);
+      background:rgba(34,197,94,0.18);
+      color:#34d399;
+    }
+    html[data-theme="light"] .panel-hint{
+      border-color:rgba(37,99,235,0.24);
+      background:rgba(37,99,235,0.18);
+      color:#1e293b;
+    }
+    html[data-theme="light"] .panel-hint[data-tone="success"]{
+      border-color:rgba(34,197,94,0.28);
+      background:rgba(34,197,94,0.18);
+      color:#166534;
+    }
+    .calendar-form{
+      margin-top:var(--space);
+      padding:var(--space);
+      border-radius:var(--radius);
+      border:1px solid rgba(255,255,255,0.08);
+      background:color-mix(in srgb, var(--card) 88%, var(--panel-base-soft) 12%);
+    }
+    html[data-theme="light"] .calendar-form{
+      border-color:rgba(15,23,42,0.08);
+      background:color-mix(in srgb, #ffffff 92%, var(--panel-base-soft) 8%);
+    }
+    .calendar-form h4{ margin:0 0 6px; }
+    .calendar-form p{ margin:0 0 var(--space-sm); color:var(--muted); font-size:13px; }
+    .calendar-form__grid{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space);
+      margin-bottom:var(--space-sm);
+    }
+    .calendar-form__grid label{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      font-size:14px;
+      color:var(--muted);
+    }
+    .calendar-form__grid input,
+    .calendar-form__grid select{
+      padding:8px 10px;
+      border-radius:10px;
+      border:1px solid rgba(255,255,255,0.16);
+      background:rgba(15,23,42,0.6);
+      color:var(--text);
+    }
+    html[data-theme="light"] .calendar-form__grid input,
+    html[data-theme="light"] .calendar-form__grid select{
+      border-color:rgba(15,23,42,0.16);
+      background:#ffffff;
+      color:#0f172a;
+    }
+    .calendar-form__actions{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+      align-items:center;
+    }
+    .calendar-form__status{
+      margin:0;
+      font-size:13px;
+      color:var(--muted);
+    }
+    .auto-reassign-card{
+      padding:var(--space);
+      border-radius:var(--radius);
+      background:color-mix(in srgb, var(--card) 90%, var(--panel-base-soft) 10%);
+      border:1px solid rgba(255,255,255,0.08);
+    }
+    html[data-theme="light"] .auto-reassign-card{
+      border-color:rgba(15,23,42,0.08);
+      background:color-mix(in srgb, #ffffff 92%, var(--panel-base-soft) 8%);
+    }
+    .auto-reassign-summary{
+      margin:0 0 var(--space-sm);
+      font-weight:600;
+      color:var(--panel-stage-text);
+    }
+    .auto-reassign-meta{
+      display:flex;
+      flex-wrap:wrap;
+      gap:10px;
+      font-size:13px;
+      color:var(--muted);
+      margin-top:4px;
+    }
+    .auto-reassign-list{
+      list-style:none;
+      margin:0;
+      padding:0;
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+    }
+    .auto-reassign-item{
+      display:flex;
+      flex-wrap:wrap;
+      gap:12px;
+      align-items:center;
+      border:1px dashed rgba(255,255,255,0.18);
+      border-radius:var(--radius);
+      padding:12px 14px;
+      background:rgba(37,99,235,0.08);
+    }
+    html[data-theme="light"] .auto-reassign-item{
+      border-color:rgba(15,23,42,0.12);
+      background:rgba(37,99,235,0.12);
+    }
+    .auto-reassign-actions{
+      margin-left:auto;
+      display:flex;
+      gap:var(--space-sm);
+      align-items:center;
+    }
+    .auto-reassign-pagination{
+      margin-top:var(--space-sm);
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      justify-content:space-between;
+      gap:var(--space-sm);
+      font-size:13px;
+      color:var(--muted);
+    }
+    .auto-reassign-pagination.hidden{ display:none; }
+    .auto-reassign-pagination__info{ flex:1 1 200px; }
+    .auto-reassign-pagination__controls{ display:flex; align-items:center; gap:var(--space-sm); }
+    .auto-reassign-pagination__page{ font-weight:600; }
+    .auto-reassign-wrapper{ margin-top:12px; }
+    .auto-reassign-pagination .btn{ display:inline-flex; align-items:center; gap:6px; font-size:13px; padding:6px 12px; }
+    .auto-reassign-pagination .btn[disabled]{ opacity:.6; cursor:not-allowed; }
+    html[data-theme="light"] .panel .contact-btn{
+      border-color: color-mix(in srgb, var(--panel-tone-strong) 35%, #ffffff 65%);
+      box-shadow: 0 12px 26px rgba(15,23,42,0.16);
+      color: var(--panel-tone-text);
+    }
+    .panel-favorite{
+      margin-top:6px;
+      border:none;
+      background:color-mix(in srgb, var(--panel-tone-soft) 70%, rgba(15,23,42,0.4) 30%);
+      color:var(--panel-tone-text);
+      border-radius:12px;
+      padding:8px 10px;
+      cursor:pointer;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
+    }
+    .panel-favorite i{ font-size:18px; }
+    .panel-favorite:hover, .panel-favorite:focus-visible{
+      transform:translateY(-1px);
+      box-shadow:0 10px 24px rgba(5,12,28,0.35);
+      outline:none;
+    }
+    .panel-favorite[aria-pressed="true"]{ background:rgba(255,215,0,0.16); color:#fde68a; }
+    html[data-theme="light"] .panel-favorite{ background:color-mix(in srgb, #ffffff 85%, var(--panel-tone-bright) 15%); color:#1f2937; }
+    html[data-theme="light"] .panel-favorite[aria-pressed="true"]{ background:#fef3c7; color:#b45309; }
+    .quick-access{
+      margin-top:12px;
+      border-radius:16px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 35%, rgba(15,23,42,0.55) 65%);
+      background:color-mix(in srgb, var(--panel-tone-soft) 75%, rgba(15,23,42,0.4) 25%);
+      display:block;
+      overflow:hidden;
+    }
+    .quick-access__summary{
+      margin:0;
+      display:flex;
+      align-items:center;
+      gap:10px;
+      padding:14px 16px;
+      font-size:14px;
+      font-weight:700;
+      letter-spacing:.3px;
+      text-transform:uppercase;
+      color:var(--panel-tone-text);
+      cursor:pointer;
+      list-style:none;
+    }
+    .quick-access__summary::-webkit-details-marker{ display:none; }
+    .quick-access__summary i{ font-size:16px; opacity:0.85; }
+    .quick-access__body{
+      display:flex;
+      flex-direction:column;
+      gap:14px;
+      padding:0 16px 16px;
+    }
+    .quick-access__description{
+      margin:0;
+      font-size:13px;
+      color:color-mix(in srgb, var(--panel-tone-text) 70%, rgba(226,232,240,0.9) 30%);
+    }
+    .quick-access__group{ display:flex; flex-direction:column; gap:8px; }
+    .quick-access__label{ font-size:13px; letter-spacing:.3px; text-transform:uppercase; color:var(--panel-tone-text); opacity:0.8; }
+    .quick-access__list{ display:flex; flex-wrap:wrap; gap:8px; }
+    .quick-access__item{
+      display:flex;
+      flex-direction:column;
+      align-items:flex-start;
+      gap:2px;
+      min-width:140px;
+      border-radius:12px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-bright) 40%, rgba(15,23,42,0.5) 60%);
+      padding:10px 12px;
+      background:color-mix(in srgb, var(--panel-tone-soft) 82%, rgba(15,23,42,0.45) 18%);
+      color:var(--panel-tone-text);
+      font-size:13px;
+      text-align:left;
+      cursor:pointer;
+      transition: transform .18s ease, box-shadow .18s ease;
+    }
+    .quick-access__item:hover, .quick-access__item:focus-visible{
+      transform:translateY(-1px);
+      box-shadow:0 12px 28px rgba(5,12,28,0.32);
+      outline:none;
+    }
+    .quick-access__item-name{ font-weight:700; font-size:13px; }
+    .quick-access__item-meta{ font-size:12px; opacity:0.75; display:flex; gap:4px; flex-wrap:wrap; }
+    .quick-access__empty{ margin:0; font-size:12px; color:var(--panel-tone-text); opacity:0.6; }
+    html[data-theme="light"] .quick-access{ background:color-mix(in srgb, #ffffff 85%, var(--panel-tone-soft) 15%); border-color:color-mix(in srgb, var(--panel-tone-strong) 28%, #cbd5f5 72%); }
+    html[data-theme="light"] .quick-access__summary{ color:color-mix(in srgb, var(--panel-tone-strong) 45%, #1f2937 55%); }
+    html[data-theme="light"] .quick-access__description{ color:color-mix(in srgb, var(--panel-tone-strong) 35%, #1e293b 65%); }
+    html[data-theme="light"] .quick-access__item{ background:#ffffff; border-color:color-mix(in srgb, var(--panel-tone-strong) 22%, #dbeafe 78%); }
+    html[data-theme="light"] .quick-access__item:hover, html[data-theme="light"] .quick-access__item:focus-visible{ box-shadow:0 12px 26px rgba(15,23,42,0.18); }
+
+    .panel-overlay { position: fixed; inset: 0; display:flex; justify-content:center; align-items:center; padding:40px; background: var(--bg-soft); opacity:0; pointer-events:none; transition: opacity .24s ease; z-index: 60; }
+    .panel-overlay.open { opacity:1; pointer-events:auto; }
+    .panel-close { position:absolute; top:12px; right:12px; border:none; background: none; color: var(--muted); cursor:pointer; font-size:18px; padding:4px; border-radius:8px; }
+    .panel-close:hover, .panel-close:focus-visible { color: var(--text); outline:none; box-shadow: var(--ring); }
+    .panel-close i { pointer-events:none; }
+    .view-label { display:flex; align-items:center; gap:8px; background: var(--card); border:1px solid rgba(255,255,255,.12); padding:8px 12px; border-radius:12px; box-shadow:0 2px 6px rgba(0,0,0,.08); font-weight:600; }
+
+    @media (min-width: 1280px){
+      .panel{
+        padding:34px 36px;
+        width:min(680px, calc(100vw - 140px));
+      }
+      .kv{ grid-template-columns: 160px 1fr; }
+    }
+
+    /* Drawer (mobile) */
+    .drawer { position: fixed; inset: 0; background: var(--bg-soft); display:none; align-items: flex-end; z-index: 50 }
+    .drawer.open { display:flex }
+    .drawer .sheet { background: var(--card); width: 100%; max-height: 85vh; border-radius: 16px 16px 0 0; padding: 12px; overflow:auto }
+    .drawer-summary{ margin:6px 0 0; color:var(--muted); font-size:13px; }
+    .drawer-quick{ margin-top:18px; padding:18px; border-radius:16px; background:var(--card-2); border:1px solid rgba(255,255,255,0.12); display:flex; flex-direction:column; gap:14px; }
+    html[data-theme="light"] .drawer-quick{ background:#f1f5f9; border-color:rgba(15,23,42,0.12); }
+    .drawer-quick__hint{ margin:0; font-size:13px; color:var(--muted); }
+    .drawer-quick__shortcuts{ display:flex; flex-wrap:wrap; gap:10px; }
+    .drawer-quick__shortcuts .btn{ flex:1 1 140px; justify-content:center; }
+    .drawer-quick__field{ display:flex; flex-direction:column; gap:8px; font-size:12px; font-weight:700; text-transform:uppercase; letter-spacing:.35px; color:var(--muted); }
+    .drawer-quick__field select,
+    .drawer-quick__field textarea{ border-radius:10px; border:1px solid rgba(148,163,184,0.35); padding:10px 12px; background:var(--card); color:var(--text); font:600 14px/1.35 'Manrope', var(--font); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08); }
+    .drawer-quick__field textarea{ min-height:96px; resize:vertical; }
+    .drawer-quick__field select:focus,
+    .drawer-quick__field textarea:focus{ outline:none; box-shadow:0 0 0 3px rgba(var(--panel-base-rgb),0.25); }
+    .drawer-quick__feedback{
+      border-radius:12px;
+      border:1px solid rgba(239,68,68,0.45);
+      background: rgba(239,68,68,0.18);
+      padding:12px 14px;
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+      color:#fecaca;
+    }
+    .drawer-quick__feedback strong{ font-size:13px; letter-spacing:.2px; }
+    .drawer-quick__feedback p{ margin:0; font-size:12px; line-height:1.45; }
+    html[data-theme="light"] .drawer-quick__feedback{
+      background: rgba(254,226,226,0.92);
+      color:#b91c1c;
+    }
+    .drawer-quick__actions{ display:flex; justify-content:flex-end; }
+
+    /* Responsive */
+    @media (max-width: 1200px){ .panel-overlay{ display:none } }
+    @media (max-width: 900px){
+      .app{
+        --sidebar-width: 0px;
+        display:block;
+        min-height:100dvh;
+      }
+      .app.collapsed{
+        --sidebar-width: 0px;
+        display:block;
+      }
+      .main{ min-height:100dvh; }
+      .sidebar{
+        position:fixed;
+        top:0;
+        left:0;
+        height:100dvh;
+        width:min(260px, 82vw);
+        max-width:320px;
+        transform:translateX(-110%);
+        transition: transform .24s ease, opacity .24s ease;
+        z-index:80;
+        box-shadow: var(--shadow);
+        overflow-y:auto;
+        opacity:0;
+        pointer-events:none;
+        visibility:hidden;
+      }
+      .app.show-sidebar .sidebar{
+        transform:translateX(0);
+        opacity:1;
+        pointer-events:auto;
+        visibility:visible;
+      }
+      .mobile-topbar{ display:flex; }
+      .menu-toggle{ display:none; }
+      .menu-btn{ display:inline-flex; }
+      .topbar-inner{ padding:var(--space) var(--space-sm); }
+      .brand-name{ display:block; }
+      .nav a span{ display:inline; }
+      .preferences-callout{ flex:1 1 100%; min-width:100%; }
+      .panel-quick{ padding:18px; }
+      .panel-quick__shortcuts .btn{ flex:1 1 100%; }
+    }
+    @media (min-width: 901px){ .sidebar-overlay{ display:none; } }
+    @media (max-width: 880px){
+      .critical-kpis{ grid-template-columns:1fr; }
+    }
+    @media (max-width: 700px){
+      .kpi-grid{ grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); }
+      .board{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space-sm); max-height:none; overflow:visible; }
+      .column{ min-height:0; }
+      .view-controls{
+        flex-direction:column;
+        align-items:flex-start;
+        gap:var(--space-sm);
+      }
+      .view-label{ width:100%; justify-content:flex-start; }
+      .view-controls .filters{
+        width:100%;
+        display:flex;
+        gap:var(--space-xs);
+        row-gap:var(--space-sm);
+        flex-wrap:wrap;
+        align-items:flex-start;
+      }
+      .view-controls .filters label{
+        width:100%;
+        flex:1 1 calc(50% - var(--space-xs));
+        min-width:0;
+      }
+      .view-controls .filters label select{
+        width:100%;
+        min-width:0;
+      }
+      .view-controls .filters .page-size{
+        margin-left:0;
+        flex:1 1 100%;
+      }
+      .column.mobile-collapsible{ min-height:0; }
+      .column.mobile-collapsible header{ padding:10px 12px; }
+      .column.mobile-collapsible .column-toggle{ display:inline-flex; }
+      .column.mobile-collapsible.collapsed .list{ display:none; }
+      .column.mobile-collapsible.collapsed .column-toggle-icon{ transform:rotate(-90deg); }
+      .column.mobile-collapsible.expanded .column-toggle-icon{ transform:rotate(0deg); }
+      .site-footer__inner{ justify-content:center; text-align:center; gap:var(--space-xs); }
+    }
+    @media (max-width: 600px){
+      .kpi-grid{ grid-template-columns:1fr; }
+      .view-controls .filters{ gap:var(--space-xs); }
+      .view-controls .filters label{ flex:1 1 100%; }
+      .view-controls .filters label select{ padding:6px 10px; font-size:13px; }
+    }
+    @media (max-width: 480px){
+      .topbar-inner{
+        flex-wrap:nowrap;
+        gap:var(--space-sm);
+      }
+      .search input{ padding:8px 32px; font-size:14px; }
+      .actions{ width:auto; }
+      .actions .btn{ padding:8px 12px; }
+      #themeBtn{ top:12px; right:12px }
+      .view-controls .filters{ gap:6px; }
+      .view-controls .filters label{ flex:1 1 100%; font-size:12px; }
+      .view-controls .filters label select{ padding:6px 8px; font-size:12px; }
+    }
+    @media (max-width: 420px){
+      .board{ padding:var(--space-xs); }
+      .column header{ padding:10px; }
+    }
+
+    /* Help view */
+    .help-role{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space); border-radius:var(--radius); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); }
+    html[data-theme="light"] .help-role{ background:rgba(15,23,42,0.04); border-color:rgba(15,23,42,0.08); }
+    .help-role-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap:var(--space-sm); }
+    .help-role-grid h4{ margin:0; font-size:14px; font-weight:700; color:var(--text); }
+    .help-role-grid ul{ margin:0; padding-left:18px; display:grid; gap:6px; list-style:disc; }
+    .help-highlights{ margin:0; padding-left:18px; display:grid; gap:8px; line-height:1.55; color:var(--text); list-style:disc; }
+    .help-role-table{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .help-table{ width:100%; border-collapse:collapse; font-size:13px; }
+    .help-table th, .help-table td{ border:1px solid rgba(255,255,255,0.12); padding:8px; text-align:left; }
+    html[data-theme="light"] .help-table th,
+    html[data-theme="light"] .help-table td{ border-color:rgba(15,23,42,0.16); }
+    .help-table th{ font-weight:700; background:rgba(var(--panel-base-rgb),0.12); color:var(--text); }
+    html[data-theme="light"] .help-table th{ background:rgba(15,23,42,0.08); }
+    html[data-contrast="high"] .card,
+    html[data-contrast="high"] .board,
+    html[data-contrast="high"] .panel,
+    html[data-contrast="high"] .help-role,
+    html[data-contrast="high"] .profile-summary,
+    html[data-contrast="high"] .security-status{ box-shadow:none; border-color:rgba(255,255,255,0.38); }
+    html[data-theme="light"][data-contrast="high"] .card,
+    html[data-theme="light"][data-contrast="high"] .board,
+    html[data-theme="light"][data-contrast="high"] .panel,
+    html[data-theme="light"][data-contrast="high"] .help-role,
+    html[data-theme="light"][data-contrast="high"] .profile-summary,
+    html[data-theme="light"][data-contrast="high"] .security-status{ border-color:rgba(15,23,42,0.32); }
+    html[data-contrast="high"] .muted{ color:#f4f6ff; }
+    html[data-theme="light"][data-contrast="high"] .muted{ color:#1f2937; }
+
+    /* Utility */
+    .muted{ color: var(--muted) }
+    .row{ display:flex; align-items:center }
+    .row.between{ justify-content:space-between }
+    .row.gap4{ gap:4px } .row.gap6{ gap:6px } .row.gap8{ gap:8px } .row.gap10{ gap:10px } .row.gap12{ gap:12px }
+    .w100{ width:100% }
+    .hidden{ display:none !important }
+    .small{ font-size:12px; line-height:1.5 }
+    .settings-card{ display:flex; flex-direction:column; gap:var(--space); }
+    .integration-layout{ display:flex; flex-direction:column; gap:var(--space); }
+    .integration-content{ display:flex; flex-direction:column; gap:var(--space); flex:1; }
+    .integration-tabs{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .integration-tabs__list{ display:flex; align-items:center; flex-wrap:wrap; gap:var(--space-xs); }
+    .integration-tab{ border:none; border-radius:999px; background:rgba(var(--panel-base-rgb),0.12); color:var(--muted); font-weight:700; letter-spacing:.2px; padding:8px 18px; cursor:pointer; transition:background .2s ease, color .2s ease, box-shadow .2s ease; }
+    .integration-tab:is(:hover,:focus-visible){ background:rgba(var(--panel-base-rgb),0.2); color:var(--text); outline:none; box-shadow:0 0 0 3px rgba(var(--panel-base-rgb),0.24); }
+    .integration-tab.is-active{ background:rgba(var(--panel-base-rgb),0.28); color:var(--text); box-shadow:inset 0 1px 0 rgba(255,255,255,0.18); }
+    html[data-theme="light"] .integration-tab{ background:rgba(var(--panel-base-rgb),0.1); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 40%, #475569 60%); }
+    html[data-theme="light"] .integration-tab.is-active{ background:rgba(var(--panel-base-rgb),0.16); box-shadow:inset 0 1px 0 rgba(255,255,255,0.7); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 20%, #0f172a 80%); }
+    .integration-tab[hidden]{ display:none !important; }
+    .integration-tabs__panels{ display:flex; flex-direction:column; gap:var(--space); }
+    .integration-tabpanel{ display:none; }
+    .integration-tabpanel.is-active{ display:block; }
+    .integration-grid{ display:grid; gap:var(--space); grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); }
+    .integration-card{ background:var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); padding:calc(var(--space)*0.9); box-shadow:inset 0 1px 0 rgba(255,255,255,0.04); display:flex; flex-direction:column; gap:var(--space-sm); position:relative; overflow:hidden; }
+    html[data-theme="light"] .integration-card{ border-color:rgba(15,23,42,0.08); box-shadow:inset 0 1px 0 rgba(255,255,255,0.8); }
+    .integration-card__header{ display:flex; align-items:flex-start; justify-content:space-between; gap:var(--space-sm); }
+    .integration-card__title{ font-weight:700; font-size:1.05rem; display:flex; align-items:center; gap:var(--space-xs); }
+    .integration-tag{ display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:999px; background:rgba(var(--panel-base-rgb),0.16); color:var(--panel-stage-text); font-size:12px; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; }
+    html[data-theme="light"] .integration-tag{ background:rgba(var(--panel-base-rgb),0.12); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 82%, #0f172a 18%); }
+    .integration-card__status{ font-weight:600; display:flex; align-items:center; gap:6px; }
+    .integration-status--connected{ color:var(--ok); }
+    .integration-status--beta{ color:var(--warn); }
+    .integration-card__body{ color:var(--muted); font-size:0.95rem; display:flex; flex-direction:column; gap:var(--space-sm); }
+    .integration-card__actions{ display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; }
+    .integration-card__meta{ font-size:0.8rem; color:var(--muted); }
+    .integration-empty{ margin:var(--space-sm) 0 0; font-size:0.9rem; color:var(--muted); }
+    .integration-dev-controls{ margin-top:auto; padding-top:var(--space-sm); border-top:1px dashed rgba(var(--panel-base-rgb),0.32); display:flex; flex-direction:column; gap:var(--space-xs); font-size:0.85rem; color:var(--muted); }
+    .integration-dev-controls__status{ font-weight:600; color:var(--text); }
+    .integration-dev-controls__actions{ display:flex; flex-wrap:wrap; gap:var(--space-xs); }
+    html[data-theme="light"] .integration-dev-controls{ border-color:rgba(var(--panel-base-rgb),0.24); }
+    html[data-theme="light"] .integration-dev-controls__status{ color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 22%, #0f172a 78%); }
+    .integration-help{ background:rgba(var(--panel-base-rgb),0.14); border-radius:var(--radius); padding:calc(var(--space)*0.9); border:1px solid rgba(var(--panel-base-rgb),0.28); box-shadow:0 12px 30px rgba(var(--panel-base-rgb),0.18); }
+    html[data-theme="light"] .integration-help{ background:color-mix(in srgb, var(--card) 84%, var(--panel-base-soft) 16%); border-color:rgba(var(--panel-base-rgb),0.24); box-shadow:0 16px 34px rgba(var(--panel-base-rgb),0.12); }
+    .integration-help h4{ margin:0 0 var(--space-sm); font-size:1.05rem; }
+    .integration-help ul{ margin:0; padding-left:20px; display:grid; gap:6px; }
+    .settings-profile{ display:flex; flex-wrap:wrap; gap:var(--space); align-items:flex-start; }
+    .profile-avatar{ display:flex; flex-direction:column; gap:var(--space-sm); align-items:flex-start; }
+    .avatar-frame{ width:var(--avatar-size); height:var(--avatar-size); border-radius:50%; border:2px dashed rgba(255,255,255,0.2); background:var(--card-2); color:var(--accent); display:flex; align-items:center; justify-content:center; font-size:32px; font-weight:700; text-transform:uppercase; position:relative; overflow:hidden; box-shadow: inset 0 2px 6px rgba(2,12,29,0.35); }
+    .avatar-image{ width:100%; height:100%; display:none; align-items:center; justify-content:center; font-size:32px; font-weight:700; text-transform:uppercase; color:var(--accent); }
+    .avatar-frame.has-image{ border-style:solid; border-color:rgba(255,255,255,0.3); }
+    .avatar-frame.has-image .avatar-image{ display:flex; }
+    .avatar-frame.has-image span{ display:none; }
+    .avatar-actions{ display:flex; flex-direction:column; gap:var(--space-sm); width:100%; }
+    .avatar-actions .btn{ justify-content:center; }
+    .profile-details{ flex:1 1 280px; display:flex; flex-direction:column; gap:var(--space-sm); }
+    .form-grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:var(--space-sm); }
+    .form-grid label{ display:flex; flex-direction:column; gap:6px; font-size:13px; font-weight:600; letter-spacing:.2px; color:var(--muted); }
+    .profile-summary{ display:grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap:var(--space-sm); padding:var(--space); border-radius:var(--radius); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); }
+    html[data-theme="light"] .profile-summary{ background:rgba(15,23,42,0.04); border-color:rgba(15,23,42,0.08); }
+    .profile-summary div{ display:flex; flex-direction:column; gap:4px; }
+    .profile-sync-alert{ padding:10px 12px; border-radius:12px; border:1px solid rgba(148,163,184,0.35); background:rgba(148,163,184,0.12); display:flex; flex-direction:column; gap:6px; font-size:13px; color:var(--muted); }
+    .profile-sync-alert strong{ font-weight:700; color:var(--text); }
+    .profile-sync-alert[data-state="stale"]{ border-color:rgba(239,68,68,0.45); background:rgba(239,68,68,0.12); color:var(--bad); }
+    .profile-sync-alert[data-state="stale"] strong{ color:var(--bad); }
+    .profile-sync-alert[data-state="unknown"]{ border-color:rgba(245,158,11,0.45); background:rgba(245,158,11,0.12); color:var(--warn); }
+    .profile-sync-alert button{ align-self:flex-start; }
+    .view-status{
+      margin: var(--space-sm) 0 0;
+      padding: 10px 14px;
+      border-radius: 12px;
+      border: 1px solid transparent;
+      font-size: 13px;
+      line-height: 1.45;
+      letter-spacing: .2px;
+    }
+    .view-status.hidden{ display:none !important; }
+    .view-status--error{ border-color: rgba(239,68,68,0.38); background: rgba(239,68,68,0.12); color: var(--bad); }
+    .view-status--info{ border-color: rgba(96,165,250,0.35); background: rgba(96,165,250,0.12); color: var(--info); }
+    .view-status--success{ border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.12); color: var(--ok); }
+    html[data-theme="light"] .view-status--error{ border-color: rgba(239,68,68,0.45); background: rgba(239,68,68,0.12); color: #b91c1c; }
+    html[data-theme="light"] .view-status--info{ border-color: rgba(59,130,246,0.35); background: rgba(59,130,246,0.12); color: #1d4ed8; }
+    html[data-theme="light"] .view-status--success{ border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.12); color: #15803d; }
+    .summary-label{ font-size:12px; text-transform:uppercase; letter-spacing:.4px; color:var(--muted); }
+    .summary-value{ font-size:14px; font-weight:600; color:var(--text); word-break:break-word; }
+    .security-form{ gap:var(--space-sm); align-items:flex-end; }
+    .security-actions{ flex-wrap:wrap; }
+    .security-status{ grid-column:1 / -1; display:flex; flex-direction:column; gap:4px; padding:var(--space-sm); border-radius:var(--radius); background:rgba(var(--panel-base-rgb),0.12); border:1px solid rgba(var(--panel-base-rgb),0.35); transition:background .2s ease, border-color .2s ease; }
+    .security-status[data-tone="success"]{ background:rgba(34,197,94,0.12); border-color:rgba(34,197,94,0.35); }
+    .security-status[data-tone="warning"]{ background:rgba(245,158,11,0.12); border-color:rgba(245,158,11,0.35); }
+    .security-status[data-tone="error"]{ background:rgba(239,68,68,0.12); border-color:rgba(239,68,68,0.35); }
+    .security-status[data-tone="success"] .summary-value{ color:var(--ok); }
+    .security-status[data-tone="warning"] .summary-value{ color:var(--warn); }
+    .security-status[data-tone="error"] .summary-value{ color:var(--bad); }
+    .security-status__header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+    .security-timeline{ margin:4px 0 0; display:flex; flex-direction:column; gap:6px; font-size:12px; color:var(--muted); }
+    .security-timeline__item{ display:flex; align-items:flex-start; gap:8px; }
+    .security-timeline__badge{ width:10px; height:10px; border-radius:50%; margin-top:5px; background:rgba(var(--panel-base-rgb),0.4); flex:0 0 auto; }
+    .security-timeline__item[data-state="done"] .security-timeline__badge{ background:var(--ok); }
+    .security-timeline__item[data-state="active"] .security-timeline__badge{ background:var(--warn); box-shadow:0 0 0 3px rgba(245,158,11,0.25); }
+    .security-timeline__item[data-state="future"] .security-timeline__badge{ background:rgba(148,163,184,0.4); }
+    .security-timeline__content{ display:flex; flex-direction:column; gap:2px; }
+    .security-timeline__label{ font-weight:600; color:var(--text); }
+    .security-timeline__meta{ font-size:11px; color:var(--muted); }
+    .security-status__actions{ display:flex; flex-wrap:wrap; gap:6px; margin-top:4px; }
+    .settings-preferences{ display:flex; flex-direction:column; gap:var(--space); }
+    .pref-layout{ display:grid; gap:var(--space); }
+    .pref-column{ display:grid; gap:var(--space-sm); }
+    .pref-select-grid{ display:grid; gap:var(--space-sm); }
+    .pref-toggles{ border:1px solid rgba(var(--panel-base-rgb),0.28); border-radius:var(--radius); padding:var(--space-sm); background:rgba(var(--panel-base-rgb),0.08); display:flex; flex-direction:column; gap:var(--space-sm); }
+    html[data-theme="light"] .pref-toggles{ background:rgba(var(--panel-base-rgb),0.12); border-color:rgba(var(--panel-base-rgb),0.22); }
+    .pref-toggles legend{ margin:0; padding:0 var(--space-xs); font-size:12px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; color:var(--text); }
+    .pref-toggle-grid{ display:grid; gap:var(--space-sm); }
+    .pref-column--toggles .settings-group.switch{ justify-content:space-between; }
+    @media (min-width: 920px){
+      .pref-layout{ grid-template-columns: minmax(0,1fr) minmax(0,420px); align-items:start; }
+      .pref-select-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .pref-toggle-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+    }
+    .pref-presets{ padding:12px 14px; border-radius:12px; border:1px dashed rgba(var(--panel-base-rgb),0.35); background:rgba(var(--panel-base-rgb),0.08); display:flex; flex-direction:column; gap:8px; }
+    .pref-presets[hidden]{ display:none; }
+    .pref-presets__title{ margin:0; font-size:13px; font-weight:700; letter-spacing:.35px; text-transform:uppercase; color:var(--muted); }
+    .pref-presets__list{ display:flex; flex-wrap:wrap; gap:10px; }
+    .pref-preset-card{ padding:10px 12px; border-radius:12px; border:1px solid rgba(255,255,255,0.12); background:var(--card); display:flex; flex-direction:column; gap:6px; max-width:320px; }
+    .pref-preset-card strong{ font-size:14px; color:var(--text); }
+    .pref-preset-card p{ margin:0; font-size:12px; color:var(--muted); }
+    .settings-group{ display:flex; flex-direction:column; gap:var(--space-sm); font-size:13px; font-weight:600; color:var(--muted); }
+    .settings-group legend{ font-size:13px; text-transform:uppercase; letter-spacing:.4px; color:var(--muted); margin-bottom:var(--space-sm); }
+    .settings-group select{ width:100%; font-weight:600; color:var(--text); }
+    .settings-group.switch{ flex-direction:row; align-items:center; gap:var(--space-sm); font-size:14px; color:var(--text); }
+    .settings-group.switch input{ position:relative; width:44px; height:24px; border-radius:999px; border:1px solid rgba(255,255,255,0.2); background:rgba(15,23,42,0.4); appearance:none; cursor:pointer; transition: background .2s ease, border-color .2s ease; }
+    .settings-group.switch input::before{ content:""; position:absolute; top:2px; left:2px; width:18px; height:18px; border-radius:50%; background:#fff; box-shadow:0 2px 4px rgba(15,23,42,0.25); transform:translateX(0); transition: transform .2s ease; }
+    .settings-group.switch input:checked{ background:var(--accent); border-color:transparent; }
+    .settings-group.switch input:checked::before{ transform:translateX(20px); }
+    html[data-theme="light"] .settings-group.switch input{ background:rgba(15,23,42,0.12); border-color:rgba(15,23,42,0.16); }
+    .settings-group.switch span{ font-weight:600; }
+    .segmented{ display:inline-flex; border-radius:12px; padding:4px; gap:4px; background:rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.12); }
+    html[data-theme="light"] .segmented{ background:rgba(15,23,42,0.06); border-color:rgba(15,23,42,0.12); }
+    .segmented-option{ position:relative; border-radius:10px; overflow:hidden; }
+    .segmented-option input{ position:absolute; inset:0; opacity:0; cursor:pointer; }
+    .segmented-option span{ display:inline-flex; align-items:center; justify-content:center; padding:8px 16px; border-radius:10px; font-size:13px; font-weight:600; color:var(--text); transition: background .2s ease, color .2s ease, box-shadow .2s ease; min-width:80px; }
+    .segmented-option input:checked + span{ background:linear-gradient(135deg, var(--accent), rgba(0,58,95,0.85)); color:#fff; box-shadow:0 10px 18px rgba(0,58,95,0.25); }
+    .segmented-option input:focus-visible + span{ outline:2px solid var(--accent); outline-offset:2px; }
+    .pref-actions{ flex-wrap:wrap; }
+    .settings-summary{ padding:var(--space-sm) var(--space); border-radius:var(--radius); border:1px solid rgba(255,255,255,0.12); background:rgba(255,255,255,0.04); color:var(--muted); min-height:24px; transition: opacity .3s ease, background .3s ease, color .3s ease; }
+    html[data-theme="light"] .settings-summary{ background:rgba(15,23,42,0.04); border-color:rgba(15,23,42,0.08); }
+    .settings-summary.visible{ color:var(--text); }
+    .settings-summary[data-state="success"]{ border-color:rgba(34,197,94,0.45); color:#22c55e; background:rgba(34,197,94,0.12); }
+    .settings-summary[data-state="error"]{ border-color:rgba(239,68,68,0.45); color:#ef4444; background:rgba(239,68,68,0.12); }
+    .settings-summary[data-state="warning"]{ border-color:rgba(245,158,11,0.45); color:#f59e0b; background:rgba(245,158,11,0.12); }
+    .settings-summary.fade{ opacity:0.45; }
+    .profile-avatar .muted{ max-width:240px; }
+    .permissions-grid{ display:grid; grid-template-columns: minmax(220px, 320px) minmax(0,1fr); gap:var(--space); align-items:flex-start; }
+    .permissions-panel{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space); background: var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius: var(--radius); box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .permissions-status{ margin:0; }
+    .permissions-status[data-tone="info"]{ color:var(--muted); }
+    .permissions-status[data-tone="success"]{ color:var(--ok); }
+    .permissions-status[data-tone="warning"]{ color:var(--warn); }
+    .permissions-status[data-tone="error"]{ color:var(--bad); }
+    .permissions-list{ display:flex; flex-direction:column; gap:6px; max-height:360px; overflow:auto; padding-right:4px; }
+    .perm-user,
+    .team-item{ border:1px solid rgba(255,255,255,0.12); background: var(--card); color: var(--text); border-radius:12px; padding:10px 12px; text-align:left; display:flex; flex-direction:column; gap:4px; cursor:pointer; transition:border-color .2s ease, box-shadow .2s ease, transform .12s ease; }
+    .perm-user .perm-user__header,
+    .team-item .team-item__header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+    .perm-user__name,
+    .team-item__name{ font-weight:600; font-size:14px; letter-spacing:.2px; }
+    .perm-user__id,
+    .team-item__id{ font-size:12px; color:var(--muted); }
+    .perm-user__meta,
+    .team-item__meta{ font-size:12px; color:var(--muted); display:flex; gap:8px; flex-wrap:wrap; }
+    .perm-user__badge,
+    .team-item__badge{ display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:999px; font-weight:600; font-size:11px; background:rgba(var(--panel-base-rgb),0.15); border:1px solid rgba(var(--panel-base-rgb),0.35); color:var(--text); text-transform:uppercase; letter-spacing:.35px; }
+    .perm-user__status,
+    .team-item__status{ font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:.35px; }
+    .team-item__description{ font-size:12px; color:var(--muted); }
+    .perm-user[aria-selected="true"],
+    .team-item[aria-selected="true"]{ border-color: var(--accent); box-shadow: var(--ring), var(--shadow); transform: translateY(-1px); }
+    .perm-user.is-inactive,
+    .team-item.is-inactive{ opacity:0.75; }
+    .permissions-form{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space); background: var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius: var(--radius); box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .perm-form-title{ margin:0; font-size:16px; }
+    .permissions-form .form-grid{ gap:var(--space-sm); }
+    .permissions-form label{ font-weight:600; }
+    .permissions-form input[type="text"],
+    .permissions-form input[type="email"],
+    .permissions-form input[type="password"],
+    .permissions-form select{ background:var(--card); }
+    .permissions-form input[readonly]{ opacity:0.8; cursor:not-allowed; }
+    .role-scope-suggestion{ margin-top:6px; padding:10px 12px; border-radius:12px; border:1px dashed rgba(255,255,255,0.18); background:rgba(255,255,255,0.04); display:flex; flex-direction:column; gap:8px; }
+    .role-scope-suggestion[hidden]{ display:none; }
+    .role-scope-suggestion__text{ margin:0; font-size:13px; color:var(--muted); line-height:1.45; }
+    .role-scope-suggestion__chips{ display:flex; flex-wrap:wrap; gap:6px; }
+    .role-scope-suggestion__chips .scope-chip{ display:inline-flex; align-items:center; gap:4px; padding:4px 10px; border-radius:999px; background:rgba(var(--panel-base-rgb),0.18); border:1px solid rgba(var(--panel-base-rgb),0.35); font-size:12px; font-weight:600; color:var(--text); letter-spacing:.2px; text-transform:uppercase; }
+    .role-scope-suggestion__chips .scope-chip i{ font-size:12px; opacity:0.85; }
+    html[data-theme="light"] .role-scope-suggestion{ background:rgba(15,23,42,0.04); border-color:rgba(15,23,42,0.16); }
+    html[data-theme="light"] .role-scope-suggestion__chips .scope-chip{ background:rgba(var(--panel-base-rgb),0.12); color:#0f172a; }
+    .multi-select[data-dirty="true"] .multi-select__button{ border-color:rgba(239,68,68,0.55); box-shadow:0 0 0 2px rgba(239,68,68,0.18); }
+    .multi-select[data-dirty="true"]::after{ content:"Personalizado"; align-self:flex-start; font-size:10px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; color:rgba(239,68,68,0.85); background:rgba(239,68,68,0.12); border:1px solid rgba(239,68,68,0.35); border-radius:999px; padding:2px 8px; margin-top:-4px; }
+    .scope-template-toolbar{ display:flex; flex-wrap:wrap; gap:8px; margin-bottom:6px; }
+    .scope-template-btn{ display:inline-flex; flex-direction:column; align-items:flex-start; gap:4px; padding:8px 12px; border-radius:12px; border:1px dashed rgba(var(--panel-base-rgb),0.35); background:rgba(var(--panel-base-rgb),0.1); color:var(--text); font-size:12px; font-weight:600; cursor:pointer; transition:border-color .2s ease, background .2s ease, transform .12s ease; }
+    .scope-template-btn:hover{ border-color:var(--accent); background:rgba(var(--panel-base-rgb),0.18); transform:translateY(-1px); }
+    .scope-template-btn span{ font-weight:500; opacity:0.8; }
+    .field-with-hint{ display:flex; flex-direction:column; }
+    .field-with-hint .field-hint{ display:block; margin-top:6px; font-size:12px; color:var(--muted); line-height:1.45; }
+    .multi-select{ position:relative; display:flex; flex-direction:column; gap:6px; }
+    .multi-select__button{ display:flex; align-items:center; justify-content:space-between; width:100%; border-radius:12px; border:1px solid rgba(255,255,255,0.14); background:var(--card); color:var(--text); padding:10px 14px; cursor:pointer; transition:border-color .2s ease, box-shadow .2s ease, background .2s ease; font:inherit; font-size:13px; }
+    .multi-select__button:hover{ border-color:rgba(var(--panel-base-rgb),0.5); }
+    .multi-select__button:focus-visible{ outline:none; box-shadow:var(--ring); border-color:var(--accent); }
+    .multi-select__button i{ font-size:14px; opacity:0.7; }
+    .multi-select__menu{ position:absolute; top:calc(100% + 6px); left:0; right:0; background:var(--card); border:1px solid rgba(255,255,255,0.12); border-radius:12px; box-shadow:0 24px 50px rgba(2,10,28,0.45); padding:6px 0; display:none; max-height:220px; overflow-y:auto; z-index:30; }
+    .multi-select.is-open .multi-select__menu{ display:block; }
+    .multi-select__menu::-webkit-scrollbar{ width:8px; }
+    .multi-select__menu::-webkit-scrollbar-thumb{ background:rgba(var(--panel-base-rgb),0.35); border-radius:999px; }
+    .multi-select__option{ display:flex; align-items:center; gap:10px; padding:10px 16px; cursor:pointer; font-size:13px; transition:background .18s ease; }
+    .multi-select__option:hover{ background:rgba(var(--panel-base-rgb),0.12); }
+    .multi-select__option input{ width:16px; height:16px; }
+    .multi-select__chips{ display:flex; flex-wrap:wrap; gap:6px; min-height:28px; padding:2px 0 4px; }
+    .multi-select__chip{ background:rgba(var(--panel-base-rgb),0.18); border:1px solid rgba(var(--panel-base-rgb),0.35); color:var(--text); padding:4px 12px; border-radius:999px; font-size:12px; font-weight:600; letter-spacing:.2px; }
+    .multi-select__placeholder{ font-size:12px; color:var(--muted); }
+    .multi-select.has-selection .multi-select__button{ border-color:rgba(var(--panel-base-rgb),0.45); box-shadow:0 18px 40px rgba(var(--panel-base-rgb),0.22); }
+    .permissions-reference{ margin-top:var(--space); display:grid; gap:var(--space); grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+    .permissions-card{ background:var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); box-shadow:inset 0 1px 0 rgba(255,255,255,0.04); padding:var(--space); display:flex; flex-direction:column; gap:var(--space-sm); }
+    .permissions-card h4{ margin:0; font-size:16px; display:flex; align-items:center; gap:8px; }
+    .permissions-card h4 i{ font-size:18px; }
+    .permissions-card p{ margin:0; font-size:13px; color:var(--muted); }
+    .permission-matrix-wrapper{ width:100%; overflow-x:auto; -webkit-overflow-scrolling:touch; margin:0 calc(var(--space-sm) * -1); padding:0 calc(var(--space-sm)); }
+    .permission-matrix-wrapper:focus-visible{ outline:2px solid var(--accent); outline-offset:4px; border-radius:12px; }
+    .permission-matrix-wrapper::-webkit-scrollbar{ height:8px; }
+    .permission-matrix-wrapper::-webkit-scrollbar-thumb{ background:rgba(var(--panel-base-rgb),0.35); border-radius:999px; }
+    .permission-matrix{ width:100%; border-collapse:collapse; font-size:13px; }
+    .permission-matrix{ min-width:520px; }
+    .permission-matrix thead th{ text-align:left; font-weight:700; padding:10px; border-bottom:1px solid rgba(255,255,255,0.12); }
+    .permission-matrix tbody td{ padding:10px; border-bottom:1px solid rgba(255,255,255,0.08); vertical-align:top; }
+    .permission-matrix tbody tr:last-child td{ border-bottom:none; }
+    .permission-rules{ margin:0; padding-left:20px; display:flex; flex-direction:column; gap:8px; font-size:13px; color:var(--text); }
+    .permission-rules li{ line-height:1.5; }
+    .permission-scope-note{ font-size:12px; color:var(--muted); display:flex; flex-direction:column; gap:4px; }
+    .permission-scope-values{ display:flex; flex-wrap:wrap; gap:6px; margin:6px 0 10px; }
+    .assignment-grid{ display:flex; flex-direction:column; gap:var(--space); }
+    .assignment-body{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .assignment-mode{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .assignment-targets{ display:grid; gap:var(--space-sm); grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+    .assignment-actions{ display:flex; flex-wrap:wrap; gap:var(--space-sm); align-items:center; justify-content:space-between; }
+    .assignment-status{ font-size:13px; color:var(--muted); transition:color .2s ease; }
+    .assignment-status[data-tone="success"]{ color:var(--ok); }
+    .assignment-status[data-tone="warning"]{ color:var(--warn); }
+    .assignment-status[data-tone="error"]{ color:var(--bad); }
+    .assignment-buttons{ display:flex; gap:var(--space-sm); flex-shrink:0; }
+    .assignment-summary{ font-size:13px; color:var(--muted); background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); padding:var(--space-sm); min-height:24px; }
+    .assignment-rules{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .assignment-rules h4{ margin:0; font-size:15px; display:flex; align-items:center; gap:8px; }
+    .assignment-rules__list{ margin:0; padding-left:20px; display:flex; flex-direction:column; gap:6px; font-size:13px; color:var(--muted); }
+    .assignment-filters{ display:grid; gap:var(--space-sm); grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); }
+    html[data-theme="light"] .assignment-summary{ background:rgba(15,23,42,0.05); border-color:rgba(15,23,42,0.08); }
+    @media (max-width:700px){
+      .assignment-buttons{ width:100%; justify-content:flex-end; }
+      .assignment-actions{ align-items:stretch; }
+    }
+    .permissions-switch{ display:flex; align-items:center; gap:10px; padding:12px; border-radius:12px; border:1px solid rgba(255,255,255,0.12); background: rgba(255,255,255,0.02); cursor:pointer; transition:border-color .2s ease, box-shadow .2s ease; }
+    .permissions-switch input{ appearance:none; width:44px; height:24px; border-radius:999px; border:1px solid rgba(255,255,255,0.25); background:rgba(15,23,42,0.55); position:relative; cursor:pointer; transition: background .2s ease, border-color .2s ease; }
+    .permissions-switch input::before{ content:""; position:absolute; top:2px; left:2px; width:18px; height:18px; border-radius:50%; background:#fff; box-shadow:0 2px 4px rgba(15,23,42,0.25); transform:translateX(0); transition: transform .2s ease; }
+    .permissions-switch input:checked{ background:var(--accent); border-color:transparent; }
+    .permissions-switch input:checked::before{ transform:translateX(20px); }
+    .permissions-switch span{ font-size:13px; font-weight:600; color:var(--text); }
+    .permissions-switch:focus-within{ border-color: var(--accent); box-shadow: var(--ring); }
+    .permissions-meta{ min-height:18px; }
+    html[data-theme="light"] .permissions-panel,
+    html[data-theme="light"] .permissions-form{ border-color:rgba(15,23,42,0.08); box-shadow: inset 0 1px 0 rgba(255,255,255,0.6); }
+    html[data-theme="light"] .perm-user,
+    html[data-theme="light"] .team-item{ border-color:rgba(15,23,42,0.12); }
+    html[data-theme="light"] .permissions-switch{ border-color:rgba(15,23,42,0.12); background:rgba(15,23,42,0.03); }
+    html[data-theme="light"] .permissions-switch input{ background:rgba(15,23,42,0.12); border-color:rgba(15,23,42,0.2); }
+    html[data-theme="light"] .permissions-form input[readonly]{ background:rgba(15,23,42,0.04); }
+    html[data-theme="light"] .multi-select__button{ background:#fff; border-color:rgba(15,23,42,0.14); }
+    html[data-theme="light"] .multi-select.has-selection .multi-select__button{ box-shadow:0 18px 40px rgba(var(--panel-base-rgb),0.22); }
+    html[data-theme="light"] .multi-select__menu{ border-color:rgba(15,23,42,0.12); box-shadow:0 28px 60px rgba(15,23,42,0.18); }
+    html[data-theme="light"] .multi-select__chip{ color:#0f172a; background:rgba(var(--panel-base-rgb),0.14); border-color:rgba(var(--panel-base-rgb),0.32); }
+    html[data-theme="light"] .permissions-card{ background:#fff; }
+    html[data-theme="light"] .permission-matrix thead th{ border-color:rgba(15,23,42,0.12); }
+    html[data-theme="light"] .permission-matrix tbody td{ border-color:rgba(15,23,42,0.08); }
+    .messages-header{ display:flex; flex-direction:column; gap:6px; }
+    .messages-header h3{ margin:0; font-size:18px; font-weight:700; letter-spacing:.3px; display:flex; align-items:center; gap:8px; }
+    .messages-workspace{ display:flex; flex-direction:row; gap:var(--space); align-items:stretch; }
+    .messages-sidebar{ display:flex; flex-direction:column; gap:var(--space-sm); min-width:280px; max-width:360px; background:var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); box-shadow:inset 0 1px 0 rgba(255,255,255,0.04); padding:var(--space); }
+    html[data-theme="light"] .messages-sidebar{ border-color:rgba(15,23,42,0.08); box-shadow:inset 0 1px 0 rgba(255,255,255,0.7); }
+    .messages-sidebar__top{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .messages-sidebar__top h4{ margin:0; font-size:15px; font-weight:700; letter-spacing:.3px; text-transform:uppercase; color:var(--muted); }
+    .messages-search{ display:flex; align-items:center; gap:8px; padding:8px 12px; border-radius:12px; border:1px solid rgba(255,255,255,0.12); background:rgba(255,255,255,0.04); transition:border-color .2s ease, box-shadow .2s ease; }
+    .messages-search i{ opacity:0.65; }
+    .messages-search input{ flex:1; border:none; background:transparent; color:var(--text); font:600 14px/1.3 var(--font); }
+    .messages-search input:focus{ outline:none; }
+    .messages-search:focus-within{ border-color:var(--accent); box-shadow:var(--ring); background:rgba(255,255,255,0.08); }
+    html[data-theme="light"] .messages-search{ border-color:rgba(15,23,42,0.12); background:rgba(15,23,42,0.04); }
+    html[data-theme="light"] .messages-search:focus-within{ background:#fff; }
+    .messages-thread-list{ flex:1; display:flex; flex-direction:column; gap:4px; overflow-y:auto; padding-right:6px; }
+    .messages-thread-list::-webkit-scrollbar{ width:8px; }
+    .messages-thread-list::-webkit-scrollbar-thumb{ background:rgba(var(--panel-base-rgb),0.35); border-radius:999px; }
+    .messages-thread{ display:flex; align-items:flex-start; gap:12px; width:100%; border:1px solid transparent; background:transparent; color:inherit; padding:10px 12px; border-radius:14px; cursor:pointer; transition:border-color .2s ease, background .2s ease, transform .12s ease; text-align:left; }
+    .messages-thread__avatar{ width:40px; height:40px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-weight:700; background:rgba(var(--panel-base-rgb),0.22); color:var(--panel-stage-text); flex-shrink:0; letter-spacing:.2px; }
+    html[data-theme="light"] .messages-thread__avatar{ background:rgba(var(--panel-base-rgb),0.18); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 68%, #0f172a 32%); }
+    .messages-thread__body{ flex:1; display:flex; flex-direction:column; gap:4px; min-width:0; }
+    .messages-thread__header{ display:flex; align-items:center; gap:8px; }
+    .messages-thread__name{ font-weight:600; font-size:14px; letter-spacing:.2px; flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .messages-thread__time{ font-size:12px; color:var(--muted); }
+    .messages-thread__meta{ font-size:12px; color:var(--muted); display:flex; gap:6px; flex-wrap:wrap; }
+    .messages-thread__preview{ font-size:13px; color:var(--muted); display:flex; align-items:center; gap:6px; min-width:0; }
+    .messages-thread__preview span{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block; }
+    .message-direction{ opacity:0.75; }
+    .messages-thread:hover{ border-color:rgba(var(--panel-base-rgb),0.35); background:rgba(var(--panel-base-rgb),0.12); transform:translateY(-1px); }
+    .messages-thread.is-active{ border-color:var(--accent); background:rgba(var(--panel-base-rgb),0.18); box-shadow:var(--ring), 0 18px 40px rgba(var(--panel-base-rgb),0.22); }
+    .messages-thread.is-active .messages-thread__name{ color:var(--text); }
+    html[data-theme="light"] .messages-thread{ border-color:rgba(15,23,42,0.06); }
+    html[data-theme="light"] .messages-thread:hover{ background:rgba(var(--panel-base-rgb),0.16); border-color:rgba(var(--panel-base-rgb),0.4); }
+    html[data-theme="light"] .messages-thread.is-active{ background:rgba(var(--panel-base-rgb),0.18); border-color:rgba(var(--panel-base-rgb),0.55); }
+    .messages-empty{ margin:0; padding:24px 12px; text-align:center; color:var(--muted); font-size:13px; display:flex; flex-direction:column; gap:8px; align-items:center; }
+    .messages-empty i{ font-size:20px; opacity:0.6; }
+    .messages-conversation{ flex:1; display:flex; flex-direction:column; background:var(--card-2); border:1px solid rgba(255,255,255,0.08); border-radius:var(--radius); box-shadow:inset 0 1px 0 rgba(255,255,255,0.04); min-height:420px; }
+    html[data-theme="light"] .messages-conversation{ border-color:rgba(15,23,42,0.08); box-shadow:inset 0 1px 0 rgba(255,255,255,0.7); }
+    .messages-conversation__header{ display:flex; flex-direction:column; gap:12px; padding:var(--space); border-bottom:1px solid rgba(255,255,255,0.08); }
+    html[data-theme="light"] .messages-conversation__header{ border-color:rgba(15,23,42,0.08); }
+    .messages-conversation__identity{ display:flex; align-items:center; gap:12px; }
+    .messages-conversation__avatar{ width:44px; height:44px; border-radius:50%; background:rgba(var(--panel-base-rgb),0.2); color:var(--panel-stage-text); display:inline-flex; align-items:center; justify-content:center; font-weight:700; font-size:18px; }
+    html[data-theme="light"] .messages-conversation__avatar{ background:rgba(var(--panel-base-rgb),0.14); color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 70%, #0f172a 30%); }
+    .messages-conversation__title{ margin:0; font-size:18px; font-weight:700; letter-spacing:.2px; }
+    .messages-conversation__subtitle{ margin:0; color:var(--muted); font-size:13px; }
+    .messages-conversation__chips{ display:flex; flex-wrap:wrap; gap:8px; }
+    .messages-chip{ display:flex; flex-direction:column; gap:2px; padding:8px 12px; border-radius:12px; background:rgba(var(--panel-base-rgb),0.12); border:1px solid rgba(var(--panel-base-rgb),0.25); font-size:12px; min-width:0; }
+    .messages-chip strong{ font-size:13px; letter-spacing:.2px; }
+    .messages-chip span{ color:var(--muted); }
+    .messages-chip--channel{ flex-direction:row; align-items:center; gap:8px; font-weight:600; }
+    .messages-chip--channel i{ font-size:16px; }
+    .messages-chip--channel span{ color:inherit; font-weight:600; }
+    html[data-theme="light"] .messages-chip{ background:rgba(var(--panel-base-rgb),0.08); border-color:rgba(var(--panel-base-rgb),0.25); color:#0f172a; }
+    html[data-theme="light"] .messages-chip span{ color:color-mix(in srgb, #0f172a 70%, rgba(var(--panel-base-rgb),0.4) 30%); }
+    .messages-conversation__body{ flex:1; padding:var(--space); display:flex; flex-direction:column; gap:var(--space-sm); overflow-y:auto; background:linear-gradient(180deg, rgba(var(--panel-base-rgb),0.08), transparent 45%); }
+    .messages-conversation__body::-webkit-scrollbar{ width:10px; }
+    .messages-conversation__body::-webkit-scrollbar-thumb{ background:rgba(var(--panel-base-rgb),0.35); border-radius:999px; }
+    .messages-placeholder{ flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:var(--space-sm); text-align:center; color:var(--muted); padding:var(--space); }
+    .messages-placeholder i{ font-size:32px; opacity:0.6; }
+    .messages-day-separator{ align-self:center; background:rgba(255,255,255,0.06); border-radius:999px; padding:4px 12px; font-size:12px; font-weight:600; letter-spacing:.25px; color:var(--muted); text-transform:uppercase; }
+    html[data-theme="light"] .messages-day-separator{ background:rgba(15,23,42,0.08); color:#475569; }
+    .message-bubble{ max-width:72%; padding:12px 14px; border-radius:18px; background:rgba(255,255,255,0.05); box-shadow:0 8px 20px rgba(2,10,28,0.28); display:flex; flex-direction:column; gap:6px; position:relative; }
+    .message-bubble.message-incoming{ align-self:flex-start; border-bottom-left-radius:6px; }
+    .message-bubble.message-outgoing{ align-self:flex-end; background:linear-gradient(155deg, var(--accent), color-mix(in srgb, var(--accent) 72%, #0b1220 28%)); color:#fff; border-bottom-right-radius:6px; box-shadow:0 8px 26px rgba(var(--panel-base-rgb),0.35); }
+    .message-bubble.message-status{ align-self:center; background:transparent; box-shadow:none; color:var(--muted); padding:6px 10px; max-width:100%; text-align:center; }
+    .message-text{ white-space:pre-wrap; word-break:break-word; font-size:14px; }
+    .message-meta{ display:flex; justify-content:flex-end; gap:8px; font-size:11px; opacity:0.75; }
+    .message-status-label{ font-weight:600; letter-spacing:.2px; }
+    .message-error{ font-size:12px; color:var(--bad); }
+    html[data-theme="light"] .message-bubble{ background:rgba(15,23,42,0.06); color:#0f172a; }
+    html[data-theme="light"] .message-bubble.message-outgoing{ background:linear-gradient(155deg, var(--accent), color-mix(in srgb, var(--accent) 68%, #1e293b 32%)); color:#fff; }
+    html[data-theme="light"] .message-bubble.message-status{ color:#475569; }
+    @media (max-width: 1100px){ .messages-sidebar{ max-width:320px; } }
+    @media (max-width: 900px){ .messages-workspace{ flex-direction:column; } .messages-sidebar{ width:100%; max-width:none; } .messages-conversation{ min-height:360px; } .message-bubble{ max-width:100%; } }
+    @media (max-width: 520px){ .messages-conversation__identity{ align-items:flex-start; } .messages-conversation__avatar{ width:38px; height:38px; font-size:16px; } }
+    @media (max-width: 900px){
+      .permissions-grid{ grid-template-columns:1fr; }
+    }
+    html[data-density="compact"]{ --space:12px; --space-sm:6px; }
+    html[data-density="compact"] .card{ padding:12px; }
+    html[data-density="compact"] .panel-section{ padding:calc(var(--space-sm) + 4px) 0; }
+    html[data-density="compact"] .form-grid{ gap:var(--space-xs); }
+    html[data-density="compact"] .settings-summary{ padding:var(--space-xs) var(--space); }
+    html[data-motion="reduced"] *,
+    html[data-motion="reduced"] *::before,
+    html[data-motion="reduced"] *::after{
+      animation-duration:0.01ms !important;
+      animation-iteration-count:1 !important;
+      transition-duration:0.01ms !important;
+      scroll-behavior:auto !important;
+    }
+    html[data-eco="true"] body{ background: var(--bg); }
+    html[data-eco="true"] .card{ box-shadow:none; background: var(--card-2); border-color: rgba(255,255,255,0.08); }
+    html[data-eco="true"][data-theme="light"] .card{ background:#fff; box-shadow:none; border-color:rgba(15,23,42,0.08); }
+    html[data-eco="true"] .segmented{ background:rgba(255,255,255,0.04); }
+    html[data-eco="true"][data-theme="light"] .segmented{ background:rgba(15,23,42,0.05); }
+    html[data-font-scale="large"]{ --font-size-base: 16px; }
+    html[data-font-scale="normal"]{ --font-size-base: 15px; }
+    @media (max-width: 700px){
+      .settings-profile{ flex-direction:column; }
+      .avatar-actions{ flex-direction:row; }
+      .avatar-actions .btn{ flex:1; }
+    }
+    @media (max-width: 480px){
+      :root{ --avatar-size: 96px; }
+      .profile-summary{ grid-template-columns:repeat(1,minmax(0,1fr)); }
+    }
+    @media (min-width: 901px){
+      .app.collapsed{ --sidebar-width: 60px; grid-template-columns: var(--sidebar-width) minmax(0, 1fr); }
+      .app.collapsed .sidebar{ padding:18px 8px; }
+      .app.collapsed .brand-name,
+      .app.collapsed .nav .nav-link span{ display:none; }
+      .app.collapsed .nav a{ justify-content:center; }
+    }
+    .sidebar-overlay{
+      position:fixed;
+      inset:0;
+      background: rgba(11,18,32,0.55);
+      opacity:0;
+      pointer-events:none;
+      transition: opacity .24s ease;
+      z-index:40;
+    }
+    .app.show-sidebar .sidebar-overlay{
+      opacity:1;
+      pointer-events:auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-screen" id="loginScreen" aria-hidden="false">
+    <div class="login-panel">
+      <div class="login-card" role="dialog" aria-labelledby="loginTitle">
+        <div class="login-brand" aria-hidden="true">
+          <span class="login-brand__image" role="presentation">ReLead EDU</span>
+        </div>
+        <h1 id="loginTitle" class="login-title">Inicia sesión con tu cuenta</h1>
+        <div id="loginSignIn" aria-hidden="false">
+          <form class="login-form" id="loginForm" autocomplete="off">
+            <label>
+              <span>Correo institucional</span>
+              <input type="email" id="loginEmail" autocomplete="username" required />
+            </label>
+            <label>
+              <span>Contraseña</span>
+              <input type="password" id="loginPassword" autocomplete="current-password" required />
+            </label>
+            <div class="login-actions">
+              <button type="submit" class="btn primary w100" id="loginSubmit">Ingresar</button>
+              <button type="button" class="btn outline w100 hidden" id="connectionCheckBtn">Verificar conexión con Apps Script</button>
+            </div>
+          </form>
+          <div class="login-support">
+            <p class="login-support__label">¿Olvidaste tu contraseña?</p>
+            <button type="button" class="link-button" id="forgotPasswordBtn">Recupérala aquí</button>
+          </div>
+          <p class="login-message login-error hidden" id="loginError" role="alert"></p>
+          <p class="login-message login-info hidden" id="connectionStatus" role="status" aria-live="polite"></p>
+          <p class="login-hint hidden" id="loginHint"></p>
+        </div>
+        <div id="loginReset" class="hidden" aria-hidden="true">
+          <form class="login-form" id="resetForm" autocomplete="off">
+            <p class="login-hint">Ingresa el correo institucional y tu ID de usuario tal como aparecen en tu hoja de asignación para generar una contraseña temporal de acceso inicial.</p>
+            <label>
+              <span>Correo institucional</span>
+              <input type="email" id="resetEmail" autocomplete="username" required />
+            </label>
+            <label>
+              <span>ID de usuario</span>
+              <input type="text" id="resetUserId" autocomplete="off" required />
+            </label>
+            <div class="login-actions">
+              <button type="submit" class="btn primary w100" id="resetSubmit">Crear contraseña temporal</button>
+              <button type="button" class="btn w100" id="resetCancel">Volver a iniciar sesión</button>
+            </div>
+          </form>
+          <p class="login-message login-info hidden" id="resetMessage" role="status" aria-live="polite"></p>
+          <p class="login-hint" id="resetHint">La contraseña temporal se muestra una sola vez. Anótala y cámbiala desde Configuración &gt; Seguridad después de entrar.</p>
+        </div>
+        <footer class="login-meta">
+          <span class="login-meta__version" data-version-format="Versión {version}"></span>
+          <span class="login-meta__rights">ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+        </footer>
+      </div>
+    </div>
+  </div>
+  <div class="loading-overlay hidden" id="globalLoading" role="status" aria-live="polite" aria-hidden="true">
+    <div class="loading-card">
+      <div class="loading-spinner" aria-hidden="true"></div>
+      <p class="loading-message" id="globalLoadingMessage">Procesando…</p>
+    </div>
+  </div>
+  <div class="modal-overlay" id="importConfirmModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card" role="document">
+      <button type="button" class="modal-close" id="importModalClose" aria-label="Cerrar revisión">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2 id="importModalTitle">Revisión de importación</h2>
+        <p class="modal-message" id="importModalMessage"></p>
+      </div>
+      <div class="modal-body">
+        <section class="modal-section" aria-labelledby="importModalSkippedTitle">
+          <div class="section-heading">
+            <h3 id="importModalSkippedTitle">Registros omitidos</h3>
+          </div>
+          <div id="importModalSkipped" class="modal-table-wrap"></div>
+        </section>
+        <section class="modal-section" aria-labelledby="importModalSummaryTitle">
+          <div class="section-heading">
+            <h3 id="importModalSummaryTitle">Resumen de validaciones</h3>
+          </div>
+          <div class="modal-validations">
+            <div>
+              <h4>Errores</h4>
+              <ul id="importModalErrors" class="modal-summary-list modal-errors"></ul>
+            </div>
+            <div>
+              <h4>Advertencias</h4>
+              <ul id="importModalWarnings" class="modal-summary-list modal-warnings"></ul>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div class="modal-footer">
+        <div id="importModalCounters" class="modal-counters"></div>
+        <div class="modal-actions">
+          <button type="button" class="btn" id="importModalCancel">Cancelar</button>
+          <button type="button" class="btn primary" id="importModalConfirm">Confirmar importación</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-overlay" id="whatsappTemplateModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card template-modal" role="document">
+      <button type="button" class="modal-close" id="waModalClose" aria-label="Cerrar selección de plantillas">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2>Enviar por WhatsApp</h2>
+        <p>Elige una plantilla, personaliza el mensaje y envíalo sin salir de la plataforma.</p>
+      </div>
+      <div class="modal-body">
+        <div class="template-modal__grid">
+          <section class="template-modal__section">
+            <h3>Plantillas guardadas</h3>
+            <ul class="template-list" id="waTemplateList" role="list"></ul>
+            <button type="button" class="btn outline" id="waCreateTemplate"><i class="bi bi-plus-lg"></i> Nueva plantilla</button>
+          </section>
+          <section class="template-modal__section">
+            <label class="template-field">
+              <span>Mensaje a enviar</span>
+              <textarea id="waMessage" rows="6"></textarea>
+            </label>
+            <p class="template-hint">Usa <code>{{nombre}}</code> en tus plantillas para insertar automáticamente el nombre del lead.</p>
+            <div class="template-modal__actions">
+              <button type="button" class="btn" id="waCancelBtn">Cancelar</button>
+              <button type="button" class="btn primary" id="waSendBtn"><i class="bi bi-whatsapp"></i> Enviar por WhatsApp</button>
+            </div>
+          </section>
+        </div>
+        <form class="template-form hidden" id="waTemplateForm">
+          <input type="hidden" id="waTemplateId" />
+          <label class="template-field">
+            <span>Nombre de la plantilla</span>
+            <input type="text" id="waTemplateName" maxlength="80" required />
+          </label>
+          <label class="template-field">
+            <span>Mensaje</span>
+            <textarea id="waTemplateContent" rows="5" required></textarea>
+          </label>
+          <div class="template-modal__actions">
+            <button type="submit" class="btn primary" id="waTemplateSave">Guardar</button>
+            <button type="button" class="btn" id="waTemplateCancel">Cerrar</button>
+            <button type="button" class="btn danger" id="waTemplateDelete">Eliminar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal-overlay" id="emailTemplateModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card template-modal" role="document">
+      <button type="button" class="modal-close" id="emailModalClose" aria-label="Cerrar selección de plantillas de correo">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2>Enviar correo</h2>
+        <p>Selecciona una plantilla, personaliza el saludo y el enlace a tu WhatsApp.</p>
+      </div>
+      <div class="modal-body">
+        <div class="template-modal__grid">
+          <section class="template-modal__section">
+            <h3>Plantillas guardadas</h3>
+            <ul class="template-list" id="emailTemplateList" role="list"></ul>
+            <button type="button" class="btn outline" id="emailCreateTemplate"><i class="bi bi-plus-lg"></i> Nueva plantilla</button>
+          </section>
+          <section class="template-modal__section">
+            <label class="template-field">
+              <span>Asunto</span>
+              <input type="text" id="emailSubject" maxlength="140" />
+            </label>
+            <label class="template-field">
+              <span>Mensaje</span>
+              <textarea id="emailBody" rows="8"></textarea>
+            </label>
+            <label class="template-field">
+              <span>WhatsApp del asesor</span>
+              <input type="tel" id="advisorWhatsapp" inputmode="tel" placeholder="521XXXXXXXXXX" />
+            </label>
+            <p class="template-hint">Puedes usar <code>{{nombre}}</code> y <code>{{whatsapp}}</code> en tus plantillas para personalizar automáticamente.</p>
+            <div class="template-modal__actions">
+              <button type="button" class="btn" id="emailCancelBtn">Cancelar</button>
+              <button type="button" class="btn" id="emailMailtoBtn"><i class="bi bi-envelope"></i> Usar mailto</button>
+              <button type="button" class="btn primary" id="emailGmailBtn"><i class="bi bi-google"></i> Abrir en Gmail</button>
+            </div>
+          </section>
+        </div>
+        <form class="template-form hidden" id="emailTemplateForm">
+          <input type="hidden" id="emailTemplateId" />
+          <label class="template-field">
+            <span>Nombre de la plantilla</span>
+            <input type="text" id="emailTemplateName" maxlength="80" required />
+          </label>
+          <label class="template-field">
+            <span>Asunto</span>
+            <input type="text" id="emailTemplateSubject" maxlength="140" required />
+          </label>
+          <label class="template-field">
+            <span>Mensaje</span>
+            <textarea id="emailTemplateBody" rows="6" required></textarea>
+          </label>
+          <div class="template-modal__actions">
+            <button type="submit" class="btn primary" id="emailTemplateSave">Guardar</button>
+            <button type="button" class="btn" id="emailTemplateCancel">Cerrar</button>
+            <button type="button" class="btn danger" id="emailTemplateDelete">Eliminar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal-overlay" id="whatsappWebModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card whatsapp-web-modal" role="document">
+      <button type="button" class="modal-close" id="whatsappWebClose" aria-label="Cerrar WhatsApp Web">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2>WhatsApp Web</h2>
+        <p>Escanea el código QR o continúa con tu sesión activa sin salir de ReLead.</p>
+      </div>
+      <div class="modal-body">
+        <iframe
+          id="whatsappWebFrame"
+          class="whatsapp-web-frame"
+          title="WhatsApp Web"
+          src="about:blank"
+          allow="clipboard-read; clipboard-write"
+        ></iframe>
+      </div>
+    </div>
+  </div>
+  <div class="app hidden" id="app">
+    <!-- Sidebar -->
+    <aside class="sidebar" id="sidebar" aria-label="Navegación principal" aria-hidden="false">
+      <button class="sidebar-close" type="button" id="sidebarClose" aria-label="Cerrar menú lateral" title="Cerrar menú lateral">×</button>
+      <nav class="nav" role="navigation">
+        <div class="brand" data-expand-label="Expandir menú lateral">
+          <div
+            class="brand-logo"
+            id="sidebarBrandImg"
+            data-fallback-src="./assets/Favicon.png?v=3"
+            data-favicon-src="./assets/Favicon.png?v=3"
+            data-logo-alt="ReLead CRM"
+            data-brand-mode="favicon"
+          >RE</div>
+          <span class="brand-name" id="sidebarBrandName">ReLead EDU</span>
+        </div>
+        <div class="nav-header">
+          <button class="menu-toggle" type="button" id="menuToggle" aria-label="Alternar menú" aria-expanded="true" aria-controls="sidebar" title="Alternar menú">
+            <span class="menu-toggle__icon" aria-hidden="true">
+              <span class="menu-toggle__avatar" id="sidebarAvatarImg" aria-hidden="true">U</span>
+              <span class="menu-toggle__bars">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+            </span>
+          </button>
+          <span class="nav-user hidden" id="userBadge" role="status" aria-live="polite"></span>
+        </div>
+        <div class="nav-divider" aria-hidden="true"></div>
+        <div class="nav-group">
+          <a href="#" class="nav-link active" data-nav="kpis" aria-current="page"><i class="bi bi-speedometer2"></i><span>KPI’s</span></a>
+          <a href="#" class="nav-link" data-nav="leads"><i class="bi bi-people"></i><span>Leads</span></a>
+          <a href="#" class="nav-link" data-nav="mensajes"><i class="bi bi-chat-dots"></i><span>Mensajes</span></a>
+          <a href="#" class="nav-link" data-nav="administrador"><i class="bi bi-person-gear"></i><span>Administrador</span></a>
+          <a href="#" class="nav-link" data-nav="desarrollador"><i class="bi bi-terminal"></i><span>Desarrollador</span></a>
+          <a href="#" class="nav-link" data-nav="configuracion"><i class="bi bi-gear"></i><span>Configuración</span></a>
+        </div>
+        <div class="nav-footer">
+          <button type="button" class="nav-link" id="logoutBtn"><i class="bi bi-box-arrow-right" aria-hidden="true"></i><span>Cerrar sesión</span></button>
+          <a href="#" class="nav-link" data-nav="ayuda">❓ <span>Ayuda</span></a>
+          <div class="nav-footer__meta" aria-live="polite">
+            <span class="nav-footer__version" data-version-format="ReLead CRM · {version}"></span>
+            <span class="nav-footer__rights">ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+          </div>
+        </div>
+      </nav>
+    </aside>
+
+    <div class="sidebar-overlay" id="sidebarOverlay" aria-hidden="true"></div>
+
+    <!-- Main -->
+    <main class="main" role="main">
+      <header class="mobile-topbar" id="mobileTopbar" aria-hidden="false">
+        <button class="menu-btn menu-trigger" type="button" aria-label="Abrir menú principal" aria-expanded="false">
+          <i class="bi bi-list"></i>
+        </button>
+        <span class="mobile-topbar__label" id="mobileViewLabel">Vista actual</span>
+      </header>
+      <section id="view-kpis" class="view-section is-visible">
+        <div class="card" style="margin:18px">
+          <div class="panel-section">
+            <h3><span aria-hidden="true">📊</span> Indicadores clave</h3>
+          </div>
+          <div class="panel-section critical-summary" aria-label="Resumen operativo prioritario">
+            <h3>Resumen operativo inmediato</h3>
+            <p>Vista rápida del pulso operativo para reaccionar ante desviaciones de SLA, duplicados y carga de asignaciones.</p>
+            <div class="kpi-grid critical-kpis" role="list">
+              <article class="kpi-metric" data-indicator="sla" role="listitem">
+                <div class="metric-header">
+                  <span class="metric-icon" aria-hidden="true"><i class="bi bi-stopwatch"></i></span>
+                  <div>
+                    <span class="metric-name">SLA de contacto</span>
+                    <span class="metric-extra" data-metric-meta="slaTarget">Meta &lt; 4 h · Últimas 24 h</span>
+                  </div>
+                </div>
+                <span class="metric-value" data-metric-value="slaPromedio" aria-live="polite">2.3 h</span>
+                <p class="metric-desc">Promedio del primer contacto desde la asignación. Activa alertas cuando supere el objetivo establecido.</p>
+              </article>
+              <article class="kpi-metric" data-indicator="duplicados" role="listitem">
+                <div class="metric-header">
+                  <span class="metric-icon" aria-hidden="true"><i class="bi bi-layers"></i></span>
+                  <div>
+                    <span class="metric-name">Duplicados detectados</span>
+                    <span class="metric-extra" data-metric-meta="dupMeta">Tolerancia diaria &lt; 2%</span>
+                  </div>
+                </div>
+                <span class="metric-value" data-metric-value="duplicadosDia" aria-live="polite">1.4%</span>
+                <p class="metric-desc">Porcentaje de registros con coincidencias activas durante las últimas cargas. Permite anticipar conflictos de contacto.</p>
+              </article>
+              <article class="kpi-metric" data-indicator="asignaciones" role="listitem">
+                <div class="metric-header">
+                  <span class="metric-icon" aria-hidden="true"><i class="bi bi-people"></i></span>
+                  <div>
+                    <span class="metric-name">Balance de asignaciones</span>
+                    <span class="metric-extra" data-metric-meta="asignacionesMeta">Objetivo &ge; 85% distribuidas</span>
+                  </div>
+                </div>
+                <span class="metric-value" data-metric-value="asignacionesBalance" aria-live="polite">89%</span>
+                <p class="metric-desc">Porcentaje de leads entregados frente al total disponible. Indica si existe rezago en la distribución entre asesores.</p>
+              </article>
+            </div>
+          </div>
+          <div class="panel-section">
+            <h3>KPIs del embudo de reactivación</h3>
+            <div class="kpi-groups" aria-label="Indicadores clave" id="kpiContainer"></div>
+          </div>
+        </div>
+      </section>
+      <section id="view-leads" class="view-section hidden" data-mobile-title="Leads · Tablero">
+      <header class="topbar">
+        <div class="topbar-inner">
+          <div class="search" role="search">
+            <svg class="icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <input id="q" type="search" placeholder="ID, nombre o teléfono… (Ctrl /)" aria-label="ID" />
+          </div>
+        </div>
+      </header>
+
+      <div class="card" style="margin:18px">
+        <div class="panel-section">
+          <div class="view-controls" aria-label="Filtros de leads">
+            <div class="filters" aria-label="Filtros">
+              <label>
+                Base
+                <select id="sheetSelect"></select>
+              </label>
+              <label>
+                Asesor
+                <select id="asesorSelect"></select>
+              </label>
+              <label>
+                Plantel
+                <select id="campusSelect"></select>
+              </label>
+              <label class="page-size">
+                Mostrar
+                <select id="pageSize">
+                  <option value="10">10</option>
+                  <option value="30" selected>30</option>
+                  <option value="50">50</option>
+                  <option value="0">Todos</option>
+                </select>
+              </label>
+            </div>
+            <div class="daily-shortcuts" id="dailyShortcuts" aria-label="Listas diarias sugeridas"></div>
+          </div>
+          <p class="view-status hidden" id="sheetStatus" role="status" aria-live="polite"></p>
+        </div>
+        <div class="panel-section">
+          <div class="row between align-center" style="gap:var(--space-sm)">
+            <h3>Leads</h3>
+            <div class="seg" role="toolbar" aria-label="Formato de visualización">
+              <button type="button" data-view-mode="board" aria-pressed="true" title="Ver como tablero">
+                <i class="bi bi-kanban"></i> Tablero
+              </button>
+              <button type="button" data-view-mode="table" aria-pressed="false" title="Ver como tabla">
+                <i class="bi bi-table"></i> Tabla
+              </button>
+            </div>
+          </div>
+          <section class="content">
+            <!-- Kanban -->
+            <div id="viewKanban" class="board" role="region" aria-label="Lead Board">
+              <!-- Column templates -->
+            </div>
+            <div id="tableWrap" class="table-wrap hidden" role="region" aria-label="Tabla de leads">
+              <table>
+                <thead>
+                  <tr>
+                    <th data-sort="id">ID</th>
+                    <th data-sort="nombre">Nombre</th>
+                    <th data-sort="matricula">Matrícula</th>
+                    <th data-sort="correo">Correo</th>
+                    <th data-sort="telefono">Teléfono</th>
+                    <th data-sort="campus">Plantel</th>
+                    <th data-sort="modalidad">Modalidad</th>
+                    <th data-sort="programa">Programa</th>
+                    <th data-sort="etapa">Etapa</th>
+                    <th data-sort="estado">Estado</th>
+                    <th data-sort="asesor">Asesor</th>
+                    <th data-sort="comentario">Comentario</th>
+                    <th data-sort="asignacion">Asignación</th>
+                  </tr>
+                  <tr class="filter-row">
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="id" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="nombre" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="matricula" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="correo" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="telefono" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="campus" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="modalidad" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="programa" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="etapa" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="estado" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="asesor" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="comentario" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="asignacion" /></th>
+                  </tr>
+                </thead>
+                <tbody id="tbody"></tbody>
+              </table>
+            </div>
+          </section>
+          <div id="paginator" class="pagination"></div>
+        </div>
+      </div>
+      <div id="panelOverlay" class="panel-overlay" aria-hidden="true">
+        <aside class="panel" aria-label="Detalle del lead" tabindex="-1">
+          <button class="panel-close" type="button" id="panelClose" aria-label="Cerrar panel de lead"><i class="bi bi-x-lg"></i></button>
+          <div class="panel-header">
+            <h3 class="panel-title">
+              <span id="d-nombre">Selecciona un lead</span>
+              <span class="stage-pill is-empty" id="d-etapa">—</span>
+            </h3>
+            <button type="button" class="panel-favorite" id="favoriteToggle" aria-pressed="false" aria-label="Agregar a favoritos">
+              <i class="bi bi-star" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div class="kv">
+            <div class="kv-label" id="lab-matricula">Matrícula</div><div id="d-matricula">—</div>
+            <div class="kv-label" id="lab-tel">Teléfono</div><div id="d-tel">—</div>
+            <div class="kv-label" id="lab-mail">Correo</div><div id="d-mail">—</div>
+            <div class="kv-label" id="lab-campus">Plantel</div><div id="d-campus">—</div>
+            <div class="kv-label" id="lab-modalidad">Modalidad</div><div id="d-modalidad">—</div>
+            <div class="kv-label" id="lab-programa">Programa</div><div id="d-programa">—</div>
+            <div class="kv-label" id="lab-estado">Estado</div><div id="d-estado">—</div>
+            <div class="kv-label" id="lab-asesor">Asesor</div><div id="d-asesor">—</div>
+          </div>
+          <section class="panel-tags" aria-labelledby="leadTagsTitle">
+            <div class="panel-tags__header">
+              <h4 id="leadTagsTitle">Etiquetas personalizadas</h4>
+              <button class="btn outline" type="button" id="leadTagAdd"><i class="bi bi-bookmark-plus"></i> Nueva etiqueta</button>
+            </div>
+            <p class="panel-tags__hint">Clasifica este lead con etiquetas privadas y resalta prioridades en tu tablero.</p>
+            <div class="panel-tags__list is-empty" id="leadTagList" aria-live="polite"></div>
+            <form class="panel-tags__form hidden" id="leadTagForm">
+              <div class="panel-tags__form-row">
+                <label>Nombre
+                  <input type="text" id="leadTagName" maxlength="40" required />
+                </label>
+                <label>Color
+                  <input type="color" id="leadTagColor" value="#2563eb" />
+                </label>
+              </div>
+              <div class="panel-tags__form-actions">
+                <button class="btn primary" type="submit" id="leadTagSave">Guardar etiqueta</button>
+                <button class="btn" type="button" id="leadTagCancel">Cancelar</button>
+              </div>
+            </form>
+            <p class="panel-tags__feedback hidden" id="leadTagFeedback"></p>
+          </section>
+          <section class="panel-quick" aria-labelledby="panelQuickTitle">
+            <header class="panel-quick__header">
+              <h4 id="panelQuickTitle">Actualiza y contacta</h4>
+              <p>Registra etapa, estado y nota antes de usar los accesos rápidos para contactar al lead.</p>
+            </header>
+            <form class="panel-quick__form" id="leadUpdateForm" autocomplete="off" novalidate>
+              <div class="panel-quick__grid">
+                <label class="panel-quick__field">Etapa
+                  <select id="selEtapa"></select>
+                </label>
+                <label class="panel-quick__field">Estado
+                  <select id="selEstado"></select>
+                </label>
+              </div>
+              <label class="panel-quick__field panel-quick__comment">Comentario
+                <textarea id="txtComentario" class="w100" rows="3" placeholder="Captura contexto, acuerdos o próximos pasos." required></textarea>
+              </label>
+              <div class="panel-quick__feedback hidden" id="panelFeedback" role="alert" aria-live="assertive">
+                <strong id="panelFeedbackTitle"></strong>
+                <p id="panelFeedbackMessage"></p>
+              </div>
+              <div class="panel-quick__actions">
+                <button class="btn primary" id="updateBtn" type="submit"><i class="bi bi-floppy"></i> Guardar cambios</button>
+                <div class="panel-quick__shortcuts" role="group" aria-label="Accesos rápidos de contacto">
+                  <a class="btn contact-btn contact-call" data-contact="call" href="#"><i class="bi bi-telephone"></i> Llamar</a>
+                  <a class="btn contact-btn contact-wa" data-contact="whatsapp" href="#"><i class="bi bi-whatsapp"></i> WhatsApp</a>
+                  <a class="btn contact-btn contact-mail" data-contact="email" href="#"><i class="bi bi-envelope"></i> Email</a>
+                </div>
+              </div>
+            </form>
+            <details class="quick-access" id="quickAccessPanel" aria-label="Accesos rápidos de leads">
+              <summary class="quick-access__summary">
+                <i class="bi bi-lightning-charge" aria-hidden="true"></i>
+                <span>Recientes y favoritos</span>
+              </summary>
+              <div class="quick-access__body">
+                <p class="quick-access__description">Accede a los leads clave que has abierto recientemente o marcado como favoritos.</p>
+                <div class="quick-access__group" id="favoriteGroup">
+                  <div class="quick-access__label">Favoritos</div>
+                  <div class="quick-access__list" id="favoriteLeads" role="list"></div>
+                  <p class="quick-access__empty" id="favoriteEmpty">Marca un lead con la estrella para guardarlo aquí.</p>
+                </div>
+                <div class="quick-access__group" id="recentGroup">
+                  <div class="quick-access__label">Recientes</div>
+                  <div class="quick-access__list" id="recentLeads" role="list"></div>
+                  <p class="quick-access__empty" id="recentEmpty">Los leads que abras aparecerán en esta lista.</p>
+                </div>
+              </div>
+            </details>
+            <p class="contact-scripts__status hidden" id="contactScriptStatus" role="status" aria-live="polite"></p>
+          </section>
+          <section class="calendar-form" data-calendar-form aria-labelledby="calendarFormTitle">
+            <h4 id="calendarFormTitle">Agendar recordatorio</h4>
+            <p>Programa un seguimiento en Google Calendar con los datos de este lead.</p>
+            <div class="calendar-form__grid">
+              <label>Fecha
+                <input type="date" id="calendarDate" data-calendar-date required />
+              </label>
+              <label>Hora
+                <input type="time" id="calendarTime" data-calendar-time required />
+              </label>
+              <label>Duración
+                <select id="calendarDuration" data-calendar-duration>
+                  <option value="15">15 minutos</option>
+                  <option value="30">30 minutos</option>
+                  <option value="45">45 minutos</option>
+                  <option value="60">60 minutos</option>
+                </select>
+              </label>
+            </div>
+            <div class="calendar-form__actions">
+              <button type="button" class="btn outline" id="calendarCreateBtn" data-calendar-create disabled>
+                <i class="bi bi-calendar-plus"></i> Crear recordatorio
+              </button>
+            </div>
+            <p class="calendar-form__status" id="calendarStatus" data-calendar-status role="status" aria-live="polite"></p>
+          </section>
+        </aside>
+      </div>
+      <!-- Drawer for mobile details -->
+      <div class="drawer" id="drawer" aria-hidden="true">
+        <div class="sheet">
+          <button class="btn" id="closeDrawer">Cerrar</button>
+          <div id="drawerContent"></div>
+        </div>
+      </div>
+      </section>
+
+      <section id="view-mensajes" class="view-section hidden" data-mobile-title="Mensajes · Bandeja">
+        <div class="card" style="margin:18px">
+          <div class="panel-section">
+            <div class="messages-header">
+              <h3><span aria-hidden="true">💬</span> Mensajes</h3>
+            </div>
+          </div>
+          <div class="panel-section messages-workspace">
+            <aside class="messages-sidebar" aria-label="Conversaciones disponibles">
+              <div class="messages-sidebar__top">
+                <div>
+                  <h4>Conversaciones</h4>
+                  <p class="muted small" id="messageThreadSummary">Sin sincronizar.</p>
+                </div>
+                <label class="messages-search" for="messageSearch">
+                  <i class="bi bi-search" aria-hidden="true"></i>
+                  <input type="search" id="messageSearch" placeholder="Buscar por nombre, teléfono o base" autocomplete="off" />
+                </label>
+              </div>
+              <div class="messages-thread-list" id="messageThreadList" role="list"></div>
+            </aside>
+            <article class="messages-conversation" id="messageConversation" aria-live="polite">
+              <div class="messages-placeholder">
+                <i class="bi bi-chat-dots" aria-hidden="true"></i>
+                <p>Sin conversaciones registradas.</p>
+                <p class="muted small">Cuando lleguen mensajes o estados nuevos desde Meta (WhatsApp o Facebook), se agruparán aquí por contacto.</p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="view-administrador" class="view-section hidden">
+        <div class="admin-panels">
+          <div class="card" style="margin:18px">
+            <div class="panel-section">
+              <h3><span aria-hidden="true">📥</span> Importar</h3>
+              <p class="muted small">Carga nuevos registros, actualiza activos y ejecuta cambios masivos.</p>
+            </div>
+            <div class="panel-section">
+              <h3>Datos</h3>
+              <div class="row gap10 panel-filters">
+                <label>
+                  Base de destino
+                  <select id="importBaseSelect"></select>
+                </label>
+                <input type="file" id="importFile" accept=".csv,.xlsx" class="file-input">
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn outline" id="btnVerify">Verificar</button>
+                <button class="btn outline" id="btnExecute" disabled>Ejecutar</button>
+              </div>
+              <div id="importPreview" class="preview-box hidden panel-preview"></div>
+              <div id="dupWrap" class="preview-box hidden panel-preview"></div>
+            </div>
+            <div class="panel-section">
+              <h3>Activos</h3>
+              <div class="row gap10 panel-filters">
+                <input type="file" id="activosFile" accept=".csv,.xlsx" class="file-input">
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn outline" id="btnActivosVerify">Analizar</button>
+                <button class="btn outline" id="btnActivosExecute" disabled>Actualizar</button>
+              </div>
+              <div id="activosPreview" class="preview-box hidden panel-preview"></div>
+              <div id="activosDiff" class="preview-box hidden panel-preview"></div>
+            </div>
+            <div class="panel-section">
+              <h3>Cambios masivos</h3>
+              <div class="row gap10 panel-filters">
+                <input type="file" id="bulkFile" accept=".csv,.xlsx" class="file-input">
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn outline" id="btnBulkVerify">Verificar</button>
+                <button class="btn outline" id="btnBulkExecute" disabled>Ejecutar</button>
+                <button class="btn outline" id="btnBulkTemplate">Plantilla</button>
+              </div>
+              <div id="bulkPreview" class="preview-box hidden panel-preview"></div>
+              <div id="bulkDupWrap" class="preview-box hidden panel-preview"></div>
+            </div>
+          </div>
+          <div class="card" style="margin:18px">
+            <div class="panel-section">
+              <h3><span aria-hidden="true">📤</span> Exportar</h3>
+              <p class="muted small">Genera extracciones de datos, reportes y resoluciones.</p>
+            </div>
+            <div class="panel-section">
+              <h3>Datos</h3>
+              <div class="row gap10 panel-filters">
+                <select id="expDataBase"><option value="">Bases</option></select>
+                <select id="expDataAsesor"><option value="">Todos los asesores</option></select>
+                <select id="expDataEtapa"><option value="">Etapa</option></select>
+                <select id="expDataEstado"><option value="">Todos los estados</option></select>
+                <label class="date-filter" for="expDataStart">
+                  <span>Desde</span>
+                  <input type="date" id="expDataStart">
+                </label>
+                <label class="date-filter" for="expDataEnd">
+                  <span>Hasta</span>
+                  <input type="date" id="expDataEnd">
+                </label>
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn primary" id="btnExportData">Ejecutar</button>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3>Reportes</h3>
+              <div class="row gap10 panel-filters">
+                <select id="expReportTipo">
+                  <option value="">Tipo de reporte</option>
+                  <option value="estado">Estado de la base</option>
+                  <option value="detalle">Detalle asesor</option>
+                  <option value="sistema">Sistema</option>
+                  <option value="losg">Losg</option>
+                </select>
+                <select id="expReportBase"><option value="">Base</option></select>
+                <select id="expReportAsesor"><option value="">Todos los asesores</option></select>
+                <label class="date-filter" for="expReportStart">
+                  <span>Desde</span>
+                  <input type="date" id="expReportStart">
+                </label>
+                <label class="date-filter" for="expReportEnd">
+                  <span>Hasta</span>
+                  <input type="date" id="expReportEnd">
+                </label>
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn primary" id="btnExportReport">Ejecutar</button>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3>Resoluciones</h3>
+              <div class="row gap10 panel-filters">
+                <select id="expResolCRM">
+                  <option value="">CRM</option>
+                  <option value="neotel">Neotel</option>
+                  <option value="hubspot">HubSpot</option>
+                </select>
+                <select id="expResolAsesor"><option value="">Todos los asesores</option></select>
+                <select id="expResolBase"><option value="">Base</option></select>
+                <label class="date-filter" for="expResolStart">
+                  <span>Desde</span>
+                  <input type="date" id="expResolStart">
+                </label>
+                <label class="date-filter" for="expResolEnd">
+                  <span>Hasta</span>
+                  <input type="date" id="expResolEnd">
+                </label>
+              </div>
+              <div class="row gap10 panel-actions">
+                <button class="btn primary" id="btnExportResolution">Ejecutar</button>
+              </div>
+            </div>
+          </div>
+          <div class="card" style="margin:18px">
+            <div class="panel-section">
+              <h3><span aria-hidden="true">🛡️</span> Permisos</h3>
+              <div class="permissions-grid" id="permissionsGrid">
+                <div class="permissions-panel" aria-label="Usuarios registrados">
+                  <div class="row gap10 panel-actions">
+                    <button type="button" class="btn outline" id="permReloadBtn"><i class="bi bi-arrow-repeat"></i> Actualizar</button>
+                    <button type="button" class="btn primary" id="permNewBtn"><i class="bi bi-plus-lg"></i> Nuevo usuario</button>
+                  </div>
+                  <p class="permissions-status small" id="permStatus" role="status" aria-live="polite">Carga los usuarios para comenzar.</p>
+                  <div class="permissions-list" id="permList" role="listbox" aria-label="Usuarios"></div>
+                </div>
+                <form class="permissions-form" id="permForm" autocomplete="off" novalidate>
+                  <h4 class="perm-form-title" id="permFormTitle">Nuevo usuario</h4>
+                  <div class="form-grid">
+                    <label>
+                      <span>Correo institucional</span>
+                      <input type="email" id="permEmail" autocomplete="email" required />
+                    </label>
+                    <label>
+                      <span>ID de usuario</span>
+                      <input type="text" id="permUserId" autocomplete="off" required />
+                    </label>
+                    <label>
+                      <span>Nombre completo</span>
+                      <input type="text" id="permName" autocomplete="name" required />
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Rol</span>
+                      <select id="permRole">
+                        <option value="developer">Desarrollador</option>
+                        <option value="admin">Administrador</option>
+                        <option value="coordinador">Coordinador</option>
+                        <option value="asesor">Asesor</option>
+                        <option value="viewer">Consulta</option>
+                      </select>
+                      <span class="field-hint" id="permRoleHint"></span>
+                      <div class="role-scope-suggestion" id="permRoleSuggestion" hidden>
+                        <p class="role-scope-suggestion__text" id="permRoleDescription"></p>
+                        <div class="role-scope-suggestion__chips" id="permRoleScopeChips" aria-live="polite"></div>
+                        <button type="button" class="btn micro" id="permApplyRolePreset"><i class="bi bi-magic"></i> Aplicar sugerencia</button>
+                      </div>
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Planteles autorizados</span>
+                      <div class="multi-select" id="permPlantelesSelect">
+                        <button type="button" class="multi-select__button" aria-haspopup="listbox" aria-expanded="false">
+                          <span class="multi-select__button-text">Selecciona planteles</span>
+                          <i class="bi bi-chevron-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="multi-select__menu" role="listbox" aria-multiselectable="true" tabindex="-1"></div>
+                        <div class="multi-select__chips" aria-live="polite"></div>
+                      </div>
+                      <input type="hidden" id="permPlanteles" />
+                      <span class="field-hint">Seleccionar "Todos" otorga acceso global a todos los planteles.</span>
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Bases autorizadas</span>
+                      <div class="multi-select" id="permBasesSelect">
+                        <button type="button" class="multi-select__button" aria-haspopup="listbox" aria-expanded="false">
+                          <span class="multi-select__button-text">Selecciona bases</span>
+                          <i class="bi bi-chevron-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="multi-select__menu" role="listbox" aria-multiselectable="true" tabindex="-1"></div>
+                        <div class="multi-select__chips" aria-live="polite"></div>
+                      </div>
+                      <input type="hidden" id="permBases" />
+                      <span class="field-hint">Seleccionar "Todas" otorga acceso global a todas las bases.</span>
+                    </label>
+                    <label>
+                      <span>Contraseña temporal</span>
+                      <input type="password" id="permPassword" autocomplete="new-password" />
+                    </label>
+                    <label class="permissions-switch">
+                      <input type="checkbox" id="permActive" checked />
+                      <span>Acceso activo</span>
+                    </label>
+                  </div>
+                  <p class="small muted" id="permPasswordHint">Se generará una contraseña temporal para compartir con la persona usuaria.</p>
+                  <div class="permissions-meta small muted" id="permMeta"></div>
+                  <div class="row gap10 panel-actions">
+                    <button type="submit" class="btn primary" id="permSaveBtn"><i class="bi bi-floppy"></i> Guardar</button>
+                    <button type="button" class="btn" id="permResetBtn"><i class="bi bi-arrow-counterclockwise"></i> Cancelar</button>
+                    <button type="button" class="btn danger" id="permDeleteBtn"><i class="bi bi-person-dash"></i> Desactivar</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3><span aria-hidden="true">👥</span> Equipos</h3>
+              <div class="permissions-grid permissions-grid--teams">
+                <div class="permissions-panel">
+                  <div class="row gap10 panel-actions">
+                    <button type="button" class="btn outline" id="teamReloadBtn"><i class="bi bi-arrow-repeat"></i> Actualizar</button>
+                    <button type="button" class="btn primary" id="teamNewBtn"><i class="bi bi-plus-lg"></i> Nuevo equipo</button>
+                  </div>
+                  <p class="permissions-status small" id="teamStatus" role="status" aria-live="polite">Carga los equipos para comenzar.</p>
+                  <div class="permissions-list" id="teamList" role="listbox" aria-label="Equipos"></div>
+                </div>
+                <form class="permissions-form" id="teamForm" autocomplete="off" novalidate>
+                  <h4 class="perm-form-title" id="teamFormTitle">Nuevo equipo</h4>
+                  <div class="form-grid">
+                    <label>
+                      <span>Nombre del equipo</span>
+                      <input type="text" id="teamName" autocomplete="off" required />
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Planteles</span>
+                      <div class="multi-select" id="teamPlantelesSelect">
+                        <button type="button" class="multi-select__button" aria-haspopup="listbox" aria-expanded="false">
+                          <span class="multi-select__button-text">Selecciona planteles</span>
+                          <i class="bi bi-chevron-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="multi-select__menu" role="listbox" aria-multiselectable="true" tabindex="-1"></div>
+                        <div class="multi-select__chips" aria-live="polite"></div>
+                      </div>
+                      <input type="hidden" id="teamPlanteles" />
+                      <span class="field-hint">Selecciona "Todos" para acceso global.</span>
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Bases</span>
+                      <div class="multi-select" id="teamBasesSelect">
+                        <button type="button" class="multi-select__button" aria-haspopup="listbox" aria-expanded="false">
+                          <span class="multi-select__button-text">Selecciona bases</span>
+                          <i class="bi bi-chevron-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="multi-select__menu" role="listbox" aria-multiselectable="true" tabindex="-1"></div>
+                        <div class="multi-select__chips" aria-live="polite"></div>
+                      </div>
+                      <input type="hidden" id="teamBases" />
+                      <span class="field-hint">Selecciona "Todas" para acceso global.</span>
+                    </label>
+                    <label class="field-with-hint">
+                      <span>Integrantes</span>
+                      <div class="multi-select" id="teamMembersSelect">
+                        <button type="button" class="multi-select__button" aria-haspopup="listbox" aria-expanded="false">
+                          <span class="multi-select__button-text">Selecciona integrantes</span>
+                          <i class="bi bi-chevron-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="multi-select__menu" role="listbox" aria-multiselectable="true" tabindex="-1"></div>
+                        <div class="multi-select__chips" aria-live="polite"></div>
+                      </div>
+                      <input type="hidden" id="teamMembers" />
+                      <span class="field-hint">Asigna usuarios responsables del equipo.</span>
+                    </label>
+                    <label class="permissions-switch">
+                      <input type="checkbox" id="teamActive" checked />
+                      <span>Equipo activo</span>
+                    </label>
+                  </div>
+                  <div class="permissions-meta small muted" id="teamMeta"></div>
+                  <div class="row gap10 panel-actions">
+                    <button type="submit" class="btn primary" id="teamSaveBtn"><i class="bi bi-floppy"></i> Guardar</button>
+                    <button type="button" class="btn" id="teamResetBtn"><i class="bi bi-arrow-counterclockwise"></i> Cancelar</button>
+                    <button type="button" class="btn" id="teamCloneBtn"><i class="bi bi-copy"></i> Clonar configuración</button>
+                    <button type="button" class="btn danger" id="teamDeleteBtn"><i class="bi bi-x-circle"></i> Desactivar</button>
+                  </div>
+                </form>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3><span aria-hidden="true">⚖️</span> Balance automático</h3>
+              <p class="muted small">Identifica sobrecarga y reasigna sugerencias de manera controlada.</p>
+              <div class="panel-hint" id="autoReassignAdminHint">
+                <p>Las sugerencias se recalculan al cargar leads o cambiar la base activa.</p>
+              </div>
+              <div class="auto-reassign-wrapper hidden" id="autoReassignSection" aria-live="polite" aria-label="Reasignación automática">
+                <div class="auto-reassign-card">
+                  <p class="auto-reassign-summary" id="autoReassignSummary">Analizando distribución de leads por asesor…</p>
+                  <ul class="auto-reassign-list" id="autoReassignList"></ul>
+                  <div class="auto-reassign-pagination hidden" id="autoReassignPagination" role="group" aria-label="Paginación de sugerencias"></div>
+                </div>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3><span aria-hidden="true">🔄</span> Asignación</h3>
+              <p class="muted small">Reasigna leads manualmente en la base activa seleccionando un caso individual, varios registros o un segmento completo.</p>
+              <div class="assignment-grid">
+                <div class="assignment-header">
+                  <div class="segmented" role="radiogroup" aria-label="Modo de reasignación">
+                    <label class="segmented-option">
+                      <input type="radio" name="assignmentMode" value="single" checked>
+                      <span>Individual</span>
+                    </label>
+                    <label class="segmented-option">
+                      <input type="radio" name="assignmentMode" value="multiple">
+                      <span>Varios</span>
+                    </label>
+                    <label class="segmented-option">
+                      <input type="radio" name="assignmentMode" value="segment">
+                      <span>Segmento</span>
+                    </label>
+                  </div>
+                </div>
+                <div class="assignment-body">
+                  <div class="assignment-mode" data-mode="single">
+                    <label class="field-with-hint">
+                      <span>Lead a reasignar</span>
+                      <input type="text" id="assignmentSingleInput" list="assignmentLeadOptions" placeholder="ID, matrícula, correo o nombre" autocomplete="off">
+                      <span class="field-hint">Empieza a escribir y selecciona una coincidencia del listado.</span>
+                      <datalist id="assignmentLeadOptions"></datalist>
+                    </label>
+                  </div>
+                  <div class="assignment-mode hidden" data-mode="multiple">
+                    <label class="field-with-hint">
+                      <span>Leads seleccionados</span>
+                      <textarea id="assignmentBulkInput" rows="4" placeholder="Pega IDs o matrículas separados por comas, saltos de línea o espacios."></textarea>
+                      <span class="field-hint">Los duplicados se omiten automáticamente.</span>
+                    </label>
+                  </div>
+                  <div class="assignment-mode hidden" data-mode="segment">
+                    <div class="assignment-filters" role="group" aria-label="Filtros del segmento">
+                      <label>
+                        <span>Asesor actual</span>
+                        <select id="assignmentFilterAsesor">
+                          <option value="">Todos</option>
+                          <option value="__unassigned__">Solo sin asesor</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Etapa</span>
+                        <select id="assignmentFilterEtapa">
+                          <option value="">Todas</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Estado</span>
+                        <select id="assignmentFilterEstado" disabled>
+                          <option value="">Todos</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Plantel</span>
+                        <select id="assignmentFilterCampus">
+                          <option value="">Todos</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Programa</span>
+                        <select id="assignmentFilterPrograma">
+                          <option value="">Todos</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Asignados desde</span>
+                        <input type="date" id="assignmentFilterStart">
+                      </label>
+                      <label>
+                        <span>Asignados hasta</span>
+                        <input type="date" id="assignmentFilterEnd">
+                      </label>
+                      <label>
+                        <span>Límite</span>
+                        <input type="number" id="assignmentFilterLimit" min="1" max="500" placeholder="Ej. 50">
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div class="assignment-targets">
+                  <label class="field-with-hint">
+                    <span>Base de trabajo</span>
+                    <select id="assignmentBaseSelect"></select>
+                    <span class="field-hint">Solo se procesarán leads de la base seleccionada.</span>
+                  </label>
+                  <label class="field-with-hint">
+                    <span>Asesor destino</span>
+                    <input type="text" id="assignmentTargetInput" list="assignmentTargetOptions" placeholder="Nombre o ID" autocomplete="off">
+                    <span class="field-hint">Sugiere asesores activos, pero puedes capturar cualquier nombre válido.</span>
+                    <datalist id="assignmentTargetOptions"></datalist>
+                  </label>
+                </div>
+                <div class="assignment-actions">
+                  <div class="assignment-status" id="assignmentStatus" role="status" aria-live="polite">Selecciona el modo de reasignación y completa los datos.</div>
+                  <div class="assignment-buttons">
+                    <button type="button" class="btn outline" id="assignmentPreviewBtn"><i class="bi bi-search"></i> Calcular selección</button>
+                    <button type="button" class="btn primary" id="assignmentExecuteBtn" disabled><i class="bi bi-arrow-repeat"></i> Reasignar leads</button>
+                  </div>
+                </div>
+                <div class="assignment-summary" id="assignmentSummary" aria-live="polite"></div>
+                <div class="assignment-rules">
+                  <h4><i class="bi bi-list-check"></i> Reglas de asignación</h4>
+                  <ul id="assignmentRulesList" class="assignment-rules__list"></ul>
+                </div>
+              </div>
+            </div>
+            <div class="panel-section">
+              <h3><span aria-hidden="true">📊</span> Referencia de permisos</h3>
+              <div class="permissions-reference">
+                <div class="permissions-card" id="permissionMatrix"></div>
+                <div class="permissions-card" id="permissionRules"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="view-desarrollador" class="view-section hidden" data-mobile-title="Desarrollador">
+        <div class="card" style="margin:18px">
+          <div class="panel-section">
+            <h3><span aria-hidden="true">🧑‍💻</span> Herramientas de desarrollador</h3>
+            <p class="muted small">Controla diagnósticos avanzados y automatiza soluciones para la plataforma.</p>
+          </div>
+          <div class="panel-section">
+            <div class="dev-grid">
+              <article class="dev-panel" aria-labelledby="dev-diagnostic-title">
+                <div class="dev-panel__header">
+                  <div>
+                    <h4 class="dev-panel__title" id="dev-diagnostic-title"><i class="bi bi-activity" aria-hidden="true"></i> Diagnóstico de integridad</h4>
+                    <p class="dev-panel__description">Ejecuta validaciones sobre hojas, servicios y conexiones principales.</p>
+                  </div>
+                  <button type="button" class="btn primary" id="diagBtn"><i class="bi bi-play-circle"></i> Ejecutar diagnóstico</button>
+                </div>
+                <p class="dev-panel__status">Los resultados más recientes aparecerán en el registro.</p>
+                <div class="dev-panel__log" role="status" aria-live="polite">
+                  <ul id="diagLog"></ul>
+                </div>
+              </article>
+              <article class="dev-panel" aria-labelledby="dev-duplicates-title">
+                <div class="dev-panel__header">
+                  <div>
+                    <h4 class="dev-panel__title" id="dev-duplicates-title"><i class="bi bi-layers" aria-hidden="true"></i> Duplicados</h4>
+                    <p class="dev-panel__description">Revisa coincidencias detectadas y ejecuta limpiezas dirigidas.</p>
+                  </div>
+                </div>
+                <p class="dev-panel__status" id="dupStatus">Ejecuta el diagnóstico para habilitar esta sección.</p>
+                <div class="dup-grid hidden" id="dupList" role="list"></div>
+              </article>
+              <article class="dev-panel" aria-labelledby="dev-solver-title">
+                <div class="dev-panel__header">
+                  <div>
+                    <h4 class="dev-panel__title" id="dev-solver-title"><i class="bi bi-magic" aria-hidden="true"></i> Solucionador automático</h4>
+                    <p class="dev-panel__description">Aplica acciones sugeridas según el último diagnóstico disponible.</p>
+                  </div>
+                  <div class="dev-actions">
+                    <button type="button" class="btn primary" id="solverAutoBtn"><i class="bi bi-lightning-charge"></i> Solución automática</button>
+                    <button type="button" class="btn outline" id="solverStepsBtn"><i class="bi bi-list-check"></i> Ver pasos</button>
+                  </div>
+                </div>
+                <p class="dev-panel__status" id="solverStatus">Ejecuta el diagnóstico para generar recomendaciones.</p>
+                <div class="dev-panel__log" role="log" aria-live="polite">
+                  <ul id="solverLog"></ul>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="view-configuracion" class="view-section hidden">
+        <div class="card settings-card" style="margin:18px">
+          <div class="panel-section">
+            <h3><span aria-hidden="true">👤</span> Perfil</h3>
+            <div class="settings-profile">
+              <div class="profile-avatar">
+                <div class="avatar-frame" id="profileAvatarFrame">
+                  <div id="profileAvatarImg" class="avatar-image" role="img" aria-label="Foto de perfil"></div>
+                  <span id="profileAvatarInitials">U</span>
+                </div>
+                <input type="file" accept="image/*" id="profileAvatarInput" class="hidden" />
+                <div class="avatar-actions">
+                  <button type="button" class="btn outline" id="profileAvatarUpload"><i class="bi bi-image"></i> Subir foto</button>
+                  <button type="button" class="btn" id="profileAvatarRemove"><i class="bi bi-trash"></i> Quitar</button>
+                </div>
+                <p class="muted small">PNG o JPG de hasta 1.5&nbsp;MB. La imagen se guarda únicamente en este navegador.</p>
+              </div>
+              <div class="profile-details">
+                <p class="muted small">Los datos se muestran en modo lectura y reflejan tu último acceso autorizado.</p>
+                <div class="profile-summary" id="profileSummary" aria-live="polite">
+                  <div>
+                    <span class="summary-label">Usuario</span>
+                    <span class="summary-value" id="profileSummaryId">Sin definir</span>
+                  </div>
+                  <div>
+                    <span class="summary-label">Nombre</span>
+                    <span class="summary-value" id="profileSummaryName">Sin definir</span>
+                  </div>
+                  <div>
+                    <span class="summary-label">Correo</span>
+                    <span class="summary-value" id="profileSummaryEmail">Sin definir</span>
+                  </div>
+                  <div>
+                    <span class="summary-label">Rol</span>
+                    <span class="summary-value" id="profileSummaryRole">Sin definir</span>
+                  </div>
+                  <div>
+                    <span class="summary-label">Plantel</span>
+                    <span class="summary-value" id="profileSummaryCampus">Sin definir</span>
+                  </div>
+                </div>
+                <div class="profile-sync-alert" id="profileSyncAlert" hidden></div>
+              </div>
+            </div>
+          </div>
+          <div class="panel-section">
+            <h3><span aria-hidden="true">📝</span> Estado</h3>
+            <div class="settings-summary visible" id="settingsStatus" role="status" aria-live="polite">Tus ajustes se guardan en este dispositivo.</div>
+          </div>
+          <div class="panel-section">
+            <h3><span aria-hidden="true">🔒</span> Seguridad</h3>
+            <form id="passwordForm" class="form-grid security-form" autocomplete="off">
+              <div class="security-status" id="passwordStatusCard" aria-live="polite">
+                <div class="security-status__header">
+                  <span class="summary-label">Solicitud de cambio de contraseña</span>
+                  <span class="summary-value" id="passwordRequestStatus">Sin solicitudes registradas.</span>
+                </div>
+                <div class="security-timeline" id="passwordRequestTimeline" aria-live="polite"></div>
+                <div class="security-status__actions" id="passwordStatusActions">
+                  <button type="button" class="btn micro" id="passwordApproveBtn" hidden><i class="bi bi-check2-circle"></i> Registrar aprobación</button>
+                  <button type="button" class="btn micro" id="passwordCompleteBtn" hidden><i class="bi bi-send-check"></i> Confirmar entrega</button>
+                </div>
+              </div>
+              <label>
+                <span>Contraseña actual</span>
+                <input type="password" id="passwordCurrent" autocomplete="current-password" />
+              </label>
+              <label>
+                <span>Nueva contraseña</span>
+                <input type="password" id="passwordNew" autocomplete="new-password" />
+              </label>
+              <label>
+                <span>Confirmar contraseña</span>
+                <input type="password" id="passwordConfirm" autocomplete="new-password" />
+              </label>
+              <div class="row gap10 security-actions">
+                <button type="submit" class="btn primary"><i class="bi bi-envelope"></i> Enviar solicitud</button>
+                <button type="button" class="btn" id="passwordClear"><i class="bi bi-x"></i> Limpiar</button>
+              </div>
+              <p class="muted small">Esta acción no actualiza tu acceso automáticamente; se guarda como referencia local.</p>
+            </form>
+          </div>
+          <div class="panel-section">
+            <h3><span aria-hidden="true">🎨</span> Preferencias</h3>
+            <div class="settings-preferences">
+              <div class="pref-layout">
+                <div class="pref-column pref-column--controls">
+                  <fieldset class="settings-group" aria-labelledby="themeOptionsLabel">
+                    <legend id="themeOptionsLabel">Tema</legend>
+                    <div class="segmented" role="radiogroup" aria-label="Tema">
+                      <label class="segmented-option">
+                        <input type="radio" name="pref-theme" value="light" />
+                        <span>Claro</span>
+                      </label>
+                      <label class="segmented-option">
+                        <input type="radio" name="pref-theme" value="dark" />
+                        <span>Oscuro</span>
+                      </label>
+                      <label class="segmented-option">
+                        <input type="radio" name="pref-theme" value="system" />
+                        <span>Sistema</span>
+                      </label>
+                    </div>
+                  </fieldset>
+                  <div class="pref-select-grid">
+                    <label class="settings-group">
+                      <span>Idioma</span>
+                      <select id="prefLanguage">
+                        <option value="es">Español</option>
+                        <option value="en">English</option>
+                      </select>
+                    </label>
+                    <label class="settings-group">
+                      <span>Densidad</span>
+                      <select id="prefDensity">
+                        <option value="comfortable">Cómoda</option>
+                        <option value="compact">Compacta</option>
+                      </select>
+                    </label>
+                    <label class="settings-group">
+                      <span>Diseño del tablero</span>
+                      <select id="prefBoardDensity">
+                        <option value="standard">Estándar</option>
+                        <option value="compact">Compacto</option>
+                        <option value="expanded">Amplio</option>
+                      </select>
+                    </label>
+                    <label class="settings-group">
+                      <span>Color de acento</span>
+                      <select id="prefAccent">
+                        <option value="blue">Azul institucional</option>
+                        <option value="green">Verde</option>
+                        <option value="purple">Morado</option>
+                        <option value="orange">Ámbar</option>
+                        <option value="teal">Turquesa</option>
+                        <option value="pink">Magenta</option>
+                      </select>
+                    </label>
+                  </div>
+                </div>
+                <div class="pref-column pref-column--toggles">
+                  <fieldset class="pref-toggles" aria-labelledby="prefToggleLegend">
+                    <legend id="prefToggleLegend">Ajustes rápidos</legend>
+                    <div class="pref-toggle-grid">
+                      <label class="settings-group switch">
+                        <input type="checkbox" id="prefEco" />
+                        <span>Modo eco</span>
+                      </label>
+                      <label class="settings-group switch">
+                        <input type="checkbox" id="prefMotion" />
+                        <span>Reducir animaciones</span>
+                      </label>
+                      <label class="settings-group switch">
+                        <input type="checkbox" id="prefLargeText" />
+                        <span>Texto amplio</span>
+                      </label>
+                      <label class="settings-group switch">
+                        <input type="checkbox" id="prefHighContrast" />
+                        <span>Contraste alto</span>
+                      </label>
+                      <label class="settings-group switch">
+                        <input type="checkbox" id="prefShowLeadId" />
+                        <span>Mostrar ID en tarjetas del tablero</span>
+                      </label>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+              <div class="pref-presets" id="prefPresetRecommendations" hidden>
+                <p class="pref-presets__title">Recomendaciones operativas</p>
+                <div class="pref-presets__list" id="prefPresetList"></div>
+              </div>
+              <div class="row gap10 pref-actions">
+                <button type="button" class="btn" id="prefReset"><i class="bi bi-arrow-counterclockwise"></i> Restablecer</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="view-ayuda" class="view-section hidden">
+        <div class="card" style="margin:18px">
+          <div class="panel-section">
+            <h3><span aria-hidden="true">✨</span> Novedades ReLead CRM</h3>
+            <ul class="help-highlights">
+              <li>Identidad renovada con acceso unificado, nuevo logotipo y título consistente en todo el sitio.</li>
+              <li>Transiciones fluidas entre pestañas, paneles y estados de carga para que sepas cuándo un proceso está en marcha.</li>
+              <li>Experiencia responsive afinada: la navegación lateral, el tablero de leads y los paneles se adaptan sin pasos extra en mobile.</li>
+              <li>Pestaña de ayuda reorganizada con atajos rápidos por módulo y recordatorios de permisos.</li>
+            </ul>
+          </div>
+          <div class="panel-section help-role">
+            <h3><span aria-hidden="true">🧭</span> Guía rápida por pestaña</h3>
+            <div class="help-role-grid">
+              <div>
+                <h4>KPI’s</h4>
+                <ul>
+                  <li>Revisa indicadores priorizados para tu rol. Los totales respetan los filtros activos en Leads.</li>
+                  <li>Usa las tarjetas de alerta para detectar pendientes antes de entrar al tablero.</li>
+                  <li>Elige la base activa desde <strong>Leads → Base</strong> para que los KPI’s se sincronicen con tus datos.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Leads</h4>
+                <ul>
+                  <li>Filtra por base, asesor, plantel y tamaño de página sin perder el conteo global por etapa.</li>
+                  <li>Abre el panel lateral o el cajón móvil para actualizar etapa, estado y comentario con animaciones de estado.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Importar</h4>
+                <ul>
+                  <li>Valida encabezados y duplicados con <strong>Verificar</strong> antes de ejecutar cambios definitivos.</li>
+                  <li>Carga bases activas o plantillas de cambios masivos con vistas previas interactivas.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Exportar</h4>
+                <ul>
+                  <li>Descarga datos filtrados por fecha, asesor o etapa desde el bloque de <strong>Datos</strong>.</li>
+                  <li>Genera reportes ejecutivos o resoluciones por CRM respetando los límites de filas.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Desarrollador</h4>
+                <ul>
+                  <li>Ejecuta diagnósticos completos y consulta resultados en tiempo real.</li>
+                  <li>Gestiona duplicados detectados y aplica soluciones automáticas desde un solo panel.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Permisos</h4>
+                <ul>
+                  <li>Crea y edita usuarios, equipos y alcances desde un panel con chips interactivos.</li>
+                  <li>Observa el resumen del acceso seleccionado sin abandonar la vista.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Configuración</h4>
+                <ul>
+                  <li>Actualiza tu foto local, revisa tus datos en modo lectura y administra preferencias visuales.</li>
+                  <li>Registra solicitudes de cambio de contraseña y consulta su historial local.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Ayuda</h4>
+                <ul>
+                  <li>Accede a las novedades y a los mensajes frecuentes del diagnóstico en un solo lugar.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="panel-section help-role">
+            <h3><span aria-hidden="true">🧑‍🤝‍🧑</span> Roles y alcance</h3>
+            <div class="help-role-grid">
+              <div>
+                <h4>Administración</h4>
+                <ul>
+                  <li>Gestiona usuarios, equipos, bases y ejecuciones del diagnóstico.</li>
+                  <li>Controla duplicados y habilita exportaciones masivas para cualquier plantel.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Coordinación</h4>
+                <ul>
+                  <li>Monitorea indicadores, administra equipos asignados y ejecuta importaciones revisadas.</li>
+                  <li>Configura preferencias personales y consulta permisos sin modificar accesos globales.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Asesoría</h4>
+                <ul>
+                  <li>Trabaja con tus leads asignados, registra avances y descarga reportes filtrados.</li>
+                  <li>Ajusta visuales (tema, densidad, contraste) y mantén tu control de seguridad personal.</li>
+                </ul>
+              </div>
+              <div>
+                <h4>Consulta</h4>
+                <ul>
+                  <li>Visualiza indicadores, leads y reportes con permisos de solo lectura.</li>
+                  <li>Personaliza la interfaz sin alterar datos ni accesos de terceros.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="panel-section help-role">
+            <h3><span aria-hidden="true">🛠️</span> Diagnóstico: mensajes clave</h3>
+            <div class="help-role-table">
+              <table class="help-table">
+                <thead>
+                  <tr><th>Mensaje</th><th>Acción sugerida</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>Error al contactar el servicio</td><td>Confirma tu conexión y que el despliegue de Apps Script siga vigente.</td></tr>
+                  <tr><td>No hay hojas disponibles para ejecutar el diagnóstico.</td><td>Verifica que tengas bases asignadas en <strong>Permisos</strong> y que no estén ocultas.</td></tr>
+                  <tr><td>No se pudo interpretar la respuesta del diagnóstico.</td><td>Repite la ejecución y valida que el backend no haya cambiado de formato.</td></tr>
+                  <tr><td>Prueba de escritura: Fallo</td><td>Asegura permisos de edición y que la hoja no esté protegida.</td></tr>
+                  <tr><td>Hoja "…": requiere revisión</td><td>Consulta columnas faltantes, duplicados o datos inválidos y corrige en la base original.</td></tr>
+                  <tr><td>Duplicados globales de ID/Teléfono</td><td>Depura coincidencias desde la vista de duplicados para evitar conflictos entre hojas.</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer class="site-footer" aria-label="Información de versión y derechos">
+        <div class="site-footer__inner">
+          <span class="site-footer__version" data-version-format="ReLead CRM · Versión {version}"></span>
+          <span class="site-footer__rights">ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+        </div>
+      </footer>
+
+    </main>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="./config/app-config.js"></script>
+  <script src="./js/utils/data-format.js"></script>
+  <script>
+  // —— Datos desde Google Sheets ——
+  function showFatalConfigError(message){
+    const text = String(message || 'Error de configuración.').trim();
+    console.error(text);
+    if(typeof setConnectionStatus === 'function'){
+      setConnectionStatus(text, 'error');
+      return;
+    }
+    const status = document.getElementById('connectionStatus');
+    if(status){
+      status.textContent = text;
+      status.classList.remove('hidden', 'login-info', 'login-success');
+      status.classList.add('login-error');
+      status.setAttribute('role', 'alert');
+      status.setAttribute('aria-live', 'assertive');
+    }
+  }
+
+  function resolveRequiredApiUrl(config){
+    const raw = typeof config.API_URL === 'string' ? config.API_URL.trim() : '';
+    if(!raw){
+      const message = 'Falta configurar ReLeadConfig.API_URL con la URL del Apps Script.';
+      showFatalConfigError(message);
+      throw new Error(message);
+    }
+    let parsed;
+    try{
+      parsed = new URL(raw);
+    }catch(_err){
+      const message = 'La URL de API configurada es inválida. Revisa ReLeadConfig.API_URL.';
+      showFatalConfigError(message);
+      throw new Error(message);
+    }
+    if(parsed.protocol !== 'https:'){
+      const message = 'La URL de API debe usar HTTPS en ReLeadConfig.API_URL.';
+      showFatalConfigError(message);
+      throw new Error(message);
+    }
+    return parsed.toString();
+  }
+
+  const appConfig = window.ReLeadConfig || {};
+  const API_URL = resolveRequiredApiUrl(appConfig);
+  const REQUEST_TIMEOUT_MS = Number.isFinite(appConfig.REQUEST_TIMEOUT_MS) ? appConfig.REQUEST_TIMEOUT_MS : 45000;
+  const SESSION_HEARTBEAT_INTERVAL_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_INTERVAL_MS)
+    ? Math.max(60000, appConfig.SESSION_HEARTBEAT_INTERVAL_MS)
+    : 5 * 60 * 1000;
+  const SESSION_HEARTBEAT_TIMEOUT_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_TIMEOUT_MS)
+    ? Math.max(5000, Math.min(appConfig.SESSION_HEARTBEAT_TIMEOUT_MS, REQUEST_TIMEOUT_MS))
+    : Math.min(REQUEST_TIMEOUT_MS, 15000);
+  const SESSION_HEARTBEAT_JITTER_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_JITTER_MS)
+    ? Math.max(0, appConfig.SESSION_HEARTBEAT_JITTER_MS)
+    : 15000;
+  const DEFAULT_APP_VERSION = '1.0.0';
+  const rawAppVersion = typeof appConfig.VERSION === 'string' ? appConfig.VERSION.trim() : '';
+  const APP_VERSION = rawAppVersion || DEFAULT_APP_VERSION;
+  const DISPLAY_APP_VERSION = APP_VERSION.startsWith('v') ? APP_VERSION : `v${APP_VERSION}`;
+  window.ReLeadAppVersion = DISPLAY_APP_VERSION;
+
+  function applyVersionLabels(){
+    const nodes = document.querySelectorAll('[data-version-format]');
+    nodes.forEach(node => {
+      const template = node.getAttribute('data-version-format') || '{version}';
+      node.textContent = template.replace('{version}', DISPLAY_APP_VERSION);
+    });
+  }
+
+  applyVersionLabels();
+  let leads = [];
+  let sheets = [];
+  let lastDiagnostics = null;
+  let globalLeadIndex = null;
+  let diagInProgress = false;
+  let currentDiagnosticsRunId = 0;
+  let currentSolutionPlan = null;
+  let solvingInProgress = false;
+  let lastSolverAutoRunId = null;
+  let permissionUsers = [];
+  let permissionsLoaded = false;
+  let permissionsLoading = false;
+  let selectedPermissionUserId = '';
+  let teams = [];
+  let teamsLoaded = false;
+  let teamsLoading = false;
+  let selectedTeamId = '';
+  let customTagStore = {};
+  let storedReassignmentDecisions = {};
+  let autoReassignmentPlan = { stats: null, suggestions: [] };
+  let detailLeadContext = null;
+  const leadTagContext = { leadId: '', editingIndex: -1 };
+  const TONE_COLORS = { ok:'var(--ok)', warn:'var(--warn)', bad:'var(--bad)', info:'var(--info)' };
+  const etapasUI = ["Nuevo","Contactado","No Contactado","Inscrito","Descartado"];
+  const estadosByEtapa = {
+    'Nuevo':['Sin contactar'],
+    'Contactado':['Interesado','Seguimiento activo','En labor de venta','Cita agendada'],
+    'No Contactado':['No contesta','Mensaje no respondido','Pendiente de reintento'],
+    'Descartado':['Sin interés','Datos incorrectos','Duplicado','SPAM'],
+    'Inscrito':['Inscrito confirmado']
+  };
+
+  const normalizeColumnKey = key => {
+    return String(key || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-zA-Z0-9]/g, '')
+      .toLowerCase();
+  };
+  const buildAliasList = list => Array.from(new Set((list || []).map(normalizeColumnKey).filter(Boolean)));
+  const leadColumnAliases = {
+    id: buildAliasList(['idlead','leadid','folio','foliolead','identificador','identificadorlead','registro','idprospecto','clave']),
+    nombre: buildAliasList(['nombrecompleto','prospecto','alumno','contacto','fullname','fullnombre','nombrelead','nombreprospecto']),
+    matricula: buildAliasList(['matriculaalumno','idcliente','expediente','nocliente','nocuenta','numexpediente','numeroprospecto']),
+    correo: buildAliasList(['correo1','correo2','correoelectronico','correoinstitucional','email','emailprincipal','mail','contactoemail']),
+    telefono: buildAliasList(['tel','telefono','telefonos','telefono1','telefono2','celular','movil','whatsapp','telefonocelular','telefonoprincipal','telefononormalizado']),
+    campus: buildAliasList(['plantel','sede','campusinteres','campuslead','plantelasignado']),
+    modalidad: buildAliasList(['modalidadinteres','tipomodalidad','modalidadlead','modalidadprograma']),
+    programa: buildAliasList(['programainteres','carrera','programaacademico','plan','oferta','licenciatura','posgrado']),
+    etapa: buildAliasList(['estatus','status','fase','faseactual','etapalead','estatusgeneral']),
+    estado: buildAliasList(['subestado','detalleestado','estatusdetalle','estadodesegimiento','estadodellead']),
+    asesor: buildAliasList(['asesorasignado','asesorresponsable','agente','ejecutivo','orientador','asesorlead','responsable']),
+    comentario: buildAliasList(['notas','nota','observaciones','observacion','seguimiento','comentarios','comentariogeneral']),
+    asignacion: buildAliasList(['fechaasignacion','asignado','fechaasignado','asignacionlead','ultimoasignado'])
+  };
+  const columns = ['id','nombre','matricula','correo','telefono','campus','modalidad','programa','etapa','estado','asesor','comentario','asignacion'];
+
+  const CONTACT_SCRIPT_TYPES = ['call','whatsapp','email'];
+  const CONTACT_CHANNEL_LABELS = { call: 'Llamada', whatsapp: 'WhatsApp', email: 'Correo' };
+  const messageInboxState = {
+    threads: [],
+    filtered: [],
+    search: '',
+    activeId: ''
+  };
+  const MESSAGE_DAY_MS = 24 * 60 * 60 * 1000;
+  const createMessageFormatter = options => {
+    try{
+      return new Intl.DateTimeFormat('es-MX', options);
+    }catch(_err){
+      return null;
+    }
+  };
+  const MESSAGE_LIST_TIME_FORMAT = createMessageFormatter({ hour: '2-digit', minute: '2-digit' });
+  const MESSAGE_LIST_DAY_FORMAT = createMessageFormatter({ weekday: 'short' });
+  const MESSAGE_LIST_DATE_FORMAT = createMessageFormatter({ month: 'short', day: 'numeric' });
+  const MESSAGE_FULL_DAY_FORMAT = createMessageFormatter({ dateStyle: 'long' });
+  const MESSAGE_CHANNEL_LABELS = { whatsapp: 'WhatsApp', facebook: 'Facebook' };
+  const MESSAGE_CHANNEL_ICONS = { whatsapp: 'bi-whatsapp', facebook: 'bi-facebook' };
+
+  function sanitizeText(value){
+    return value === undefined || value === null ? '' : String(value).trim();
+  }
+
+  function tryParseJson(text){
+    if(!text) return null;
+    try{
+      return JSON.parse(text);
+    }catch(_err){
+      return null;
+    }
+  }
+
+  function detectMessageChannel(log){
+    if(!log || typeof log !== 'object') return '';
+    const candidates = [];
+    const pushCandidate = value => {
+      const text = sanitizeText(value);
+      if(text) candidates.push(text);
+    };
+    pushCandidate(log.channel);
+    pushCandidate(log.source);
+    pushCandidate(log.platform);
+    pushCandidate(log.provider);
+    pushCandidate(log.type);
+    pushCandidate(log.transport);
+    pushCandidate(log.integration && log.integration.channel);
+    pushCandidate(log.integration && log.integration.type);
+    pushCandidate(log.metadata && log.metadata.channel);
+    pushCandidate(log.metadata && log.metadata.source);
+    const message = log.message && typeof log.message === 'object' ? log.message : null;
+    if(message){
+      pushCandidate(message.channel);
+      pushCandidate(message.platform);
+      pushCandidate(message.provider);
+      pushCandidate(message.type);
+    }
+    for(let i = 0; i < candidates.length; i += 1){
+      const normalized = candidates[i].toLowerCase();
+      if(!normalized) continue;
+      if(normalized.includes('whatsapp')) return 'whatsapp';
+      if(normalized.includes('messenger') || normalized.includes('facebook')) return 'facebook';
+    }
+    if(log.waId || log.wa_id || (message && (message.waId || message.wa_id || (sanitizeText(message.id).toLowerCase().startsWith('wamid'))))){
+      return 'whatsapp';
+    }
+    if(log.psid || log.fbUserId || log.fb_user_id || log.userId || (message && (message.mid || message.sender || message.participants))){
+      return 'facebook';
+    }
+    const summary = sanitizeText(log.summary).toLowerCase();
+    if(summary.includes('whatsapp')) return 'whatsapp';
+    if(summary.includes('facebook') || summary.includes('messenger')) return 'facebook';
+    return '';
+  }
+
+  function normalizeThreadIdentifier(value){
+    return sanitizeText(value)
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9@._:+-]/gi, '')
+      .toLowerCase();
+  }
+
+  function buildMessageThreadKey(channel, identifier){
+    const normalizedChannel = sanitizeText(channel).toLowerCase() || 'meta';
+    const normalizedIdentifier = normalizeThreadIdentifier(identifier);
+    if(!normalizedIdentifier) return '';
+    return `${normalizedChannel}:${normalizedIdentifier}`;
+  }
+
+  function parseIntegrationMetadataObject(value){
+    if(value && typeof value === 'object'){
+      if(Array.isArray(value.integrationLogs)) return value;
+      if(typeof value.integrationLogs === 'string'){
+        const parsedLogs = tryParseJson(value.integrationLogs);
+        if(parsedLogs && Array.isArray(parsedLogs)){
+          return Object.assign({}, value, { integrationLogs: parsedLogs });
+        }
+      }
+      return value;
+    }
+    if(typeof value === 'string'){
+      const trimmed = value.trim();
+      if(!trimmed) return { integrationLogs: [] };
+      let parsed = tryParseJson(trimmed);
+      if(!parsed && trimmed.includes('{') && trimmed.includes('}')){
+        const start = trimmed.indexOf('{');
+        const end = trimmed.lastIndexOf('}');
+        if(start !== -1 && end !== -1 && end > start){
+          parsed = tryParseJson(trimmed.slice(start, end + 1));
+        }
+      }
+      if(!parsed && trimmed.includes('integrationLogs')){
+        const match = trimmed.match(/\{[\s\S]*"integrationLogs"[\s\S]*\}/);
+        if(match) parsed = tryParseJson(match[0]);
+      }
+      if(parsed && typeof parsed === 'object'){
+        return parsed;
+      }
+    }
+    return { integrationLogs: [] };
+  }
+
+  function extractIntegrationLogsFromLead(lead){
+    if(!lead) return [];
+    const metadata = parseIntegrationMetadataObject(lead.metadatos !== undefined ? lead.metadatos : '');
+    const logs = Array.isArray(metadata.integrationLogs) ? metadata.integrationLogs : [];
+    return logs.filter(Boolean);
+  }
+
+  function extractMessageContactName(log, channel){
+    if(!log || typeof log !== 'object') return '';
+    const safeChannel = sanitizeText(channel).toLowerCase();
+    const direct = sanitizeText(log.contact && (log.contact.name || log.contact.fullName || log.contact.display || log.contact.username));
+    if(direct) return direct;
+    const conversation = log.conversation && typeof log.conversation === 'object' ? log.conversation : null;
+    if(conversation){
+      const conversationName = sanitizeText(conversation.name || conversation.title);
+      if(conversationName) return conversationName;
+    }
+    const message = log.message && typeof log.message === 'object' ? log.message : null;
+    if(message){
+      const profileName = sanitizeText(message.profile && (message.profile.name || message.profile.full_name));
+      if(profileName) return profileName;
+      const contactName = sanitizeText(message.contact && (message.contact.name || message.contact.fullName));
+      if(contactName) return contactName;
+      const fromName = typeof message.from === 'object' ? sanitizeText(message.from.name || message.from.fullName) : sanitizeText(message.fromName || message.from);
+      if(fromName) return fromName;
+      const senderName = sanitizeText(message.sender && (message.sender.name || message.sender.full_name));
+      if(senderName) return senderName;
+      const threadName = sanitizeText(message.thread && message.thread.name);
+      if(threadName) return threadName;
+      if(Array.isArray(message.contacts)){
+        for(let i = 0; i < message.contacts.length; i += 1){
+          const contact = message.contacts[i];
+          if(!contact || typeof contact !== 'object') continue;
+          const candidate = sanitizeText(contact.name || (contact.profile && (contact.profile.name || contact.profile.full_name)));
+          if(candidate) return candidate;
+        }
+      }
+      if(Array.isArray(message.participants)){
+        for(let i = 0; i < message.participants.length; i += 1){
+          const participant = message.participants[i];
+          if(!participant || typeof participant !== 'object') continue;
+          const candidate = sanitizeText(participant.name || participant.fullName);
+          if(candidate) return candidate;
+        }
+      }
+    }
+    const summary = sanitizeText(log.summary);
+    if(summary){
+      const normalized = summary.toLowerCase();
+      if(normalized.startsWith('whatsapp recibido') || normalized.startsWith('facebook recibido') || normalized.startsWith('messenger recibido')){
+        const parts = summary.split('·').map(part => sanitizeText(part)).filter(Boolean);
+        if(parts.length >= 2){
+          const candidate = parts[1];
+          if(candidate && candidate.toLowerCase() !== 'whatsapp recibido' && candidate.toLowerCase() !== 'facebook recibido' && candidate.toLowerCase() !== 'messenger recibido'){
+            return candidate;
+          }
+        }
+      }
+      if(!safeChannel && summary.includes('·')){
+        const parts = summary.split('·').map(part => sanitizeText(part)).filter(Boolean);
+        if(parts.length >= 2) return parts[1];
+      }
+    }
+    return '';
+  }
+
+  function extractWhatsappErrorText(error){
+    if(!error || typeof error !== 'object') return '';
+    const fields = [
+      error.error_data && (error.error_data.details || error.error_data.message),
+      error.detail,
+      error.message,
+      error.title,
+      error.description,
+      error.error_message,
+      error.code
+    ];
+    for(let i = 0; i < fields.length; i += 1){
+      const text = sanitizeText(fields[i]);
+      if(text) return text;
+    }
+    return '';
+  }
+
+  function formatStatusLabel(value){
+    const text = sanitizeText(value);
+    if(!text) return '';
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+
+  function describeMessageContent(log){
+    if(!log || typeof log !== 'object') return '';
+    const message = log.message && typeof log.message === 'object' ? log.message : null;
+    if(message){
+      if(typeof message.text === 'string') return sanitizeText(message.text);
+      if(message.text && typeof message.text === 'object'){
+        if(message.text.body) return sanitizeText(message.text.body);
+        if(message.text.value) return sanitizeText(message.text.value);
+        if(message.text.message) return sanitizeText(message.text.message);
+      }
+      if(typeof message.message === 'string') return sanitizeText(message.message);
+      if(message.button && message.button.text) return sanitizeText(message.button.text);
+      if(message.interactive){
+        const interactive = message.interactive;
+        if(interactive.body && interactive.body.text) return sanitizeText(interactive.body.text);
+        if(interactive.button_reply && interactive.button_reply.title) return sanitizeText(interactive.button_reply.title);
+        if(interactive.list_reply && interactive.list_reply.title) return sanitizeText(interactive.list_reply.title);
+      }
+      if(message.quick_reply && message.quick_reply.payload) return sanitizeText(message.quick_reply.payload);
+      if(message.image){
+        if(message.image.caption) return sanitizeText(message.image.caption);
+        if(message.image.url || message.image.link) return '[Imagen]';
+      }
+      if(message.audio) return '[Audio]';
+      if(message.document){
+        if(message.document.filename) return `[Documento] ${sanitizeText(message.document.filename)}`;
+        return '[Documento]';
+      }
+      if(message.video){
+        if(message.video.caption) return sanitizeText(message.video.caption);
+        return '[Video]';
+      }
+      if(message.sticker) return '[Sticker]';
+      if(message.location) return '[Ubicación]';
+      if(Array.isArray(message.attachments) && message.attachments.length){
+        const attachmentTypes = Array.from(new Set(message.attachments.map(att => sanitizeText(att.type || att.mime_type || att.attachmentType || '').toLowerCase()).filter(Boolean)));
+        if(attachmentTypes.length){
+          return `[Adjunto] ${attachmentTypes.map(type => type.charAt(0).toUpperCase() + type.slice(1)).join(', ')}`;
+        }
+        return '[Adjunto]';
+      }
+    }
+    if(log.status){
+      const label = formatStatusLabel(log.status);
+      const errors = Array.isArray(log.errors) ? log.errors.map(extractWhatsappErrorText).filter(Boolean) : [];
+      return errors.length ? `${label} · ${errors.join(' · ')}` : label;
+    }
+    if(typeof log.message === 'string') return sanitizeText(log.message);
+    if(log.messageText) return sanitizeText(log.messageText);
+    return sanitizeText(log.summary);
+  }
+
+  function parseLogTimestamp(log){
+    if(!log || typeof log !== 'object') return Date.now();
+    const timestampSources = [log.timestamp, log.timestampText];
+    for(let i = 0; i < timestampSources.length; i += 1){
+      const source = sanitizeText(timestampSources[i]);
+      if(!source) continue;
+      const parsed = Date.parse(source);
+      if(!Number.isNaN(parsed)) return parsed;
+    }
+    if(log.message && log.message.timestamp){
+      const rawTs = Number(log.message.timestamp);
+      if(Number.isFinite(rawTs)){
+        return rawTs > 1e12 ? rawTs : rawTs * 1000;
+      }
+    }
+    return Date.now();
+  }
+
+  function resolveMessageContact(log, lead, channel){
+    const normalizedChannel = sanitizeText(channel).toLowerCase() || 'meta';
+    const channelLabel = MESSAGE_CHANNEL_LABELS[normalizedChannel] || 'Meta';
+    const channelIcon = MESSAGE_CHANNEL_ICONS[normalizedChannel] || 'bi-chat-dots';
+    const leadName = lead ? sanitizeText(lead.nombre) : '';
+    if(normalizedChannel === 'whatsapp'){
+      const candidates = [];
+      const pushCandidate = value => {
+        const text = sanitizeText(value);
+        if(text) candidates.push(text);
+      };
+      if(log && typeof log === 'object'){
+        pushCandidate(log.waId || log.wa_id);
+        const message = log.message && typeof log.message === 'object' ? log.message : null;
+        if(message){
+          pushCandidate(message.from);
+          pushCandidate(message.to);
+          if(message.context && typeof message.context === 'object'){
+            pushCandidate(message.context.from);
+            pushCandidate(message.context.to);
+          }
+          if(Array.isArray(message.contacts)){
+            message.contacts.forEach(contact => {
+              if(contact && typeof contact === 'object'){
+                pushCandidate(contact.wa_id || contact.waId);
+              }
+            });
+          }
+        }
+      }
+      if(lead){
+        pushCandidate(lead.telefonoNormalizado);
+        pushCandidate(lead.telefono);
+      }
+      for(let i = 0; i < candidates.length; i += 1){
+        const candidate = candidates[i];
+        const identifier = normalizePhoneKey(candidate);
+        if(!identifier) continue;
+        const key = buildMessageThreadKey(normalizedChannel, identifier);
+        if(!key) continue;
+        const phone = parsePhone(candidate);
+        const displayPhone = fmtPhone(phone.raw || phone.digits || candidate);
+        return {
+          key,
+          identifier,
+          display: displayPhone || candidate || leadName || identifier,
+          raw: candidate,
+          channel: normalizedChannel,
+          channelLabel,
+          channelIcon
+        };
+      }
+      if(lead){
+        const fallbackIdentifier = normalizePhoneKey(lead.telefonoNormalizado || lead.telefono);
+        if(fallbackIdentifier){
+          const key = buildMessageThreadKey(normalizedChannel, fallbackIdentifier);
+          if(key){
+            const displayPhone = fmtPhone(lead.telefono || lead.telefonoNormalizado || fallbackIdentifier);
+            const contactName = extractMessageContactName(log, normalizedChannel) || leadName;
+            return {
+              key,
+              identifier: fallbackIdentifier,
+              display: contactName || displayPhone || fallbackIdentifier,
+              raw: lead.telefono || lead.telefonoNormalizado || fallbackIdentifier,
+              channel: normalizedChannel,
+              channelLabel,
+              channelIcon
+            };
+          }
+        }
+      }
+      return null;
+    }
+    if(normalizedChannel === 'facebook'){
+      const userCandidates = [];
+      const pageCandidates = new Set();
+      const pushUserCandidate = value => {
+        const raw = sanitizeText(value);
+        const normalized = normalizeThreadIdentifier(raw);
+        if(normalized){
+          userCandidates.push({ raw, normalized });
+        }
+      };
+      const pushPageCandidate = value => {
+        const normalized = normalizeThreadIdentifier(value);
+        if(normalized) pageCandidates.add(normalized);
+      };
+      if(log && typeof log === 'object'){
+        pushUserCandidate(log.contact && (log.contact.id || log.contact.psid || log.contact.uid));
+        pushUserCandidate(log.psid);
+        pushUserCandidate(log.userId || log.user_id);
+        pushUserCandidate(log.senderId || log.sender_id);
+        const conversation = log.conversation && typeof log.conversation === 'object' ? log.conversation : null;
+        if(conversation){
+          pushUserCandidate(conversation.id);
+          pushPageCandidate(conversation.pageId || conversation.page_id);
+        }
+        pushUserCandidate(log.threadId);
+        pushUserCandidate(log.conversationId);
+      }
+      const message = log && log.message && typeof log.message === 'object' ? log.message : null;
+      if(message){
+        const sender = message.sender;
+        if(sender){
+          if(typeof sender === 'object'){
+            pushUserCandidate(sender.id || sender.user_id);
+            if((sender.category || sender.type || '').toLowerCase() === 'page'){ pushPageCandidate(sender.id || sender.user_id); }
+          }else{
+            pushUserCandidate(sender);
+          }
+        }
+        const from = message.from;
+        if(from){
+          if(typeof from === 'object'){
+            pushUserCandidate(from.id || from.user_id);
+            if((from.category || from.type || '').toLowerCase() === 'page'){ pushPageCandidate(from.id || from.user_id); }
+          }else{
+            pushUserCandidate(from);
+          }
+        }
+        const recipient = message.recipient;
+        if(recipient){
+          if(typeof recipient === 'object'){
+            pushPageCandidate(recipient.id || recipient.user_id || recipient.page_id);
+          }else{
+            pushPageCandidate(recipient);
+          }
+        }
+        if(Array.isArray(message.participants)){
+          message.participants.forEach(participant => {
+            if(!participant || typeof participant !== 'object') return;
+            const normalized = normalizeThreadIdentifier(participant.id || participant.user_id);
+            if(!normalized) return;
+            if((participant.role || participant.type || '').toLowerCase() === 'page'){
+              pageCandidates.add(normalized);
+            }else{
+              userCandidates.push({ raw: sanitizeText(participant.id || participant.user_id), normalized });
+            }
+          });
+        }
+        if(message.conversation && typeof message.conversation === 'object'){
+          pushUserCandidate(message.conversation.id);
+          pushPageCandidate(message.conversation.thread_key || message.conversation.threadKey);
+        }
+        pushUserCandidate(message.mid);
+      }
+      let contactCandidate = null;
+      for(let i = 0; i < userCandidates.length; i += 1){
+        const candidate = userCandidates[i];
+        if(!candidate || !candidate.normalized) continue;
+        if(pageCandidates.has(candidate.normalized)) continue;
+        contactCandidate = candidate;
+        break;
+      }
+      if(!contactCandidate && userCandidates.length){
+        contactCandidate = userCandidates[0];
+      }
+      if(contactCandidate){
+        const key = buildMessageThreadKey(normalizedChannel, contactCandidate.normalized);
+        if(key){
+          const contactName = extractMessageContactName(log, normalizedChannel) || leadName;
+          return {
+            key,
+            identifier: contactCandidate.normalized,
+            display: contactName || contactCandidate.raw || leadName || contactCandidate.normalized,
+            raw: contactCandidate.raw || contactCandidate.normalized,
+            channel: normalizedChannel,
+            channelLabel,
+            channelIcon
+          };
+        }
+      }
+      if(lead){
+        const fallbackIdentifier = normalizeThreadIdentifier(lead.id || lead.matricula || lead.telefonoNormalizado || lead.telefono);
+        if(fallbackIdentifier){
+          const key = buildMessageThreadKey(normalizedChannel, fallbackIdentifier);
+          if(key){
+            const contactName = extractMessageContactName(log, normalizedChannel) || leadName;
+            return {
+              key,
+              identifier: fallbackIdentifier,
+              display: contactName || fmtPhone(lead.telefono || lead.telefonoNormalizado) || fallbackIdentifier,
+              raw: fallbackIdentifier,
+              channel: normalizedChannel,
+              channelLabel,
+              channelIcon
+            };
+          }
+        }
+      }
+      return null;
+    }
+    if(lead){
+      const fallbackIdentifier = normalizeThreadIdentifier(lead.id || lead.matricula || lead.telefonoNormalizado || lead.telefono);
+      if(fallbackIdentifier){
+        const key = buildMessageThreadKey(normalizedChannel, fallbackIdentifier);
+        if(key){
+          const contactName = extractMessageContactName(log, normalizedChannel) || leadName;
+          return {
+            key,
+            identifier: fallbackIdentifier,
+            display: contactName || fmtPhone(lead.telefono || lead.telefonoNormalizado) || fallbackIdentifier,
+            raw: fallbackIdentifier,
+            channel: normalizedChannel,
+            channelLabel,
+            channelIcon
+          };
+        }
+      }
+    }
+    return null;
+  }
+
+  function finalizeThread(thread){
+    thread.messages.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+    const last = thread.messages.length ? thread.messages[thread.messages.length - 1] : null;
+    thread.lastTimestamp = last ? last.timestamp : 0;
+    thread.lastPreview = last ? sanitizeText(last.preview) : '';
+    thread.lastDirection = last ? last.direction : 'incoming';
+    thread.leads = Array.from(thread.leads.values());
+    const contactNames = Array.from(thread.contactNames || []).filter(Boolean);
+    const leadNames = thread.leads.map(item => sanitizeText(item.nombre)).filter(Boolean);
+    const displayContact = thread.contact ? sanitizeText(thread.contact.display) : '';
+    thread.displayContact = displayContact;
+    thread.contactName = contactNames[0] || leadNames[0] || displayContact || 'Sin nombre';
+    const tokens = new Set();
+    [thread.contactName, displayContact, thread.key, thread.channelLabel, thread.contact && thread.contact.identifier]
+      .forEach(token => {
+        const cleaned = sanitizeText(token).toLowerCase();
+        if(cleaned) tokens.add(cleaned);
+      });
+    thread.leads.forEach(item => {
+      const nameToken = sanitizeText(item.nombre).toLowerCase();
+      if(nameToken) tokens.add(nameToken);
+      const baseToken = sanitizeText(item.base).toLowerCase();
+      if(baseToken) tokens.add(baseToken);
+      const asesorToken = sanitizeText(item.asesor).toLowerCase();
+      if(asesorToken) tokens.add(asesorToken);
+    });
+    thread.searchTokens = Array.from(tokens).filter(Boolean);
+  }
+
+  function buildMessageThreadsFromLeads(list){
+    const entries = Array.isArray(list) ? list : [];
+    const threads = new Map();
+    entries.forEach(lead => {
+      const logs = extractIntegrationLogsFromLead(lead);
+      if(!logs.length) return;
+      logs.forEach(log => {
+        if(!log || typeof log !== 'object') return;
+        const detectedChannel = detectMessageChannel(log);
+        const contact = resolveMessageContact(log, lead, detectedChannel || 'meta');
+        if(!contact || !contact.key) return;
+        const key = contact.key;
+        if(!threads.has(key)){
+          threads.set(key, {
+            id: key,
+            key,
+            contact,
+            channel: contact.channel || detectedChannel || 'meta',
+            channelLabel: contact.channelLabel || MESSAGE_CHANNEL_LABELS[detectedChannel] || MESSAGE_CHANNEL_LABELS[contact.channel] || 'Meta',
+            channelIcon: contact.channelIcon || MESSAGE_CHANNEL_ICONS[detectedChannel] || MESSAGE_CHANNEL_ICONS[contact.channel] || 'bi-chat-dots',
+            contactNames: new Set(),
+            messageIds: new Set(),
+            leads: new Map(),
+            messages: []
+          });
+        }
+        const thread = threads.get(key);
+        if(contact.display){
+          thread.contact = contact;
+        }
+        if(contact.channel){
+          thread.channel = contact.channel;
+        }
+        if(contact.channelLabel){
+          thread.channelLabel = contact.channelLabel;
+        }
+        if(contact.channelIcon){
+          thread.channelIcon = contact.channelIcon;
+        }
+        const messageId = sanitizeText(log.id) || `${key}:${log.timestamp || ''}`;
+        if(thread.messageIds.has(messageId)) return;
+        thread.messageIds.add(messageId);
+        const timestamp = parseLogTimestamp(log);
+        const direction = log.status
+          ? 'status'
+          : (String(log.direction || '').toLowerCase() === 'outgoing' ? 'outgoing' : 'incoming');
+        const messageText = describeMessageContent(log);
+        thread.messages.push({
+          id: messageId,
+          timestamp,
+          direction,
+          preview: messageText || sanitizeText(log.summary) || 'Sin contenido',
+          text: messageText,
+          summary: sanitizeText(log.summary),
+          status: sanitizeText(log.status),
+          errors: Array.isArray(log.errors) ? log.errors.slice() : [],
+          raw: log,
+          channel: thread.channel
+        });
+        const contactName = extractMessageContactName(log, thread.channel);
+        if(contactName) thread.contactNames.add(contactName);
+        if(lead){
+          const leadId = sanitizeText(lead.id) || `${lead.nombre || ''}:${key}`;
+          if(!thread.leads.has(leadId)){
+            thread.leads.set(leadId, {
+              id: sanitizeText(lead.id),
+              nombre: lead.nombre || '',
+              base: lead.base || '',
+              etapa: lead.etapa || '',
+              asesor: lead.asesor || ''
+            });
+          }
+        }
+      });
+    });
+    const result = Array.from(threads.values());
+    result.forEach(thread => finalizeThread(thread));
+    result.sort((a, b) => (b.lastTimestamp || 0) - (a.lastTimestamp || 0));
+    return result;
+  }
+
+  function startOfDay(timestamp){
+    const date = new Date(timestamp);
+    if(Number.isNaN(date.getTime())) return 0;
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+  }
+
+  function formatMessageListTime(timestamp){
+    if(!timestamp) return '';
+    const date = new Date(timestamp);
+    if(Number.isNaN(date.getTime())) return '';
+    const now = new Date();
+    const diff = Math.floor((startOfDay(now) - startOfDay(date)) / MESSAGE_DAY_MS);
+    if(diff === 0 && MESSAGE_LIST_TIME_FORMAT){
+      return MESSAGE_LIST_TIME_FORMAT.format(date);
+    }
+    if(diff === 1) return 'Ayer';
+    if(diff > 1 && diff < 7){
+      return MESSAGE_LIST_DAY_FORMAT ? MESSAGE_LIST_DAY_FORMAT.format(date) : date.toLocaleDateString('es-MX', { weekday: 'short' });
+    }
+    if(MESSAGE_LIST_DATE_FORMAT){
+      return MESSAGE_LIST_DATE_FORMAT.format(date);
+    }
+    return date.toLocaleDateString();
+  }
+
+  function formatConversationDay(timestamp){
+    if(!timestamp) return '';
+    const date = new Date(timestamp);
+    if(Number.isNaN(date.getTime())) return '';
+    const now = new Date();
+    const diff = Math.floor((startOfDay(now) - startOfDay(date)) / MESSAGE_DAY_MS);
+    if(diff === 0) return 'Hoy';
+    if(diff === 1) return 'Ayer';
+    if(MESSAGE_FULL_DAY_FORMAT){
+      return MESSAGE_FULL_DAY_FORMAT.format(date);
+    }
+    return date.toLocaleDateString();
+  }
+
+  function formatMessageTimeOfDay(timestamp){
+    if(!timestamp) return '';
+    const date = new Date(timestamp);
+    if(Number.isNaN(date.getTime())) return '';
+    if(MESSAGE_LIST_TIME_FORMAT){
+      return MESSAGE_LIST_TIME_FORMAT.format(date);
+    }
+    return date.toLocaleTimeString();
+  }
+
+  function syncMessageSearchInput(){
+    const searchInput = el('#messageSearch');
+    if(searchInput && searchInput.value !== messageInboxState.search){
+      searchInput.value = messageInboxState.search;
+    }
+  }
+
+  function updateMessageSummary(){
+    const summaryEl = el('#messageThreadSummary');
+    if(!summaryEl) return;
+    const total = messageInboxState.threads.length;
+    const filtered = messageInboxState.filtered.length;
+    if(!total){
+      summaryEl.textContent = 'Sin conversaciones registradas.';
+      return;
+    }
+    if(sanitizeText(messageInboxState.search)){
+      summaryEl.textContent = `${filtered} de ${total} conversación${total === 1 ? '' : 'es'} coinciden con la búsqueda.`;
+      return;
+    }
+    summaryEl.textContent = `${total} conversación${total === 1 ? '' : 'es'} sincronizada${total === 1 ? '' : 's'}.`;
+  }
+
+  function renderMessagePlaceholder(mode){
+    const container = el('#messageConversation');
+    if(!container) return;
+    let icon = 'bi-chat-dots';
+    let lines = [];
+    if(mode === 'no-results'){
+      icon = 'bi-search';
+      lines = ['Sin coincidencias.', 'Ajusta la búsqueda para ver otras conversaciones.'];
+    }else if(mode === 'empty'){
+      lines = ['Sin conversaciones registradas.', 'Cuando Meta envíe mensajes o estados (WhatsApp o Facebook), se agruparán aquí por contacto.'];
+    }else{
+      lines = ['Selecciona una conversación para revisar el detalle.'];
+    }
+    const items = lines.map((line, index) => {
+      if(index === 0){
+        return '<p>' + escapeHtml(line) + '</p>';
+      }
+      return '<p class="muted small">' + escapeHtml(line) + '</p>';
+    }).join('');
+    container.innerHTML = `<div class="messages-placeholder"><i class="bi ${icon}" aria-hidden="true"></i>${items}</div>`;
+  }
+
+  function renderMessageThreads(){
+    const listEl = el('#messageThreadList');
+    if(!listEl) return;
+    const threads = messageInboxState.filtered;
+    const total = messageInboxState.threads.length;
+    if(!threads.length){
+      if(total){
+        listEl.innerHTML = '<div class="messages-empty"><i class="bi bi-search"></i><p>No hay conversaciones que coincidan con la búsqueda.</p></div>';
+        renderMessagePlaceholder('no-results');
+      }else{
+        listEl.innerHTML = '<div class="messages-empty"><i class="bi bi-inboxes"></i><p>Aún no hay conversaciones registradas.</p></div>';
+        renderMessagePlaceholder('empty');
+      }
+      return;
+    }
+    const html = threads.map(thread => {
+      const active = thread.id === messageInboxState.activeId;
+      const classes = ['messages-thread'];
+      if(active) classes.push('is-active');
+      const initials = sanitizeText(thread.contactName).charAt(0).toUpperCase() || '#';
+      const extraLeads = thread.leads.length > 1 ? ` · +${thread.leads.length - 1} coincidencia${thread.leads.length - 1 === 1 ? '' : 's'}` : '';
+      const baseLabel = thread.leads.length ? sanitizeText(thread.leads[0].base) : '';
+      const metaParts = [];
+      if(thread.channelLabel) metaParts.push(thread.channelLabel);
+      if(thread.displayContact) metaParts.push(thread.displayContact);
+      if(baseLabel) metaParts.push(baseLabel);
+      if(extraLeads) metaParts.push(extraLeads.trim());
+      const metaHtml = metaParts.length ? `<div class="messages-thread__meta">${escapeHtml(metaParts.join(' · '))}</div>` : '';
+      const directionIcon = thread.lastDirection === 'outgoing'
+        ? '<i class="bi bi-arrow-up-right message-direction" aria-hidden="true"></i>'
+        : thread.lastDirection === 'status'
+          ? '<i class="bi bi-check2-all message-direction" aria-hidden="true"></i>'
+          : '<i class="bi bi-arrow-down-left message-direction" aria-hidden="true"></i>';
+      const preview = thread.lastPreview ? escapeHtml(thread.lastPreview) : 'Sin contenido';
+      const timeLabel = thread.lastTimestamp ? escapeHtml(formatMessageListTime(thread.lastTimestamp)) : '';
+      return `<button type="button" class="${classes.join(' ')}" data-thread-id="${escapeHtml(thread.id)}" aria-pressed="${active ? 'true' : 'false'}">
+        <span class="messages-thread__avatar" aria-hidden="true">${escapeHtml(initials)}</span>
+        <span class="messages-thread__body">
+          <span class="messages-thread__header">
+            <span class="messages-thread__name">${escapeHtml(thread.contactName || 'Sin nombre')}</span>
+            <span class="messages-thread__time">${timeLabel}</span>
+          </span>
+          ${metaHtml}
+          <span class="messages-thread__preview">${directionIcon}<span>${preview}</span></span>
+        </span>
+      </button>`;
+    }).join('');
+    listEl.innerHTML = html;
+  }
+
+  function renderActiveConversation(){
+    const container = el('#messageConversation');
+    if(!container) return;
+    const thread = messageInboxState.filtered.find(item => item.id === messageInboxState.activeId);
+    if(!thread){
+      if(messageInboxState.filtered.length){
+        renderMessagePlaceholder('prompt');
+      }
+      return;
+    }
+    const initials = sanitizeText(thread.contactName).charAt(0).toUpperCase() || '#';
+    const subtitleParts = [];
+    if(thread.channelLabel) subtitleParts.push(thread.channelLabel);
+    if(thread.displayContact) subtitleParts.push(thread.displayContact);
+    const subtitleText = subtitleParts.join(' · ') || 'Identificador no disponible';
+    const channelChip = thread.channelLabel
+      ? `<span class="messages-chip messages-chip--channel"><i class="bi ${escapeHtml(thread.channelIcon || 'bi-chat-dots')}" aria-hidden="true"></i><span>${escapeHtml(thread.channelLabel)}</span></span>`
+      : '';
+    const leadChipsHtml = thread.leads.length
+      ? thread.leads.map(lead => {
+          const details = [sanitizeText(lead.base), sanitizeText(lead.etapa), sanitizeText(lead.asesor)].filter(Boolean).join(' · ');
+          return `<span class="messages-chip"><strong>${escapeHtml(lead.nombre || lead.id || 'Lead sin nombre')}</strong>${details ? `<span>${escapeHtml(details)}</span>` : ''}</span>`;
+        }).join('')
+      : '';
+    const chipsHtml = channelChip || leadChipsHtml
+      ? `<div class="messages-conversation__chips">${channelChip}${leadChipsHtml}</div>`
+      : '';
+    container.innerHTML = `
+      <header class="messages-conversation__header">
+        <div class="messages-conversation__identity">
+          <div class="messages-conversation__avatar" aria-hidden="true">${escapeHtml(initials)}</div>
+          <div>
+            <p class="messages-conversation__title">${escapeHtml(thread.contactName)}</p>
+            <p class="messages-conversation__subtitle">${escapeHtml(subtitleText)}</p>
+          </div>
+        </div>
+        ${chipsHtml}
+      </header>
+      <div class="messages-conversation__body"></div>
+    `;
+    const body = container.querySelector('.messages-conversation__body');
+    if(!body) return;
+    body.innerHTML = '';
+    let lastDayKey = '';
+    thread.messages.forEach(message => {
+      const dayKey = startOfDay(message.timestamp || Date.now());
+      if(dayKey && dayKey !== lastDayKey){
+        const dayLabel = formatConversationDay(message.timestamp);
+        if(dayLabel){
+          const separator = document.createElement('div');
+          separator.className = 'messages-day-separator';
+          separator.textContent = dayLabel;
+          body.appendChild(separator);
+        }
+        lastDayKey = dayKey;
+      }
+      const directionClass = message.direction === 'outgoing'
+        ? 'message-outgoing'
+        : message.direction === 'status'
+          ? 'message-status'
+          : 'message-incoming';
+      const bubble = document.createElement('div');
+      bubble.className = `message-bubble ${directionClass}`;
+      const text = sanitizeText(message.text) || sanitizeText(message.summary) || 'Sin contenido';
+      const timeLabel = formatMessageTimeOfDay(message.timestamp);
+      const statusLabel = directionClass === 'message-outgoing' ? formatStatusLabel(message.status) : '';
+      const metaParts = [];
+      if(timeLabel) metaParts.push(`<span>${escapeHtml(timeLabel)}</span>`);
+      if(statusLabel) metaParts.push(`<span class="message-status-label">${escapeHtml(statusLabel)}</span>`);
+      bubble.innerHTML = `<div class="message-text">${escapeHtml(text)}</div>${metaParts.length ? `<div class="message-meta">${metaParts.join('')}</div>` : ''}`;
+      if(message.errors && message.errors.length){
+        const errorText = message.errors.map(extractWhatsappErrorText).filter(Boolean).join(' · ');
+        if(errorText){
+          const errorEl = document.createElement('div');
+          errorEl.className = 'message-error';
+          errorEl.textContent = errorText;
+          bubble.appendChild(errorEl);
+        }
+      }
+      body.appendChild(bubble);
+    });
+    body.scrollTop = body.scrollHeight;
+  }
+
+  function selectMessageThread(threadId){
+    if(!threadId) return;
+    if(messageInboxState.activeId !== threadId){
+      messageInboxState.activeId = threadId;
+    }
+    renderMessageThreads();
+    renderActiveConversation();
+    const listEl = el('#messageThreadList');
+    if(listEl){
+      const activeButton = listEl.querySelector(`.messages-thread[data-thread-id="${threadId}"]`);
+      if(activeButton && typeof activeButton.focus === 'function'){
+        activeButton.focus();
+      }
+    }
+  }
+
+  function applyMessageFilters(options = {}){
+    const preserveActive = options.preserveActive !== undefined ? options.preserveActive : true;
+    const query = sanitizeText(messageInboxState.search).toLowerCase();
+    let filtered = messageInboxState.threads.slice();
+    if(query){
+      filtered = filtered.filter(thread => Array.isArray(thread.searchTokens) && thread.searchTokens.some(token => token.includes(query)));
+    }
+    messageInboxState.filtered = filtered;
+    if(!filtered.length){
+      if(!preserveActive){
+        messageInboxState.activeId = '';
+      }
+      return;
+    }
+    if(preserveActive && filtered.some(thread => thread.id === messageInboxState.activeId)){
+      return;
+    }
+    messageInboxState.activeId = filtered[0].id;
+  }
+
+  function syncMessageInbox(options = {}){
+    const preserveActive = options.preserveActive !== undefined ? options.preserveActive : true;
+    if(options.reset){
+      messageInboxState.search = '';
+      messageInboxState.activeId = '';
+    }
+    const threads = buildMessageThreadsFromLeads(leads);
+    messageInboxState.threads = threads;
+    if(!preserveActive || !threads.some(thread => thread.id === messageInboxState.activeId)){
+      messageInboxState.activeId = threads.length ? threads[0].id : '';
+    }
+    applyMessageFilters({ preserveActive });
+    syncMessageSearchInput();
+    updateMessageSummary();
+    renderMessageThreads();
+    renderActiveConversation();
+  }
+
+  const DAILY_SHORTCUT_LIMIT = 3;
+  const LEAD_PRIORITY_THRESHOLDS = { high: 6, medium: 3 };
+  const CONTACT_TIMESTAMP_FORMAT = (() => {
+    try{
+      return new Intl.DateTimeFormat('es-MX', { dateStyle: 'short', timeStyle: 'short' });
+    }catch(err){
+      return null;
+    }
+  })();
+
+  const KPI_INTEREST_STATES = new Set(['interesado','seguimiento activo','cita agendada','en labor de venta']);
+  const KPI_NUMBER_FORMAT = new Intl.NumberFormat('es-MX');
+  const KPI_PERCENT_FORMAT = new Intl.NumberFormat('es-MX', { style: 'percent', minimumFractionDigits: 0, maximumFractionDigits: 1 });
+  const KPI_GROUPS = {
+    Base_Fria: {
+      label: 'Base fría',
+      description: 'Volumen y depuración de la base fría en seguimiento.',
+      metrics: [
+        {
+          key: 'Total_Leads_Frios',
+          label: 'Total leads fríos',
+          description: 'Número total de leads en la base fría',
+          compute: ctx => ({ value: formatKpiNumber(ctx.total) })
+        },
+        {
+          key: 'Leads_Reimpactados',
+          label: 'Leads reimpactados',
+          description: 'Cantidad de leads fríos a los que se intentó contactar nuevamente',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.reimpactados, ctx.total);
+            return {
+              value: formatKpiNumber(ctx.reimpactados),
+              extra: ratio !== null ? `${formatKpiPercent(ratio)} del total` : ''
+            };
+          }
+        },
+        {
+          key: 'Porcentaje_Reimpactados',
+          label: '% reimpactados',
+          description: 'Leads reimpactados / Leads fríos totales',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.reimpactados, ctx.total);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Se requieren leads cargados para calcular el porcentaje.' : ''
+            };
+          }
+        },
+        {
+          key: 'Leads_Descartados',
+          label: 'Leads descartados',
+          description: 'Cantidad y % de leads con datos falsos, sin interés o imposibles de recuperar',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.descartados, ctx.total);
+            return {
+              value: formatKpiNumber(ctx.descartados),
+              extra: ratio !== null ? `${formatKpiPercent(ratio)} del total` : ''
+            };
+          }
+        }
+      ]
+    },
+    Reactivacion: {
+      label: 'Reactivación',
+      description: 'Impacto de la segunda vuelta y el interés recuperado.',
+      metrics: [
+        {
+          key: 'Leads_Reactivados',
+          label: 'Leads reactivados',
+          description: 'Leads que respondieron o mostraron interés en la segunda vuelta',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.reactivados, ctx.reimpactados);
+            return {
+              value: formatKpiNumber(ctx.reactivados),
+              extra: ratio !== null ? `${formatKpiPercent(ratio)} de reimpactados` : '',
+              note: ctx.reimpactados ? '' : 'Aún no hay leads reimpactados en la base.'
+            };
+          }
+        },
+        {
+          key: 'Porcentaje_Reactivados',
+          label: '% reactivados',
+          description: 'Leads reactivados / Leads reimpactados',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.reactivados, ctx.reimpactados);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Necesitas leads reimpactados para obtener este porcentaje.' : ''
+            };
+          }
+        },
+        {
+          key: 'Tasa_Respuesta',
+          label: 'Tasa de respuesta',
+          description: '% de leads que responden en la segunda vuelta',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.responded, ctx.reimpactados);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Se requieren leads reimpactados para medir la respuesta.' : ''
+            };
+          }
+        }
+      ]
+    },
+    Conversion: {
+      label: 'Conversión',
+      description: 'Proporción de leads fríos que avanzan a etapas clave.',
+      metrics: [
+        {
+          key: 'Conversion_Frios_Interesados',
+          label: 'Fríos a interesados',
+          description: '% de leads fríos que avanzan a interesados',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.interesados, ctx.total);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Carga leads para estimar la conversión.' : ''
+            };
+          }
+        },
+        {
+          key: 'Conversion_Frios_Inscritos',
+          label: 'Fríos a inscritos',
+          description: '% de leads fríos que terminan inscritos',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.inscritos, ctx.total);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Aún no hay leads para calcular la conversión.' : ''
+            };
+          }
+        },
+        {
+          key: 'Conversion_Por_Etapa',
+          label: 'Avance por etapa',
+          description: 'Porcentaje de avance en cada etapa del embudo de reactivación',
+          compute: ctx => {
+            const etapaRatios = [
+              { label: 'Reimpactación', value: safeDivide(ctx.reimpactados, ctx.total) },
+              { label: 'Respuesta', value: safeDivide(ctx.responded, ctx.reimpactados) },
+              { label: 'Interés', value: safeDivide(ctx.reactivados, ctx.responded) },
+              { label: 'Inscripción', value: safeDivide(ctx.inscritos, ctx.reactivados) }
+            ];
+            return {
+              value: ctx.total ? formatKpiPercent(safeDivide(ctx.responded, ctx.total) || 0) : '—',
+              extra: ctx.total ? 'Respondieron del total' : '',
+              list: etapaRatios.map(step => `${step.label}: ${step.value !== null ? formatKpiPercent(step.value) : '—'}`)
+            };
+          }
+        }
+      ]
+    },
+    Eficiencia_Operativa: {
+      label: 'Eficiencia operativa',
+      description: 'Esfuerzo necesario para reimpactar la base fría.',
+      metrics: [
+        {
+          key: 'Tiempo_Promedio_Contacto',
+          label: 'Tiempo promedio de contacto',
+          description: 'Tiempo promedio para volver a contactar a un lead frío',
+          compute: () => ({ value: '—', note: 'Pendiente de integrar tiempos de gestión desde CRM.' })
+        },
+        {
+          key: 'Intentos_Promedio_Por_Lead',
+          label: 'Intentos por lead',
+          description: 'Cantidad de intentos de contacto necesarios para obtener respuesta',
+          compute: () => ({ value: '—', note: 'Requiere registrar los intentos de contacto por lead.' })
+        },
+        {
+          key: 'Distribucion_Intentos',
+          label: 'Distribución de intentos',
+          description: 'Porcentaje de leads que requirieron 1, 2 o más intentos',
+          compute: () => ({ value: '—', note: 'Disponible al capturar los intentos de contacto en CRM.' })
+        }
+      ]
+    },
+    Rendimiento_Asesores: {
+      label: 'Rendimiento de asesores',
+      description: 'Seguimiento de la gestión por asesor en segunda vuelta.',
+      metrics: [
+        {
+          key: 'Leads_Reimpactados_Por_Asesor',
+          label: 'Leads reimpactados por asesor',
+          description: 'Cantidad de leads fríos gestionados por cada asesor',
+          compute: ctx => {
+            const top = ctx.asesorList
+              .filter(item => item.reimpactados > 0)
+              .sort((a, b) => b.reimpactados - a.reimpactados)
+              .slice(0, 3);
+            if(!top.length){
+              return { value: '—', note: 'Aún no hay leads reimpactados asignados a asesores.' };
+            }
+            return {
+              value: formatKpiNumber(top[0].reimpactados),
+              extra: `Mejor: ${top[0].name}`,
+              list: top.map(item => `${item.name}: ${formatKpiNumber(item.reimpactados)} leads`)
+            };
+          }
+        },
+        {
+          key: 'Conversion_Asesor',
+          label: 'Conversión por asesor',
+          description: 'Tasa de conversión por asesor en segunda vuelta',
+          compute: ctx => {
+            const top = ctx.asesorList
+              .filter(item => item.reimpactados > 0)
+              .map(item => ({
+                name: item.name,
+                ratio: safeDivide(item.inscritos, item.reimpactados),
+                inscritos: item.inscritos
+              }))
+              .filter(item => item.inscritos > 0 || (item.ratio !== null && item.ratio > 0))
+              .sort((a, b) => (b.ratio || 0) - (a.ratio || 0))
+              .slice(0, 3);
+            if(!top.length){
+              return { value: '—', note: 'No hay inscripciones registradas por asesor.' };
+            }
+            const best = top[0];
+            return {
+              value: best.ratio !== null ? formatKpiPercent(best.ratio) : '—',
+              extra: `Mejor: ${best.name}`,
+              list: top.map(item => `${item.name}: ${item.ratio !== null ? formatKpiPercent(item.ratio) : '—'} · ${formatKpiNumber(item.inscritos)} inscritos`)
+            };
+          }
+        },
+        {
+          key: 'Tiempo_Respuesta_Asesor',
+          label: 'Tiempo de respuesta',
+          description: 'Tiempo promedio de cada asesor en retomar un lead frío',
+          compute: () => ({ value: '—', note: 'Se integrará cuando el CRM comparta tiempos de respuesta por asesor.' })
+        }
+      ]
+    },
+    Salud_Base: {
+      label: 'Salud de la base',
+      description: 'Cobertura de la base fría disponible en CRM.',
+      metrics: [
+        {
+          key: 'Tamaño_Base_Fria',
+          label: 'Tamaño base fría',
+          description: 'Número total de leads fríos en CRM',
+          compute: ctx => ({ value: formatKpiNumber(ctx.total) })
+        },
+        {
+          key: 'Porcentaje_Base_Trabajada',
+          label: '% base trabajada',
+          description: '% de la base fría ya gestionada en segunda vuelta',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.reimpactados, ctx.total);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Carga leads para conocer el avance.' : ''
+            };
+          }
+        },
+        {
+          key: 'Porcentaje_Base_Pendiente',
+          label: '% base pendiente',
+          description: '% de la base fría aún sin reimpactar',
+          compute: ctx => {
+            const ratio = safeDivide(ctx.basePendiente, ctx.total);
+            return {
+              value: ratio !== null ? formatKpiPercent(ratio) : '—',
+              note: ratio === null ? 'Sin leads cargados para evaluar el pendiente.' : ''
+            };
+          }
+        }
+      ]
+    },
+    ROI: {
+      label: 'ROI de reactivación',
+      description: 'Relación entre inscripciones logradas y el esfuerzo de reimpacto.',
+      metrics: [
+        {
+          key: 'ROI_Reactivacion',
+          label: 'ROI reactivación',
+          description: 'Inscripciones obtenidas de leads fríos / costo y esfuerzo de reimpacto',
+          compute: () => ({ value: '—', note: 'Pendiente de integrar costos y horas invertidas en la reactivación.' })
+        }
+      ]
+    }
+  };
+
+  const KPI_ROLE_GROUPS = {
+    developer: Object.keys(KPI_GROUPS),
+    admin: Object.keys(KPI_GROUPS),
+    coordinador: Object.keys(KPI_GROUPS),
+    asesor: ['Base_Fria','Reactivacion','Conversion','Eficiencia_Operativa','Rendimiento_Asesores','Salud_Base']
+  };
+
+  const STORAGE_KEYS = {
+    profile: 'pulseProfile',
+    preferences: 'pulsePreferences',
+    password: 'pulsePasswordRequest',
+
+    favorites: 'pulseLeadFavorites',
+    recents: 'pulseLeadRecents',
+    whatsappTemplates: 'pulseWhatsappTemplates',
+    whatsappLastTemplate: 'pulseWhatsappLastTemplate',
+    emailTemplates: 'pulseEmailTemplates',
+    emailLastTemplate: 'pulseEmailLastTemplate',
+    advisorWhatsapp: 'pulseAdvisorWhatsapp',
+    integrationRelease: 'pulseIntegrationRelease'
+  };
+  const DEFAULT_PASSWORD_REQUEST = {
+    status: 'idle',
+    requestedAt: 0,
+    requestedBy: '',
+    approvedAt: 0,
+    approvedBy: '',
+    completedAt: 0,
+    completedBy: ''
+  };
+  const QUICK_ACCESS_FAVORITES_LIMIT = 20;
+  const QUICK_ACCESS_RECENTS_LIMIT = 10;
+  const WHATSAPP_TEMPLATE_LIMIT = 30;
+  const EMAIL_TEMPLATE_LIMIT = 30;
+  const CUSTOM_TEMPLATE_KEY = '__custom__';
+  const WHATSAPP_WEB_URL = 'https://web.whatsapp.com/';
+  const WHATSAPP_SESSION_DURATION_MS = 14 * 60 * 60 * 1000;
+  const DEFAULT_WHATSAPP_SESSION = { status: 'inactive', startedAt: 0, lastActiveAt: 0 };
+  let quickAccessFavorites = loadQuickAccessList(STORAGE_KEYS.favorites);
+  let quickAccessRecents = loadQuickAccessList(STORAGE_KEYS.recents);
+  let quickAccessInitialized = false;
+  let currentLeadRecord = null;
+  let whatsappTemplates = loadWhatsappTemplates();
+  let whatsappLastTemplateId = readStorageValue(STORAGE_KEYS.whatsappLastTemplate) || '';
+  let emailTemplates = loadEmailTemplates();
+  let emailLastTemplateId = readStorageValue(STORAGE_KEYS.emailLastTemplate) || '';
+  let advisorWhatsappNumber = readStorageValue(STORAGE_KEYS.advisorWhatsapp) || '';
+  let whatsappSessionState = loadWhatsappSessionState();
+  let whatsappTemplateFormEditingId = '';
+  let emailTemplateFormEditingId = '';
+  const whatsappModalState = { lead: null, digits: '', defaultMessage: '', onSend: null, selectedId: '' };
+  const emailModalState = { lead: null, email: '', defaultSubject: '', defaultBody: '', mailtoFallback: '', onSend: null, selectedId: '' };
+  let whatsappModalReady = false;
+  let whatsappWebModalReady = false;
+  let emailModalReady = false;
+
+  function normalizeLeadId(value){
+    return String(value || '').trim();
+  }
+
+  function loadQuickAccessList(key){
+    const stored = readStorageJSON(key);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(entry => ({
+        id: normalizeLeadId(entry.id),
+        nombre: String(entry.nombre || '').trim(),
+        etapa: String(entry.etapa || '').trim(),
+        campus: String(entry.campus || '').trim(),
+        programa: String(entry.programa || '').trim(),
+        base: String(entry.base || '').trim(),
+        updatedAt: Number(entry.updatedAt) || 0
+      }))
+      .filter(entry => entry.id);
+  }
+
+  function saveQuickAccessList(key, list, limit){
+    if(!Array.isArray(list)) return;
+    const trimmed = list.slice(0, limit);
+    writeStorageJSON(key, trimmed);
+  }
+
+  function summarizeLeadForQuickAccess(lead){
+    if(!lead) return null;
+    const id = normalizeLeadId(lead.id);
+    if(!id) return null;
+    const etapa = etapaGroup(lead.etapa);
+    return {
+      id,
+      nombre: String(lead.nombre || '').trim(),
+      etapa,
+      campus: String(lead.campus || '').trim(),
+      programa: String(lead.programa || '').trim(),
+      base: String(lead.base || state.sheet || '').trim(),
+      updatedAt: Date.now()
+    };
+  }
+
+  function isLeadFavorite(id){
+    if(!id) return false;
+    return quickAccessFavorites.some(entry => entry.id === id);
+  }
+
+  function updateQuickAccessUI(){
+    if(!quickAccessInitialized) return;
+    const favoritesContainer = el('#favoriteLeads');
+    const favoritesEmpty = el('#favoriteEmpty');
+    renderQuickAccessList(favoritesContainer, favoritesEmpty, quickAccessFavorites);
+    const recentsContainer = el('#recentLeads');
+    const recentsEmpty = el('#recentEmpty');
+    renderQuickAccessList(recentsContainer, recentsEmpty, quickAccessRecents);
+    updateFavoriteToggleState();
+  }
+
+  function renderQuickAccessList(container, emptyEl, list){
+    if(!container) return;
+    container.innerHTML = '';
+    if(!Array.isArray(list) || !list.length){
+      if(emptyEl) emptyEl.classList.remove('hidden');
+      return;
+    }
+    if(emptyEl) emptyEl.classList.add('hidden');
+    list.forEach(entry => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'quick-access__item';
+      button.dataset.leadId = entry.id;
+      if(entry.base) button.dataset.leadBase = entry.base;
+      const metaParts = [entry.etapa || '', entry.campus || '', entry.programa || ''].filter(Boolean);
+      button.innerHTML = `<span class="quick-access__item-name">${escapeHtml(entry.nombre || 'Sin nombre')}</span>`+
+        (metaParts.length ? `<span class="quick-access__item-meta">${escapeHtml(metaParts.join(' · '))}</span>` : '');
+      container.appendChild(button);
+    });
+  }
+
+  function updateFavoriteToggleState(){
+    const button = el('#favoriteToggle');
+    if(!button) return;
+    const leadId = currentLeadRecord ? normalizeLeadId(currentLeadRecord.id) : '';
+    if(!leadId){
+      button.disabled = true;
+      button.setAttribute('aria-pressed', 'false');
+      button.title = 'Agrega un lead a favoritos';
+      button.innerHTML = '<i class="bi bi-star" aria-hidden="true"></i>';
+      return;
+    }
+    button.disabled = false;
+    const favored = isLeadFavorite(leadId);
+    button.setAttribute('aria-pressed', favored ? 'true' : 'false');
+    button.title = favored ? 'Quitar de favoritos' : 'Agregar a favoritos';
+    const icon = favored ? 'bi-star-fill' : 'bi-star';
+    button.innerHTML = `<i class="bi ${icon}" aria-hidden="true"></i>`;
+  }
+
+  function rememberRecentLead(lead){
+    const summary = summarizeLeadForQuickAccess(lead);
+    if(!summary) return;
+    quickAccessRecents = quickAccessRecents.filter(entry => entry.id !== summary.id);
+    summary.updatedAt = Date.now();
+    quickAccessRecents.unshift(summary);
+    if(quickAccessRecents.length > QUICK_ACCESS_RECENTS_LIMIT){
+      quickAccessRecents = quickAccessRecents.slice(0, QUICK_ACCESS_RECENTS_LIMIT);
+    }
+    saveQuickAccessList(STORAGE_KEYS.recents, quickAccessRecents, QUICK_ACCESS_RECENTS_LIMIT);
+    updateQuickAccessUI();
+  }
+
+  function setLeadFavorite(lead, shouldAdd){
+    const summary = summarizeLeadForQuickAccess(lead);
+    if(!summary) return;
+    quickAccessFavorites = quickAccessFavorites.filter(entry => entry.id !== summary.id);
+    if(shouldAdd){
+      quickAccessFavorites.unshift(summary);
+      if(quickAccessFavorites.length > QUICK_ACCESS_FAVORITES_LIMIT){
+        quickAccessFavorites = quickAccessFavorites.slice(0, QUICK_ACCESS_FAVORITES_LIMIT);
+      }
+    }
+    saveQuickAccessList(STORAGE_KEYS.favorites, quickAccessFavorites, QUICK_ACCESS_FAVORITES_LIMIT);
+    updateQuickAccessUI();
+  }
+
+  async function openQuickAccessLead(entry){
+    if(!entry || !entry.id) return;
+    const targetBase = entry.base ? entry.base : state.sheet;
+    if(targetBase && targetBase !== state.sheet){
+      try{
+        await withGlobalLoading('Cargando leads…', async () => {
+          state.sheet = targetBase;
+          syncSheetSelectorsUI();
+          await loadLeads();
+        });
+        syncQuickAccessWithLeads();
+        populateAsesores();
+        populateCampuses();
+        refresh();
+      }catch(err){
+        console.error('No se pudo cambiar la base para el acceso rápido', err);
+      }
+    }
+    const lead = leads.find(item => normalizeLeadId(item.id) === entry.id);
+    if(lead){
+      openDetails(lead);
+      return;
+    }
+    alert('No encontramos este lead en la base actual. Verifica si sigue disponible.');
+  }
+
+  function initQuickAccessUI(){
+    if(quickAccessInitialized) return;
+    const favoritesContainer = el('#favoriteLeads');
+    if(favoritesContainer){
+      favoritesContainer.addEventListener('click', event => {
+        const button = event.target.closest('.quick-access__item');
+        if(!button) return;
+        const id = button.dataset.leadId || '';
+        const base = button.dataset.leadBase || '';
+        openQuickAccessLead({ id, base });
+      });
+    }
+    const recentsContainer = el('#recentLeads');
+    if(recentsContainer){
+      recentsContainer.addEventListener('click', event => {
+        const button = event.target.closest('.quick-access__item');
+        if(!button) return;
+        const id = button.dataset.leadId || '';
+        const base = button.dataset.leadBase || '';
+        openQuickAccessLead({ id, base });
+      });
+    }
+    const toggle = el('#favoriteToggle');
+    if(toggle){
+      toggle.addEventListener('click', () => {
+        if(!currentLeadRecord) return;
+        const leadId = normalizeLeadId(currentLeadRecord.id);
+        if(!leadId) return;
+        const shouldAdd = !isLeadFavorite(leadId);
+        setLeadFavorite(currentLeadRecord, shouldAdd);
+      });
+    }
+    quickAccessInitialized = true;
+    updateQuickAccessUI();
+  }
+
+  function syncQuickAccessWithLeads(){
+    if(!Array.isArray(leads) || !leads.length) return;
+    const map = new Map();
+    leads.forEach(lead => {
+      const id = normalizeLeadId(lead.id);
+      if(id) map.set(id, lead);
+    });
+    let favChanged = false;
+    quickAccessFavorites = quickAccessFavorites.map(entry => {
+      const lead = map.get(entry.id);
+      if(!lead) return entry;
+      const summary = summarizeLeadForQuickAccess(lead);
+      if(!summary) return entry;
+      const updated = { ...entry, ...summary, updatedAt: entry.updatedAt || summary.updatedAt };
+      if(entry.nombre !== updated.nombre || entry.etapa !== updated.etapa || entry.campus !== updated.campus || entry.programa !== updated.programa || entry.base !== updated.base){
+        favChanged = true;
+      }
+      return updated;
+    });
+    if(favChanged){
+      saveQuickAccessList(STORAGE_KEYS.favorites, quickAccessFavorites, QUICK_ACCESS_FAVORITES_LIMIT);
+    }
+    let recChanged = false;
+    quickAccessRecents = quickAccessRecents.map(entry => {
+      const lead = map.get(entry.id);
+      if(!lead) return entry;
+      const summary = summarizeLeadForQuickAccess(lead);
+      if(!summary) return entry;
+      const updated = { ...entry, ...summary, updatedAt: entry.updatedAt || summary.updatedAt };
+      if(entry.nombre !== updated.nombre || entry.etapa !== updated.etapa || entry.campus !== updated.campus || entry.programa !== updated.programa || entry.base !== updated.base){
+        recChanged = true;
+      }
+      return updated;
+    });
+    if(recChanged){
+      saveQuickAccessList(STORAGE_KEYS.recents, quickAccessRecents, QUICK_ACCESS_RECENTS_LIMIT);
+    }
+    updateQuickAccessUI();
+  }
+
+  function generateTemplateId(prefix){
+    const base = prefix || 'tpl';
+    return `${base}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function loadWhatsappTemplates(){
+    const stored = readStorageJSON(STORAGE_KEYS.whatsappTemplates);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(item => {
+        const id = item && item.id ? String(item.id).trim() : generateTemplateId('wa');
+        const name = item && item.name !== undefined ? String(item.name).trim() : '';
+        const message = item && (item.message !== undefined ? String(item.message) : String(item.body || '')).trim();
+        if(!id) return null;
+        return {
+          id,
+          name: name || 'Plantilla sin nombre',
+          message
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function saveWhatsappTemplates(list){
+    whatsappTemplates = Array.isArray(list) ? list.slice(0, WHATSAPP_TEMPLATE_LIMIT) : [];
+    writeStorageJSON(STORAGE_KEYS.whatsappTemplates, whatsappTemplates);
+  }
+
+  function loadEmailTemplates(){
+    const stored = readStorageJSON(STORAGE_KEYS.emailTemplates);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(item => {
+        const id = item && item.id ? String(item.id).trim() : generateTemplateId('email');
+        const name = item && item.name !== undefined ? String(item.name).trim() : '';
+        const subject = item && item.subject !== undefined ? String(item.subject).trim() : '';
+        const body = item && item.body !== undefined ? String(item.body).trim() : '';
+        if(!id) return null;
+        return {
+          id,
+          name: name || 'Plantilla sin nombre',
+          subject,
+          body
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function saveEmailTemplates(list){
+    emailTemplates = Array.isArray(list) ? list.slice(0, EMAIL_TEMPLATE_LIMIT) : [];
+    writeStorageJSON(STORAGE_KEYS.emailTemplates, emailTemplates);
+  }
+
+  function loadWhatsappSessionState(){
+    const stored = readStorageJSON(STORAGE_KEYS.whatsappSession);
+    if(!stored || typeof stored !== 'object'){
+      return { ...DEFAULT_WHATSAPP_SESSION };
+    }
+    return {
+      status: typeof stored.status === 'string' ? stored.status : 'inactive',
+      startedAt: Number(stored.startedAt) || 0,
+      lastActiveAt: Number(stored.lastActiveAt) || 0
+    };
+  }
+
+  function persistWhatsappSessionState(updates){
+    const current = whatsappSessionState && typeof whatsappSessionState === 'object'
+      ? { ...whatsappSessionState }
+      : { ...DEFAULT_WHATSAPP_SESSION };
+    const next = { ...current, ...updates };
+    const status = typeof next.status === 'string' ? next.status : 'inactive';
+    if(!status || status === 'inactive'){
+      whatsappSessionState = { ...DEFAULT_WHATSAPP_SESSION };
+      removeStorageKey(STORAGE_KEYS.whatsappSession);
+      return whatsappSessionState;
+    }
+    let startedAt = Number(next.startedAt) || Date.now();
+    let lastActiveAt = Number(next.lastActiveAt) || startedAt;
+    if(lastActiveAt < startedAt){
+      lastActiveAt = startedAt;
+    }
+    whatsappSessionState = {
+      status,
+      startedAt,
+      lastActiveAt
+    };
+    writeStorageJSON(STORAGE_KEYS.whatsappSession, whatsappSessionState);
+    return whatsappSessionState;
+  }
+
+  function getWhatsappSessionEffectiveStatus(){
+    const state = whatsappSessionState && typeof whatsappSessionState === 'object'
+      ? whatsappSessionState
+      : DEFAULT_WHATSAPP_SESSION;
+    const status = typeof state.status === 'string' ? state.status : 'inactive';
+    const startedAt = Number(state.startedAt) || 0;
+    const lastActiveAt = Number(state.lastActiveAt) || startedAt;
+    const reference = lastActiveAt || startedAt;
+    if(!reference){
+      return 'inactive';
+    }
+    if(status === 'inactive'){
+      return 'inactive';
+    }
+    if(Date.now() - reference >= WHATSAPP_SESSION_DURATION_MS){
+      return 'expired';
+    }
+    if(status === 'pairing'){
+      return 'pairing';
+    }
+    if(status === 'expired'){
+      return 'expired';
+    }
+    return 'active';
+  }
+
+  function formatWhatsappSessionTimestamp(timestamp){
+    if(!timestamp) return '';
+    try{
+      if(CONTACT_TIMESTAMP_FORMAT){
+        return CONTACT_TIMESTAMP_FORMAT.format(new Date(timestamp));
+      }
+    }catch(err){
+      console.warn('No se pudo formatear la marca de tiempo de WhatsApp.', err);
+    }
+    try{
+      return new Date(timestamp).toLocaleString('es-MX');
+    }catch(err){
+      return '';
+    }
+  }
+      }else{
+        metaText = 'Sesión activa. La sesión caduca tras 14 horas de inactividad.';
+      }
+    }else if(effectiveStatus === 'expired'){
+      statusText = 'Sesión expirada';
+      statusIcon = 'bi-exclamation-triangle';
+      metaText = 'La sesión anterior caducó. Inicia un nuevo emparejamiento para continuar.';
+    }
+    if(statusContainer){
+      statusContainer.classList.remove('integration-status--connected', 'integration-status--beta');
+      statusContainer.classList.add(statusClass);
+      const iconEl = statusContainer.querySelector('i');
+      if(iconEl){
+        iconEl.className = `bi ${statusIcon}`;
+        iconEl.setAttribute('aria-hidden', 'true');
+      }
+      const textEl = statusContainer.querySelector('span');
+      if(textEl){
+        textEl.textContent = statusText;
+      }
+    }
+    if(metaContainer){
+      metaContainer.textContent = metaText;
+    }
+    if(card){
+      card.setAttribute('data-session-status', effectiveStatus);
+    }
+  }
+
+  function initWhatsappWebModal(){
+    if(whatsappWebModalReady) return;
+    const overlay = el('#whatsappWebModal');
+    if(!overlay) return;
+    overlay.addEventListener('click', event => {
+      if(event.target === overlay){
+        hideWhatsappWebModal();
+      }
+    });
+    const closeBtn = el('#whatsappWebClose');
+    if(closeBtn) closeBtn.addEventListener('click', hideWhatsappWebModal);
+    const handleEscape = event => {
+      if(event.key !== 'Escape') return;
+      if(!overlay.classList.contains('active')) return;
+      event.preventDefault();
+      hideWhatsappWebModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    whatsappWebModalReady = true;
+  }
+
+  function hideWhatsappWebModal(){
+    const overlay = el('#whatsappWebModal');
+    if(overlay){
+      overlay.classList.remove('active');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+    document.body.classList.remove('modal-open');
+    const frame = el('#whatsappWebFrame');
+    if(frame){
+      frame.src = 'about:blank';
+    }
+  }
+
+  function showWhatsappWebModal(){
+    initWhatsappWebModal();
+    const overlay = el('#whatsappWebModal');
+    const frame = el('#whatsappWebFrame');
+    if(!overlay || !frame){
+      return false;
+    }
+    frame.src = WHATSAPP_WEB_URL;
+    overlay.classList.add('active');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    return true;
+  }
+
+  function openWhatsappWebPopup(){
+    try{
+      const popup = window.open(WHATSAPP_WEB_URL, '_blank', 'noopener,noreferrer');
+      if(popup){
+        if(typeof popup.focus === 'function'){
+          popup.focus();
+        }
+        return true;
+      }
+      const body = document.body;
+      if(body){
+        const link = document.createElement('a');
+        link.href = WHATSAPP_WEB_URL;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.style.position = 'absolute';
+        link.style.width = '1px';
+        link.style.height = '1px';
+        link.style.overflow = 'hidden';
+        link.style.clip = 'rect(0 0 0 0)';
+        body.appendChild(link);
+        link.click();
+        const cleanup = () => {
+          if(link.parentNode){
+            link.parentNode.removeChild(link);
+          }
+        };
+        if(typeof window.requestAnimationFrame === 'function'){
+          window.requestAnimationFrame(cleanup);
+        }else{
+          setTimeout(cleanup, 0);
+        }
+        return true;
+      }
+      window.location.assign(WHATSAPP_WEB_URL);
+      return true;
+    }catch(err){
+      console.error('No se pudo abrir WhatsApp Web.', err);
+      alert('No se pudo abrir WhatsApp Web en este navegador.');
+      return false;
+    }
+  }
+
+  function openWhatsappWebExperience(){
+    if(showWhatsappWebModal()){
+      return true;
+    }
+    return openWhatsappWebPopup();
+  }
+    if(openBtn){
+      openBtn.addEventListener('click', handleWhatsappIntegrationOpen);
+    }
+    updateWhatsappIntegrationCard();
+  }
+
+  function resetWhatsappTemplateForm(){
+    const form = el('#waTemplateForm');
+    if(!form) return;
+    form.classList.add('hidden');
+    form.reset();
+    whatsappTemplateFormEditingId = '';
+  }
+
+  function renderWhatsappTemplateList(selectedId){
+    const list = el('#waTemplateList');
+    if(!list) return;
+    list.innerHTML = '';
+    if(!whatsappTemplates.length){
+      list.innerHTML = '<li class="template-list__empty">No tienes plantillas guardadas.</li>';
+      return;
+    }
+    whatsappTemplates.forEach(template => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'template-list__item';
+      button.dataset.templateId = template.id;
+      const preview = template.message ? `<div class="template-list__meta">${escapeHtml(template.message.slice(0, 120))}</div>` : '';
+      button.innerHTML = `<div><strong>${escapeHtml(template.name)}</strong>${preview}</div>`;
+      li.appendChild(button);
+      const actions = document.createElement('div');
+      actions.className = 'template-list__actions';
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.dataset.action = 'edit';
+      editBtn.dataset.templateId = template.id;
+      editBtn.textContent = 'Editar';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.dataset.action = 'delete';
+      deleteBtn.dataset.templateId = template.id;
+      deleteBtn.textContent = 'Eliminar';
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+      li.appendChild(actions);
+      list.appendChild(li);
+    });
+    if(selectedId){
+      selectWhatsappTemplate(selectedId);
+    }
+  }
+
+  function selectWhatsappTemplate(templateId){
+    const messageInput = el('#waMessage');
+    if(!messageInput) return;
+    const template = whatsappTemplates.find(item => item.id === templateId);
+    if(!template){
+      whatsappModalState.selectedId = '';
+      return;
+    }
+    messageInput.value = template.message || '';
+    whatsappModalState.selectedId = template.id;
+  }
+
+  function startWhatsappTemplateEdit(templateId){
+    const form = el('#waTemplateForm');
+    const nameInput = el('#waTemplateName');
+    const contentInput = el('#waTemplateContent');
+    if(!form || !nameInput || !contentInput) return;
+    const template = whatsappTemplates.find(item => item.id === templateId);
+    whatsappTemplateFormEditingId = template ? template.id : '';
+    if(template){
+      nameInput.value = template.name || '';
+      contentInput.value = template.message || '';
+    }else{
+      nameInput.value = '';
+      contentInput.value = '';
+    }
+    form.classList.remove('hidden');
+    nameInput.focus();
+  }
+
+  function initWhatsAppModal(){
+    if(whatsappModalReady) return;
+    const overlay = el('#whatsappTemplateModal');
+    const closeBtn = el('#waModalClose');
+    const cancelBtn = el('#waCancelBtn');
+    const sendBtn = el('#waSendBtn');
+    const createBtn = el('#waCreateTemplate');
+    const list = el('#waTemplateList');
+    const form = el('#waTemplateForm');
+    const formCancel = el('#waTemplateCancel');
+    const formDelete = el('#waTemplateDelete');
+    if(overlay){
+      overlay.addEventListener('click', event => {
+        if(event.target === overlay) hideWhatsAppModal();
+      });
+    }
+    if(closeBtn) closeBtn.addEventListener('click', hideWhatsAppModal);
+    if(cancelBtn) cancelBtn.addEventListener('click', hideWhatsAppModal);
+    if(sendBtn) sendBtn.addEventListener('click', handleWhatsappSend);
+    if(createBtn) createBtn.addEventListener('click', () => {
+      startWhatsappTemplateEdit('');
+    });
+    if(list){
+      list.addEventListener('click', event => {
+        const target = event.target.closest('button');
+        if(!target) return;
+        const id = target.dataset.templateId || '';
+        const action = target.dataset.action || '';
+        if(action === 'edit'){
+          startWhatsappTemplateEdit(id);
+          return;
+        }
+        if(action === 'delete'){
+          whatsappTemplateFormEditingId = id;
+          handleWhatsappTemplateDelete();
+          return;
+        }
+        selectWhatsappTemplate(id);
+        whatsappLastTemplateId = id;
+      });
+    }
+    if(form) form.addEventListener('submit', handleWhatsappTemplateSave);
+    if(formCancel) formCancel.addEventListener('click', resetWhatsappTemplateForm);
+    if(formDelete) formDelete.addEventListener('click', handleWhatsappTemplateDelete);
+    whatsappModalReady = true;
+  }
+
+  function hideWhatsAppModal(){
+    const overlay = el('#whatsappTemplateModal');
+    if(overlay){
+      overlay.classList.remove('active');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+    document.body.classList.remove('modal-open');
+    resetWhatsappTemplateForm();
+    whatsappModalState.lead = null;
+    whatsappModalState.digits = '';
+    whatsappModalState.defaultMessage = '';
+    whatsappModalState.onSend = null;
+    whatsappModalState.selectedId = '';
+  }
+
+  function showWhatsAppModal(options){
+    initWhatsAppModal();
+    const overlay = el('#whatsappTemplateModal');
+    const messageInput = el('#waMessage');
+    if(!overlay || !messageInput) return;
+    const digits = String(options?.digits || '').replace(/\D/g, '');
+    if(!digits){
+      alert('No hay un número válido de WhatsApp para este lead.');
+      return;
+    }
+    whatsappModalState.lead = options?.lead || null;
+    whatsappModalState.digits = digits;
+    whatsappModalState.defaultMessage = options?.defaultMessage || '';
+    whatsappModalState.onSend = typeof options?.onSend === 'function' ? options.onSend : null;
+    whatsappModalState.selectedId = '';
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList(whatsappLastTemplateId && whatsappLastTemplateId !== CUSTOM_TEMPLATE_KEY ? whatsappLastTemplateId : '');
+    if(whatsappLastTemplateId === CUSTOM_TEMPLATE_KEY && whatsappModalState.defaultMessage){
+      messageInput.value = whatsappModalState.defaultMessage;
+    }else if(whatsappLastTemplateId && whatsappLastTemplateId !== CUSTOM_TEMPLATE_KEY){
+      selectWhatsappTemplate(whatsappLastTemplateId);
+    }else{
+      messageInput.value = whatsappModalState.defaultMessage || '';
+    }
+    overlay.classList.add('active');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    messageInput.focus();
+  }
+
+  function handleWhatsappTemplateSave(event){
+    event.preventDefault();
+    const nameInput = el('#waTemplateName');
+    const contentInput = el('#waTemplateContent');
+    if(!nameInput || !contentInput) return;
+    const name = nameInput.value.trim();
+    const content = contentInput.value.trim();
+    if(!content){
+      alert('Ingresa el contenido de la plantilla.');
+      return;
+    }
+    let savedId = whatsappTemplateFormEditingId;
+    if(whatsappTemplateFormEditingId){
+      const existing = whatsappTemplates.find(item => item.id === whatsappTemplateFormEditingId);
+      if(existing){
+        existing.name = name || existing.name;
+        existing.message = content;
+      }
+    }else{
+      const id = generateTemplateId('wa');
+      whatsappTemplates.unshift({ id, name: name || 'Plantilla sin nombre', message: content });
+      savedId = id;
+    }
+    saveWhatsappTemplates(whatsappTemplates);
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList(savedId);
+    if(savedId){
+      whatsappLastTemplateId = savedId;
+      writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, savedId);
+    }
+  }
+
+  function handleWhatsappTemplateDelete(){
+    if(!whatsappTemplateFormEditingId) return;
+    if(!confirm('¿Eliminar la plantilla seleccionada?')) return;
+    whatsappTemplates = whatsappTemplates.filter(item => item.id !== whatsappTemplateFormEditingId);
+    saveWhatsappTemplates(whatsappTemplates);
+    if(whatsappLastTemplateId === whatsappTemplateFormEditingId){
+      whatsappLastTemplateId = '';
+      writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, '');
+    }
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList('');
+  }
+
+  function handleWhatsappSend(){
+    const messageInput = el('#waMessage');
+    if(!messageInput) return;
+    const digits = whatsappModalState.digits;
+    if(!digits){
+      alert('No hay un número válido de WhatsApp para este lead.');
+      return;
+    }
+    const leadName = String(whatsappModalState.lead?.nombre || '').trim();
+    let message = messageInput.value.trim();
+    if(!message){
+      message = whatsappModalState.defaultMessage || '';
+    }
+    if(leadName){
+      if(message.includes('{{nombre}}')){
+        message = message.replace(/\{\{nombre\}\}/gi, leadName);
+      }else{
+        message = `${leadName} ${message}`.trim();
+      }
+    }
+    if(!message){
+      alert('Escribe un mensaje para enviar.');
+      return;
+    }
+    const url = `https://wa.me/${digits}?text=${encodeURIComponent(message)}`;
+    window.open(url, '_blank', 'noopener');
+    const templateKey = whatsappModalState.selectedId || CUSTOM_TEMPLATE_KEY;
+    whatsappLastTemplateId = templateKey;
+    writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, templateKey);
+    if(typeof whatsappModalState.onSend === 'function'){
+      whatsappModalState.onSend();
+    }
+    hideWhatsAppModal();
+  }
+
+  function resetEmailTemplateForm(){
+    const form = el('#emailTemplateForm');
+    if(!form) return;
+    form.classList.add('hidden');
+    form.reset();
+    emailTemplateFormEditingId = '';
+  }
+
+  function renderEmailTemplateList(selectedId){
+    const list = el('#emailTemplateList');
+    if(!list) return;
+    list.innerHTML = '';
+    if(!emailTemplates.length){
+      list.innerHTML = '<li class="template-list__empty">No tienes plantillas guardadas.</li>';
+      return;
+    }
+    emailTemplates.forEach(template => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'template-list__item';
+      button.dataset.templateId = template.id;
+      const preview = template.body ? `<div class="template-list__meta">${escapeHtml(template.body.slice(0, 120))}</div>` : '';
+      button.innerHTML = `<div><strong>${escapeHtml(template.name)}</strong>${preview}</div>`;
+      li.appendChild(button);
+      const actions = document.createElement('div');
+      actions.className = 'template-list__actions';
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.dataset.action = 'edit';
+      editBtn.dataset.templateId = template.id;
+      editBtn.textContent = 'Editar';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.dataset.action = 'delete';
+      deleteBtn.dataset.templateId = template.id;
+      deleteBtn.textContent = 'Eliminar';
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+      li.appendChild(actions);
+      list.appendChild(li);
+    });
+    if(selectedId){
+      selectEmailTemplate(selectedId);
+    }
+  }
+
+  function selectEmailTemplate(templateId){
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    if(!subjectInput || !bodyInput) return;
+    const template = emailTemplates.find(item => item.id === templateId);
+    if(!template){
+      emailModalState.selectedId = '';
+      return;
+    }
+    subjectInput.value = template.subject || '';
+    bodyInput.value = template.body || '';
+    emailModalState.selectedId = template.id;
+  }
+
+  function startEmailTemplateEdit(templateId){
+    const form = el('#emailTemplateForm');
+    const nameInput = el('#emailTemplateName');
+    const subjectInput = el('#emailTemplateSubject');
+    const bodyInput = el('#emailTemplateBody');
+    if(!form || !nameInput || !subjectInput || !bodyInput) return;
+    const template = emailTemplates.find(item => item.id === templateId);
+    emailTemplateFormEditingId = template ? template.id : '';
+    if(template){
+      nameInput.value = template.name || '';
+      subjectInput.value = template.subject || '';
+      bodyInput.value = template.body || '';
+    }else{
+      nameInput.value = '';
+      subjectInput.value = '';
+      bodyInput.value = '';
+    }
+    form.classList.remove('hidden');
+    nameInput.focus();
+  }
+
+  function initEmailModal(){
+    if(emailModalReady) return;
+    const overlay = el('#emailTemplateModal');
+    const closeBtn = el('#emailModalClose');
+    const cancelBtn = el('#emailCancelBtn');
+    const gmailBtn = el('#emailGmailBtn');
+    const mailtoBtn = el('#emailMailtoBtn');
+    const createBtn = el('#emailCreateTemplate');
+    const list = el('#emailTemplateList');
+    const form = el('#emailTemplateForm');
+    const formCancel = el('#emailTemplateCancel');
+    const formDelete = el('#emailTemplateDelete');
+    const advisorInput = el('#advisorWhatsapp');
+    if(overlay){
+      overlay.addEventListener('click', event => {
+        if(event.target === overlay) hideEmailModal();
+      });
+    }
+    if(closeBtn) closeBtn.addEventListener('click', hideEmailModal);
+    if(cancelBtn) cancelBtn.addEventListener('click', hideEmailModal);
+    if(gmailBtn) gmailBtn.addEventListener('click', () => handleEmailSend('gmail'));
+    if(mailtoBtn) mailtoBtn.addEventListener('click', () => handleEmailSend('mailto'));
+    if(createBtn) createBtn.addEventListener('click', () => startEmailTemplateEdit(''));
+    if(list){
+      list.addEventListener('click', event => {
+        const target = event.target.closest('button');
+        if(!target) return;
+        const id = target.dataset.templateId || '';
+        const action = target.dataset.action || '';
+        if(action === 'edit'){
+          startEmailTemplateEdit(id);
+          return;
+        }
+        if(action === 'delete'){
+          emailTemplateFormEditingId = id;
+          handleEmailTemplateDelete();
+          return;
+        }
+        selectEmailTemplate(id);
+        emailLastTemplateId = id;
+      });
+    }
+    if(form) form.addEventListener('submit', handleEmailTemplateSave);
+    if(formCancel) formCancel.addEventListener('click', resetEmailTemplateForm);
+    if(formDelete) formDelete.addEventListener('click', handleEmailTemplateDelete);
+    if(advisorInput){
+      advisorInput.addEventListener('blur', () => {
+        const normalized = normalizeWhatsappDigits(advisorInput.value);
+        advisorWhatsappNumber = normalized;
+        writeStorageValue(STORAGE_KEYS.advisorWhatsapp, normalized);
+        advisorInput.value = normalized;
+      });
+    }
+    emailModalReady = true;
+  }
+
+  function hideEmailModal(){
+    const overlay = el('#emailTemplateModal');
+    if(overlay){
+      overlay.classList.remove('active');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+    document.body.classList.remove('modal-open');
+    resetEmailTemplateForm();
+    emailModalState.lead = null;
+    emailModalState.email = '';
+    emailModalState.defaultSubject = '';
+    emailModalState.defaultBody = '';
+    emailModalState.mailtoFallback = '';
+    emailModalState.onSend = null;
+    emailModalState.selectedId = '';
+  }
+
+  function showEmailModal(options){
+    initEmailModal();
+    const overlay = el('#emailTemplateModal');
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    const advisorInput = el('#advisorWhatsapp');
+    if(!overlay || !subjectInput || !bodyInput) return;
+    const email = String(options?.email || '').trim();
+    if(!email){
+      alert('No hay un correo válido para este lead.');
+      return;
+    }
+    emailModalState.lead = options?.lead || null;
+    emailModalState.email = email;
+    emailModalState.defaultSubject = options?.defaultSubject || '';
+    emailModalState.defaultBody = options?.defaultBody || '';
+    emailModalState.mailtoFallback = options?.mailtoFallback || '';
+    emailModalState.onSend = typeof options?.onSend === 'function' ? options.onSend : null;
+    emailModalState.selectedId = '';
+    resetEmailTemplateForm();
+    renderEmailTemplateList(emailLastTemplateId && emailLastTemplateId !== CUSTOM_TEMPLATE_KEY ? emailLastTemplateId : '');
+    if(emailLastTemplateId === CUSTOM_TEMPLATE_KEY){
+      subjectInput.value = emailModalState.defaultSubject || '';
+      bodyInput.value = emailModalState.defaultBody || '';
+    }else if(emailLastTemplateId){
+      selectEmailTemplate(emailLastTemplateId);
+    }else{
+      subjectInput.value = emailModalState.defaultSubject || '';
+      bodyInput.value = emailModalState.defaultBody || '';
+    }
+    if(advisorInput){
+      advisorInput.value = advisorWhatsappNumber;
+    }
+    overlay.classList.add('active');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    subjectInput.focus();
+  }
+
+  function handleEmailTemplateSave(event){
+    event.preventDefault();
+    const nameInput = el('#emailTemplateName');
+    const subjectInput = el('#emailTemplateSubject');
+    const bodyInput = el('#emailTemplateBody');
+    if(!nameInput || !subjectInput || !bodyInput) return;
+    const name = nameInput.value.trim();
+    const subject = subjectInput.value.trim();
+    const body = bodyInput.value.trim();
+    if(!subject || !body){
+      alert('Completa asunto y mensaje para guardar la plantilla.');
+      return;
+    }
+    let savedId = emailTemplateFormEditingId;
+    if(emailTemplateFormEditingId){
+      const existing = emailTemplates.find(item => item.id === emailTemplateFormEditingId);
+      if(existing){
+        existing.name = name || existing.name;
+        existing.subject = subject;
+        existing.body = body;
+      }
+    }else{
+      const id = generateTemplateId('email');
+      emailTemplates.unshift({ id, name: name || 'Plantilla sin nombre', subject, body });
+      savedId = id;
+    }
+    saveEmailTemplates(emailTemplates);
+    resetEmailTemplateForm();
+    renderEmailTemplateList(savedId);
+    if(savedId){
+      emailLastTemplateId = savedId;
+      writeStorageValue(STORAGE_KEYS.emailLastTemplate, savedId);
+    }
+  }
+
+  function handleEmailTemplateDelete(){
+    if(!emailTemplateFormEditingId) return;
+    if(!confirm('¿Eliminar la plantilla seleccionada?')) return;
+    emailTemplates = emailTemplates.filter(item => item.id !== emailTemplateFormEditingId);
+    saveEmailTemplates(emailTemplates);
+    if(emailLastTemplateId === emailTemplateFormEditingId){
+      emailLastTemplateId = '';
+      writeStorageValue(STORAGE_KEYS.emailLastTemplate, '');
+    }
+    resetEmailTemplateForm();
+    renderEmailTemplateList('');
+  }
+
+  function handleEmailSend(mode){
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    const advisorInput = el('#advisorWhatsapp');
+    if(!subjectInput || !bodyInput) return;
+    const email = emailModalState.email;
+    if(!email){
+      alert('No hay un correo válido para este lead.');
+      return;
+    }
+    let subject = subjectInput.value.trim() || emailModalState.defaultSubject || '';
+    let body = bodyInput.value.trim() || emailModalState.defaultBody || '';
+    const leadName = String(emailModalState.lead?.nombre || '').trim();
+    const advisorRaw = advisorInput ? advisorInput.value : advisorWhatsappNumber;
+    const advisorDigits = normalizeWhatsappDigits(advisorRaw);
+    advisorWhatsappNumber = advisorDigits;
+    if(advisorInput) advisorInput.value = advisorDigits;
+    writeStorageValue(STORAGE_KEYS.advisorWhatsapp, advisorDigits);
+    const whatsappLink = advisorDigits ? `https://wa.me/${advisorDigits}` : '';
+    if(leadName){
+      if(subject.includes('{{nombre}}')){
+        subject = subject.replace(/\{\{nombre\}\}/gi, leadName);
+      }
+      if(body.includes('{{nombre}}')){
+        body = body.replace(/\{\{nombre\}\}/gi, leadName);
+      }else{
+        const greeting = `Hola ${leadName},`;
+        body = body ? `${greeting}\n\n${body}` : greeting;
+      }
+    }
+    if(whatsappLink){
+      if(subject.includes('{{whatsapp}}')){
+        subject = subject.replace(/\{\{whatsapp\}\}/gi, whatsappLink);
+      }
+      if(body.includes('{{whatsapp}}')){
+        body = body.replace(/\{\{whatsapp\}\}/gi, whatsappLink);
+      }else{
+        body = `${body}\n\nContáctame también por WhatsApp: ${whatsappLink}`.trim();
+      }
+    }else{
+      subject = subject.replace(/\{\{whatsapp\}\}/gi, '').trim();
+      body = body.replace(/\{\{whatsapp\}\}/gi, '').trim();
+    }
+    if(!subject || !body){
+      alert('Completa asunto y mensaje para enviar el correo.');
+      return;
+    }
+    const encodedSubject = encodeURIComponent(subject);
+    const encodedBody = encodeURIComponent(body);
+    if(mode === 'gmail'){
+      const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(email)}&su=${encodedSubject}&body=${encodedBody}`;
+      window.open(gmailUrl, '_blank', 'noopener');
+    }else{
+      const mailtoUrl = `mailto:${encodeURIComponent(email)}?subject=${encodedSubject}&body=${encodedBody}`;
+      window.location.href = mailtoUrl;
+    }
+    const templateKey = emailModalState.selectedId || CUSTOM_TEMPLATE_KEY;
+    emailLastTemplateId = templateKey;
+    writeStorageValue(STORAGE_KEYS.emailLastTemplate, templateKey);
+    if(typeof emailModalState.onSend === 'function'){
+      emailModalState.onSend();
+    }
+    hideEmailModal();
+  }
+
+  function normalizeWhatsappDigits(value){
+    const text = String(value || '').trim();
+    if(!text) return '';
+    const parsed = parsePhone(text);
+    if(parsed && parsed.wa){
+      return parsed.wa.replace(/\D/g, '');
+    }
+    return text.replace(/\D/g, '');
+  }
+  function clearLegacyThemeKey(){
+    try{
+      localStorage.removeItem('pulseTheme');
+    }catch(err){
+      /* noop */
+    }
+  }
+  function loadStoredProfile(){
+    const stored = readStorageJSON(STORAGE_KEYS.profile);
+    if(stored && typeof stored === 'object'){
+      return { ...DEFAULT_PROFILE, ...stored };
+    }
+    return { ...DEFAULT_PROFILE };
+  }
+  function loadStoredPreferences(){
+    const stored = readStorageJSON(STORAGE_KEYS.preferences);
+    let prefs = { ...DEFAULT_PREFERENCES, ...(stored && typeof stored === 'object' ? stored : {}) };
+    if((!stored || typeof stored.reducedMotion === 'undefined') && typeof window !== 'undefined' && window.matchMedia){
+      const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if(motionQuery.matches){
+        prefs.reducedMotion = true;
+      }
+    }
+    try{
+      const legacyTheme = localStorage.getItem('pulseTheme');
+      if(legacyTheme && !prefs.theme){
+        prefs.theme = legacyTheme;
+      }
+    }catch(err){
+      /* ignore legacy read */
+    }
+    return prefs;
+  }
+  function loadStoredLeadTags(){
+    const stored = readStorageJSON(STORAGE_KEYS.leadTags);
+    return stored && typeof stored === 'object' ? stored : {};
+  }
+  function loadStoredReassignmentDecisions(){
+    const stored = readStorageJSON(STORAGE_KEYS.reassignments);
+    return stored && typeof stored === 'object' ? stored : {};
+  }
+  function getCurrentUserStorageKey(){
+    if(currentUser){
+      if(currentUser.userId){
+        return String(currentUser.userId).trim().toLowerCase();
+      }
+      if(currentUser.email){
+        return String(currentUser.email).trim().toLowerCase();
+      }
+    }
+    return 'anon';
+  }
+  function getUserLeadTagStore(create = true){
+    const key = getCurrentUserStorageKey();
+    if(!customTagStore || typeof customTagStore !== 'object'){
+      customTagStore = {};
+    }
+    if(!customTagStore[key]){
+      if(!create) return null;
+      customTagStore[key] = {};
+    }
+    return customTagStore[key];
+  }
+  function getUserReassignmentStore(create = true){
+    const key = getCurrentUserStorageKey();
+    if(!storedReassignmentDecisions || typeof storedReassignmentDecisions !== 'object'){
+      storedReassignmentDecisions = {};
+    }
+    if(!storedReassignmentDecisions[key]){
+      if(!create) return null;
+      storedReassignmentDecisions[key] = {};
+    }
+    return storedReassignmentDecisions[key];
+  }
+  function generateTagId(){
+    return `tag-${Date.now().toString(36)}-${Math.random().toString(36).slice(2,8)}`;
+  }
+  function sanitizeTagColor(value){
+    const text = String(value || '').trim();
+    if(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(text)) return text;
+    return DEFAULT_TAG_COLOR;
+  }
+  function normalizeTagEntry(tag){
+    if(!tag || typeof tag !== 'object') return null;
+    const label = String(tag.label || '').trim();
+    if(!label) return null;
+    return {
+      id: tag.id || generateTagId(),
+      label,
+      color: sanitizeTagColor(tag.color)
+    };
+  }
+  function getLeadTagsForLead(leadId){
+    const id = String(leadId || '').trim();
+    if(!id) return [];
+    const store = getUserLeadTagStore(false);
+    if(!store || typeof store !== 'object') return [];
+    const tags = store[id];
+    return Array.isArray(tags) ? tags.slice() : [];
+  }
+  function saveLeadTagsForLead(leadId, tags){
+    const id = String(leadId || '').trim();
+    if(!id) return;
+    const store = getUserLeadTagStore(true);
+    const normalized = (Array.isArray(tags) ? tags : [])
+      .map(normalizeTagEntry)
+      .filter(Boolean);
+    if(normalized.length){
+      store[id] = normalized;
+    }else{
+      delete store[id];
+    }
+    writeStorageJSON(STORAGE_KEYS.leadTags, customTagStore);
+  }
+  function getStoredReassignmentDecision(leadId){
+    const id = String(leadId || '').trim();
+    if(!id) return null;
+    const store = getUserReassignmentStore(false);
+    const decision = store && store[id];
+    return decision && typeof decision === 'object' ? { ...decision } : null;
+  }
+  function saveReassignmentDecision(leadId, decision){
+    const id = String(leadId || '').trim();
+    if(!id) return;
+    const store = getUserReassignmentStore(true);
+    if(decision && typeof decision === 'object'){
+      store[id] = { ...decision, updatedAt: decision.updatedAt || Date.now() };
+    }else{
+      delete store[id];
+    }
+    writeStorageJSON(STORAGE_KEYS.reassignments, storedReassignmentDecisions);
+  }
+  function clearReassignmentDecision(leadId){
+    const id = String(leadId || '').trim();
+    if(!id) return;
+    const store = getUserReassignmentStore(false);
+    if(store && store[id]){
+      delete store[id];
+      writeStorageJSON(STORAGE_KEYS.reassignments, storedReassignmentDecisions);
+    }
+  }
+  customTagStore = loadStoredLeadTags();
+  storedReassignmentDecisions = loadStoredReassignmentDecisions();
+  function loadStoredPasswordRequest(){
+    const stored = readStorageJSON(STORAGE_KEYS.password);
+    if(stored && typeof stored === 'object'){
+      const normalized = { ...DEFAULT_PASSWORD_REQUEST };
+      if(typeof stored.status === 'string') normalized.status = stored.status;
+      if(typeof stored.requestedAt === 'number') normalized.requestedAt = stored.requestedAt;
+      if(typeof stored.requestedBy === 'string') normalized.requestedBy = stored.requestedBy;
+      if(typeof stored.approvedAt === 'number') normalized.approvedAt = stored.approvedAt;
+      if(typeof stored.approvedBy === 'string') normalized.approvedBy = stored.approvedBy;
+      if(typeof stored.completedAt === 'number') normalized.completedAt = stored.completedAt;
+      if(typeof stored.completedBy === 'string') normalized.completedBy = stored.completedBy;
+      if(!normalized.requestedAt && typeof stored.timestamp === 'number'){
+        normalized.requestedAt = stored.timestamp;
+      }
+      if(!normalized.status){
+        if(normalized.completedAt) normalized.status = 'completed';
+        else if(normalized.approvedAt) normalized.status = 'approved';
+        else if(normalized.requestedAt) normalized.status = 'requested';
+      }
+      return normalized;
+    }
+    if(typeof stored === 'number' && stored > 0){
+      return { ...DEFAULT_PASSWORD_REQUEST, status: 'requested', requestedAt: stored };
+    }
+    return { ...DEFAULT_PASSWORD_REQUEST };
+  }
+  function handleSystemThemeChange(){
+    if((userPreferences.theme || 'system') === 'system'){
+      applyTheme();
+    }
+  }
+  function resolveTheme(themePref){
+    const pref = themePref || 'system';
+    return pref === 'system' ? (systemThemeQuery.matches ? 'dark' : 'light') : pref;
+  }
+  function applyPreferences(){
+    applyTheme();
+    applyLanguage();
+    applyDensity();
+    applyEcoMode();
+    applyMotionPreference();
+    applyFontScale();
+    applyAccentPreference();
+    applyBoardLayoutPreference();
+    applyContrastPreference();
+    applyLeadIdPreference();
+  }
+  function applyTheme(){
+    const pref = userPreferences.theme || 'system';
+    const resolved = resolveTheme(pref);
+    document.documentElement.setAttribute('data-theme', resolved);
+    document.documentElement.setAttribute('data-theme-pref', pref);
+    document.documentElement.style.setProperty('color-scheme', resolved === 'dark' ? 'dark' : 'light');
+    const body = document.body;
+    if(body){
+      body.dataset.theme = resolved;
+    }
+    updateThemeMeta(resolved);
+  }
+  function updateThemeMeta(resolved){
+    const themeMeta = document.querySelector('meta[name="theme-color"]');
+    const surface = THEME_SURFACE_COLORS[resolved] || THEME_SURFACE_COLORS.dark;
+    if(themeMeta && themeMeta.getAttribute('content') !== surface){
+      themeMeta.setAttribute('content', surface);
+    }
+  }
+  function applyLanguage(){
+    const lang = userPreferences.language || 'es';
+    document.documentElement.setAttribute('lang', lang);
+  }
+  function applyDensity(){
+    const density = userPreferences.density || 'comfortable';
+    document.documentElement.setAttribute('data-density', density);
+  }
+  function applyEcoMode(){
+    document.documentElement.setAttribute('data-eco', userPreferences.eco ? 'true' : 'false');
+  }
+  function applyMotionPreference(){
+    document.documentElement.setAttribute('data-motion', userPreferences.reducedMotion ? 'reduced' : 'full');
+  }
+  function applyFontScale(){
+    document.documentElement.setAttribute('data-font-scale', userPreferences.largeText ? 'large' : 'normal');
+  }
+  function applyAccentPreference(){
+    const palette = ACCENT_PALETTES[userPreferences.accent] || ACCENT_PALETTES.blue;
+    document.documentElement.style.setProperty('--color-primary', palette.primary);
+    document.documentElement.style.setProperty('--color-secondary', palette.secondary);
+    document.documentElement.style.setProperty('--accent', palette.primary);
+    document.documentElement.style.setProperty('--accent-2', palette.secondary);
+    document.documentElement.style.setProperty('--panel-base-rgb', palette.panel);
+  }
+  function applyBoardLayoutPreference(){
+    const layout = userPreferences.boardDensity || 'standard';
+    document.documentElement.setAttribute('data-board-density', layout);
+  }
+  function applyContrastPreference(){
+    document.documentElement.setAttribute('data-contrast', userPreferences.highContrast ? 'high' : 'normal');
+  }
+  function applyLeadIdPreference(){
+    document.documentElement.setAttribute('data-show-lead-id', userPreferences.showLeadId ? 'true' : 'false');
+  }
+  function renderPreferencePresets(){
+    const container = el('#prefPresetRecommendations');
+    const list = el('#prefPresetList');
+    if(!container || !list) return;
+    const presets = Array.isArray(INSTITUTIONAL_PRESETS) ? INSTITUTIONAL_PRESETS.filter(Boolean) : [];
+    if(getUserRole() !== 'admin' || !presets.length){
+      container.hidden = true;
+      list.innerHTML = '';
+      return;
+    }
+    list.innerHTML = '';
+    presets.forEach(preset => {
+      const card = document.createElement('div');
+      card.className = 'pref-preset-card';
+      const title = document.createElement('strong');
+      title.textContent = preset.name || 'Preset';
+      card.appendChild(title);
+      if(preset.description){
+        const desc = document.createElement('p');
+        desc.textContent = preset.description;
+        card.appendChild(desc);
+      }
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'btn micro';
+      if(userPreferences.appliedPreset === preset.id){
+        button.innerHTML = '<i class="bi bi-check-circle"></i> Aplicado';
+        button.disabled = true;
+      }else{
+        button.innerHTML = '<i class="bi bi-lightning-charge"></i> Aplicar';
+        button.addEventListener('click', () => applyInstitutionalPreset(preset));
+      }
+      card.appendChild(button);
+      list.appendChild(card);
+    });
+    container.hidden = false;
+    container.removeAttribute('hidden');
+  }
+  function applyInstitutionalPreset(preset){
+    if(!preset || !preset.values) return;
+    const updates = { ...preset.values, appliedPreset: preset.id || '' };
+    updatePreferences(updates);
+    showSettingsMessage(`Se aplicó el preset ${preset.name || 'institucional'}.`, 'success');
+  }
+  function updatePreferences(partial){
+    const updates = partial && typeof partial === 'object' ? { ...partial } : {};
+    const keys = Object.keys(updates);
+    if(keys.length === 0){
+      return;
+    }
+    const touchesOnlyPreset = keys.length === 1 && keys[0] === 'appliedPreset';
+    if(!touchesOnlyPreset && !('appliedPreset' in updates)){
+      updates.appliedPreset = '';
+    }
+    const previousPreferences = userPreferences;
+    const nextPreferences = { ...userPreferences, ...updates };
+    const changedKeys = Object.keys(nextPreferences).filter(key => nextPreferences[key] !== previousPreferences[key]);
+    if(!changedKeys.length){
+      return;
+    }
+    userPreferences = nextPreferences;
+    writeStorageJSON(STORAGE_KEYS.preferences, userPreferences);
+    clearLegacyThemeKey();
+    applyPreferences();
+    if(settingsReady){
+      syncPreferencesForm();
+      renderPreferencePresets();
+      announcePreferenceChanges(changedKeys, userPreferences);
+    }
+    if(typeof refresh === 'function'){
+      try{
+        refresh();
+      }catch(err){
+        console.warn('No se pudo actualizar la vista tras modificar preferencias.', err);
+      }
+    }
+  }
+  function resetPreferences(){
+    userPreferences = { ...DEFAULT_PREFERENCES };
+    removeStorageKey(STORAGE_KEYS.preferences);
+    clearLegacyThemeKey();
+    applyPreferences();
+    if(settingsReady){
+      syncPreferencesForm();
+      renderPreferencePresets();
+    }
+    if(typeof refresh === 'function'){
+      try{
+        refresh();
+      }catch(err){
+        console.warn('No se pudo actualizar la vista tras restablecer preferencias.', err);
+      }
+    }
+  }
+  function updateProfileData(partial){
+    userProfile = { ...userProfile, ...partial };
+    writeStorageJSON(STORAGE_KEYS.profile, userProfile);
+    if(settingsReady){
+      syncProfileUI();
+    }
+    updateUserBadge();
+  }
+  function resetProfileData(){
+    userProfile = { ...DEFAULT_PROFILE };
+    removeStorageKey(STORAGE_KEYS.profile);
+    if(settingsReady){
+      syncProfileUI();
+    }
+    updateUserBadge();
+  }
+  function resolveProfileText(key){
+    const fromProfile = userProfile && userProfile[key];
+    if(typeof fromProfile === 'string'){
+      const trimmed = fromProfile.trim();
+      if(trimmed) return trimmed;
+    }else if(typeof fromProfile === 'number'){
+      const numericText = String(fromProfile).trim();
+      if(numericText) return numericText;
+    }
+    const fromUser = currentUser && currentUser[key];
+    if(typeof fromUser === 'string'){
+      const trimmedUser = fromUser.trim();
+      if(trimmedUser) return trimmedUser;
+    }else if(typeof fromUser === 'number'){
+      const numericUser = String(fromUser).trim();
+      if(numericUser) return numericUser;
+    }
+    if(key === 'campus' && Array.isArray(currentUser?.planteles)){
+      const plantel = currentUser.planteles.find(value => value && String(value).trim());
+      if(plantel) return String(plantel).trim();
+    }
+    return '';
+  }
+
+  function computeInitials(){
+    const name = resolveProfileText('name');
+    if(name){
+      const parts = name.split(/\s+/).filter(Boolean).slice(0, 2);
+      if(parts.length){
+        return parts.map(p => p.charAt(0).toUpperCase()).join('');
+      }
+    }
+    const id = resolveProfileText('userId');
+    if(id){
+      return id.slice(0, 2).toUpperCase();
+    }
+    return 'U';
+  }
+  function syncProfileUI(){
+    const idValue = resolveProfileText('userId');
+    const nameValue = resolveProfileText('name');
+    const emailValue = resolveProfileText('email');
+    const roleValue = resolveProfileText('role');
+    const campusValue = resolveProfileText('campus');
+    const idInput = el('#profileId');
+    if(idInput) idInput.value = idValue;
+    const nameInput = el('#profileName');
+    if(nameInput) nameInput.value = nameValue;
+    const emailInput = el('#profileEmail');
+    if(emailInput) emailInput.value = emailValue;
+    const roleInput = el('#profileRole');
+    if(roleInput) roleInput.value = roleValue;
+    const campusInput = el('#profileCampus');
+    if(campusInput) campusInput.value = campusValue;
+    const avatarFrame = el('#profileAvatarFrame');
+    const avatarImg = el('#profileAvatarImg');
+    const avatarInitials = el('#profileAvatarInitials');
+    const avatarSource = userProfile.avatar || (currentUser && currentUser.avatar) || '';
+    const initialsValue = computeInitials();
+    if(avatarFrame){
+      avatarFrame.classList.toggle('has-image', Boolean(avatarSource));
+    }
+    if(avatarImg){
+      avatarImg.textContent = avatarSource ? initialsValue : '';
+    }
+    if(avatarInitials){
+      avatarInitials.textContent = initialsValue;
+    }
+    const summaryId = el('#profileSummaryId');
+    if(summaryId) summaryId.textContent = idValue || 'Sin definir';
+    const summaryName = el('#profileSummaryName');
+    if(summaryName) summaryName.textContent = nameValue || 'Sin definir';
+    const summaryEmail = el('#profileSummaryEmail');
+    if(summaryEmail) summaryEmail.textContent = emailValue || 'Sin definir';
+    const summaryRole = el('#profileSummaryRole');
+    if(summaryRole) summaryRole.textContent = roleValue ? formatRoleLabel(roleValue) : 'Sin definir';
+    const summaryCampus = el('#profileSummaryCampus');
+    if(summaryCampus) summaryCampus.textContent = campusValue || 'Sin definir';
+    updateProfileSyncAlert();
+  }
+
+  function updateProfileSyncAlert(){
+    const alert = el('#profileSyncAlert');
+    if(!alert) return;
+    if(getUserRole() !== 'admin'){
+      alert.hidden = true;
+      return;
+    }
+    const sourceLabel = userProfile.sourceLabel || 'Directorio maestro';
+    const syncedAt = Number(userProfile.syncedAt) || 0;
+    const sourceAt = Number(userProfile.sourceUpdatedAt) || 0;
+    alert.innerHTML = '';
+    let state = '';
+    const title = document.createElement('strong');
+    const description = document.createElement('span');
+    if(!sourceAt && !syncedAt){
+      state = 'unknown';
+      title.textContent = 'Sin referencia de sincronización';
+      description.textContent = `Vincula este perfil con ${sourceLabel} para garantizar datos vigentes.`;
+    }else if(sourceAt && (!syncedAt || sourceAt > syncedAt)){
+      state = 'stale';
+      title.textContent = 'Datos desactualizados';
+      description.textContent = `Última actualización en ${sourceLabel}: ${formatDateTime(sourceAt)}.`;
+    }else{
+      title.textContent = 'Información sincronizada';
+      description.textContent = `Última verificación local: ${formatDateTime(syncedAt)}.`;
+    }
+    alert.appendChild(title);
+    alert.appendChild(description);
+    if(state === 'stale'){
+      const hint = document.createElement('span');
+      hint.textContent = 'Sincroniza la ficha y alinea los datos críticos con la fuente maestra.';
+      alert.appendChild(hint);
+    }else if(state === 'unknown'){
+      const hint = document.createElement('span');
+      hint.textContent = 'Registra una sincronización cuando valides la información desde la fuente maestra.';
+      alert.appendChild(hint);
+    }
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn micro';
+    if(state === ''){
+      button.innerHTML = '<i class="bi bi-clock-history"></i> Registrar nueva sincronización';
+    }else{
+      button.innerHTML = '<i class="bi bi-arrow-repeat"></i> Sincronizar ahora';
+    }
+    button.addEventListener('click', handleProfileSyncNow);
+    alert.appendChild(button);
+    if(state){
+      alert.dataset.state = state;
+    }else{
+      delete alert.dataset.state;
+    }
+    alert.hidden = false;
+  }
+
+  function handleProfileSyncNow(){
+    const now = Date.now();
+    const updates = { syncedAt: now };
+    if(!userProfile.sourceUpdatedAt){
+      updates.sourceUpdatedAt = now;
+    }
+    updateProfileData(updates);
+    showSettingsMessage('Se marcó la información del perfil como sincronizada.', 'success');
+  }
+
+  function syncPreferencesForm(){
+    const themePref = userPreferences.theme || 'system';
+    els('input[name="pref-theme"]').forEach(radio => {
+      radio.checked = radio.value === themePref;
+    });
+    const languageSel = el('#prefLanguage');
+    if(languageSel) languageSel.value = userPreferences.language || 'es';
+    const densitySel = el('#prefDensity');
+    if(densitySel) densitySel.value = userPreferences.density || 'comfortable';
+    const boardDensitySel = el('#prefBoardDensity');
+    if(boardDensitySel) boardDensitySel.value = userPreferences.boardDensity || 'standard';
+    const accentSel = el('#prefAccent');
+    if(accentSel) accentSel.value = userPreferences.accent || 'blue';
+    const ecoToggle = el('#prefEco');
+    if(ecoToggle) ecoToggle.checked = Boolean(userPreferences.eco);
+    const motionToggle = el('#prefMotion');
+    if(motionToggle) motionToggle.checked = Boolean(userPreferences.reducedMotion);
+    const largeTextToggle = el('#prefLargeText');
+    if(largeTextToggle) largeTextToggle.checked = Boolean(userPreferences.largeText);
+    const highContrastToggle = el('#prefHighContrast');
+    if(highContrastToggle) highContrastToggle.checked = Boolean(userPreferences.highContrast);
+    const showLeadIdToggle = el('#prefShowLeadId');
+    if(showLeadIdToggle) showLeadIdToggle.checked = Boolean(userPreferences.showLeadId);
+  }
+  function formatDateTime(timestamp){
+    if(!timestamp) return 'nunca';
+    try{
+      return new Date(timestamp).toLocaleString(userPreferences.language || 'es', { dateStyle: 'medium', timeStyle: 'short' });
+    }catch(err){
+      return new Date(timestamp).toLocaleString();
+    }
+  }
+  function updatePasswordInfo(){
+    const state = passwordRequestState || { ...DEFAULT_PASSWORD_REQUEST };
+    let message = 'Sin solicitudes registradas.';
+    let tone = 'info';
+    if(state.status === 'requested' && state.requestedAt){
+      const parts = [`Pendiente de aprobación desde ${formatDateTime(state.requestedAt)}`];
+      if(state.requestedBy) parts.push(`Responsable: ${state.requestedBy}`);
+      message = parts.join(' · ');
+      tone = 'warning';
+    }else if(state.status === 'approved' && state.approvedAt){
+      const parts = [`Aprobada el ${formatDateTime(state.approvedAt)}`];
+      if(state.approvedBy) parts.push(`Responsable: ${state.approvedBy}`);
+      message = parts.join(' · ');
+      tone = 'info';
+    }else if(state.status === 'completed' && state.completedAt){
+      const parts = [`Completada el ${formatDateTime(state.completedAt)}`];
+      if(state.completedBy) parts.push(`Responsable: ${state.completedBy}`);
+      message = parts.join(' · ');
+      tone = 'success';
+    }
+    setPasswordStatus(message, tone);
+    renderPasswordTimeline(state);
+    updatePasswordActionVisibility(state);
+  }
+  function clearPasswordForm(){
+    const current = el('#passwordCurrent');
+    const next = el('#passwordNew');
+    const confirm = el('#passwordConfirm');
+    if(current) current.value = '';
+    if(next) next.value = '';
+    if(confirm) confirm.value = '';
+  }
+  function setPasswordStatus(message, tone = 'info'){
+    const statusWrap = el('#passwordStatusCard');
+    const statusText = el('#passwordRequestStatus');
+    if(statusText){
+      statusText.textContent = message;
+    }
+    if(statusWrap){
+      if(tone){
+        statusWrap.dataset.tone = tone;
+      }else{
+        statusWrap.removeAttribute('data-tone');
+      }
+    }
+  }
+  function renderPasswordTimeline(state){
+    const timeline = el('#passwordRequestTimeline');
+    if(!timeline) return;
+    timeline.innerHTML = '';
+    const currentState = state || { ...DEFAULT_PASSWORD_REQUEST };
+    if(!currentState.requestedAt && !currentState.approvedAt && !currentState.completedAt){
+      const empty = document.createElement('span');
+      empty.className = 'security-timeline__meta';
+      empty.textContent = 'Registra una solicitud para iniciar el flujo de aprobación.';
+      timeline.appendChild(empty);
+      return;
+    }
+    const steps = [
+      { key: 'requestedAt', label: 'Solicitud registrada', timestamp: currentState.requestedAt, by: currentState.requestedBy },
+      { key: 'approvedAt', label: 'Aprobación', timestamp: currentState.approvedAt, by: currentState.approvedBy },
+      { key: 'completedAt', label: 'Entrega confirmada', timestamp: currentState.completedAt, by: currentState.completedBy }
+    ];
+    steps.forEach((step, index) => {
+      const item = document.createElement('div');
+      item.className = 'security-timeline__item';
+      let stateTag = 'future';
+      if(step.timestamp){
+        stateTag = 'done';
+      }else if(index === 0){
+        stateTag = 'active';
+      }else if(index === 1 && currentState.requestedAt){
+        stateTag = 'active';
+      }else if(index === 2 && currentState.approvedAt){
+        stateTag = 'active';
+      }
+      item.dataset.state = stateTag;
+      const badge = document.createElement('span');
+      badge.className = 'security-timeline__badge';
+      item.appendChild(badge);
+      const content = document.createElement('div');
+      content.className = 'security-timeline__content';
+      const label = document.createElement('span');
+      label.className = 'security-timeline__label';
+      label.textContent = step.label;
+      content.appendChild(label);
+      const meta = document.createElement('span');
+      meta.className = 'security-timeline__meta';
+      if(step.timestamp){
+        const metaParts = [formatDateTime(step.timestamp)];
+        if(step.by) metaParts.push(`Responsable: ${step.by}`);
+        meta.textContent = metaParts.join(' · ');
+      }else if(stateTag === 'active'){
+        meta.textContent = 'Pendiente de registrar.';
+      }else{
+        meta.textContent = 'En espera del paso previo.';
+      }
+      content.appendChild(meta);
+      item.appendChild(content);
+      timeline.appendChild(item);
+    });
+  }
+
+  function updatePasswordActionVisibility(state){
+    const approveBtn = el('#passwordApproveBtn');
+    const completeBtn = el('#passwordCompleteBtn');
+    const actions = el('#passwordStatusActions');
+    const canApprove = Boolean(state?.requestedAt) && !state?.approvedAt;
+    const canComplete = Boolean(state?.approvedAt) && !state?.completedAt;
+    if(approveBtn) approveBtn.hidden = !canApprove;
+    if(completeBtn) completeBtn.hidden = !canComplete;
+    if(actions){
+      actions.hidden = !canApprove && !canComplete;
+    }
+  }
+
+  function persistPasswordRequestState(){
+    writeStorageJSON(STORAGE_KEYS.password, passwordRequestState);
+  }
+
+  function getCurrentOperatorLabel(){
+    if(currentUser){
+      if(currentUser.name) return currentUser.name;
+      if(currentUser.userId) return currentUser.userId;
+      if(currentUser.email) return currentUser.email;
+    }
+    if(userProfile){
+      if(userProfile.name) return userProfile.name;
+      if(userProfile.userId) return userProfile.userId;
+      if(userProfile.email) return userProfile.email;
+    }
+    return 'Administrador';
+  }
+  function showSettingsMessage(message, type = 'info'){
+    const status = el('#settingsStatus');
+    if(!status) return;
+    status.textContent = message;
+    if(type && type !== 'info'){
+      status.dataset.state = type;
+    }else{
+      delete status.dataset.state;
+    }
+    status.classList.add('visible');
+    status.classList.remove('fade');
+    if(settingsStatusTimer){
+      clearTimeout(settingsStatusTimer);
+    }
+    settingsStatusTimer = setTimeout(()=>{
+      status.classList.add('fade');
+    }, 4500);
+  }
+  function resolvePreferenceAnnouncement(key, preferences){
+    const config = QUICK_PREFERENCE_MESSAGES[key];
+    if(!config) return null;
+    const stateKey = String(Boolean(preferences && preferences[key]));
+    const entry = config[stateKey];
+    if(!entry || !entry.text) return null;
+    return { text: entry.text, tone: entry.tone || 'info' };
+  }
+  function announcePreferenceChanges(changedKeys, preferences){
+    if(!Array.isArray(changedKeys) || !changedKeys.length) return;
+    const announcements = changedKeys
+      .map(key => resolvePreferenceAnnouncement(key, preferences))
+      .filter(Boolean);
+    if(!announcements.length) return;
+    let tone = 'info';
+    const tonePriority = ['error','warning','success','info'];
+    tonePriority.some(candidate => {
+      if(announcements.some(item => item.tone === candidate)){
+        tone = candidate;
+        return true;
+      }
+      return false;
+    });
+    const message = announcements.map(item => item.text).join(' ');
+    showSettingsMessage(message, tone);
+  }
+  function handleAvatarUpload(file){
+    if(!file) return;
+    if(file.size > 1572864){
+      showSettingsMessage('La imagen supera 1.5 MB, elige una versión más ligera.', 'error');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = event => {
+      updateProfileData({ avatar: event.target?.result || '' });
+      showSettingsMessage('Foto de perfil actualizada.', 'success');
+    };
+    reader.onerror = () => {
+      showSettingsMessage('No se pudo leer la imagen seleccionada.', 'error');
+    };
+    reader.readAsDataURL(file);
+  }
+  function initSettings(){
+    if(settingsReady){
+      syncProfileUI();
+      syncPreferencesForm();
+      renderPreferencePresets();
+      updatePasswordInfo();
+      return;
+    }
+    settingsReady = true;
+    syncProfileUI();
+    syncPreferencesForm();
+    renderPreferencePresets();
+    updatePasswordInfo();
+    const profileForm = el('#profileForm');
+    if(profileForm){
+      profileForm.addEventListener('submit', e => {
+        e.preventDefault();
+        updateProfileData({
+          userId: (el('#profileId')?.value || '').trim(),
+          name: (el('#profileName')?.value || '').trim(),
+          email: (el('#profileEmail')?.value || '').trim(),
+          role: (el('#profileRole')?.value || '').trim(),
+          campus: (el('#profileCampus')?.value || '').trim()
+        });
+        showSettingsMessage('Perfil actualizado correctamente.', 'success');
+      });
+    }
+    const profileReset = el('#profileReset');
+    if(profileReset){
+      profileReset.addEventListener('click', () => {
+        resetProfileData();
+        showSettingsMessage('Se restableció la información del perfil.', 'warning');
+      });
+    }
+    const avatarInput = el('#profileAvatarInput');
+    const avatarUpload = el('#profileAvatarUpload');
+    if(avatarUpload && avatarInput){
+      avatarUpload.addEventListener('click', () => avatarInput.click());
+    }
+    if(avatarInput){
+      avatarInput.addEventListener('change', () => {
+        const file = avatarInput.files && avatarInput.files[0];
+        handleAvatarUpload(file || null);
+        avatarInput.value = '';
+      });
+    }
+    const avatarRemove = el('#profileAvatarRemove');
+    if(avatarRemove){
+      avatarRemove.addEventListener('click', () => {
+        if(userProfile.avatar){
+          updateProfileData({ avatar: '' });
+          showSettingsMessage('Se eliminó la foto de perfil.', 'success');
+        }else{
+          showSettingsMessage('No hay una foto guardada.', 'warning');
+        }
+      });
+    }
+    els('input[name="pref-theme"]').forEach(radio => {
+      radio.addEventListener('change', () => {
+        if(radio.checked){
+          updatePreferences({ theme: radio.value });
+        }
+      });
+    });
+    const languageSel = el('#prefLanguage');
+    if(languageSel){
+      languageSel.addEventListener('change', () => updatePreferences({ language: languageSel.value }));
+    }
+    const densitySel = el('#prefDensity');
+    if(densitySel){
+      densitySel.addEventListener('change', () => updatePreferences({ density: densitySel.value }));
+    }
+    const boardLayoutSel = el('#prefBoardDensity');
+    if(boardLayoutSel){
+      boardLayoutSel.addEventListener('change', () => updatePreferences({ boardDensity: boardLayoutSel.value }));
+    }
+    const accentSel = el('#prefAccent');
+    if(accentSel){
+      accentSel.addEventListener('change', () => updatePreferences({ accent: accentSel.value }));
+    }
+    const ecoToggle = el('#prefEco');
+    if(ecoToggle){
+      ecoToggle.addEventListener('change', () => updatePreferences({ eco: ecoToggle.checked }));
+    }
+    const motionToggle = el('#prefMotion');
+    if(motionToggle){
+      motionToggle.addEventListener('change', () => updatePreferences({ reducedMotion: motionToggle.checked }));
+    }
+    const largeTextToggle = el('#prefLargeText');
+    if(largeTextToggle){
+      largeTextToggle.addEventListener('change', () => updatePreferences({ largeText: largeTextToggle.checked }));
+    }
+    const highContrastToggle = el('#prefHighContrast');
+    if(highContrastToggle){
+      highContrastToggle.addEventListener('change', () => updatePreferences({ highContrast: highContrastToggle.checked }));
+    }
+    const showLeadIdToggle = el('#prefShowLeadId');
+    if(showLeadIdToggle){
+      showLeadIdToggle.addEventListener('change', () => updatePreferences({ showLeadId: showLeadIdToggle.checked }));
+    }
+    const prefReset = el('#prefReset');
+    if(prefReset){
+      prefReset.addEventListener('click', () => {
+        resetPreferences();
+        showSettingsMessage('Restauraste las preferencias originales.', 'success');
+      });
+    }
+    const passwordForm = el('#passwordForm');
+    if(passwordForm){
+      passwordForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const current = (el('#passwordCurrent')?.value || '').trim();
+        const next = (el('#passwordNew')?.value || '').trim();
+        const confirm = (el('#passwordConfirm')?.value || '').trim();
+        if(!current || !next || !confirm){
+          setPasswordStatus('Completa todos los campos para registrar la solicitud.', 'warning');
+          showSettingsMessage('Completa todos los campos de seguridad.', 'warning');
+          return;
+        }
+        if(next.length < 8){
+          setPasswordStatus('La nueva contraseña debe tener al menos 8 caracteres.', 'error');
+          showSettingsMessage('La nueva contraseña debe tener al menos 8 caracteres.', 'error');
+          return;
+        }
+        if(next !== confirm){
+          setPasswordStatus('La confirmación no coincide con la nueva contraseña.', 'error');
+          showSettingsMessage('La confirmación no coincide con la nueva contraseña.', 'error');
+          return;
+        }
+        if(current === next){
+          setPasswordStatus('La nueva contraseña debe ser distinta a la actual.', 'warning');
+          showSettingsMessage('La nueva contraseña debe ser distinta a la actual.', 'warning');
+          return;
+        }
+        const requestedAt = Date.now();
+        passwordRequestState = {
+          ...DEFAULT_PASSWORD_REQUEST,
+          status: 'requested',
+          requestedAt,
+          requestedBy: getCurrentOperatorLabel()
+        };
+        persistPasswordRequestState();
+        clearPasswordForm();
+        updatePasswordInfo();
+        showSettingsMessage('Se registró tu solicitud de cambio de contraseña.', 'success');
+      });
+    }
+    const passwordClear = el('#passwordClear');
+    if(passwordClear){
+      passwordClear.addEventListener('click', () => {
+        clearPasswordForm();
+        showSettingsMessage('Se limpiaron los campos de seguridad.', 'info');
+      });
+    }
+    const passwordApproveBtn = el('#passwordApproveBtn');
+    if(passwordApproveBtn){
+      passwordApproveBtn.addEventListener('click', () => {
+        if(!passwordRequestState?.requestedAt){
+          setPasswordStatus('Registra una solicitud antes de aprobarla.', 'warning');
+          showSettingsMessage('Registra una solicitud antes de aprobarla.', 'warning');
+          return;
+        }
+        if(passwordRequestState.approvedAt){
+          setPasswordStatus('La solicitud ya fue aprobada.', 'info');
+          return;
+        }
+        passwordRequestState = {
+          ...passwordRequestState,
+          status: 'approved',
+          approvedAt: Date.now(),
+          approvedBy: getCurrentOperatorLabel()
+        };
+        persistPasswordRequestState();
+        updatePasswordInfo();
+        showSettingsMessage('Se registró la aprobación de la solicitud.', 'success');
+      });
+    }
+    const passwordCompleteBtn = el('#passwordCompleteBtn');
+    if(passwordCompleteBtn){
+      passwordCompleteBtn.addEventListener('click', () => {
+        if(!passwordRequestState?.requestedAt){
+          setPasswordStatus('Registra una solicitud antes de confirmarla.', 'warning');
+          showSettingsMessage('Registra una solicitud antes de confirmarla.', 'warning');
+          return;
+        }
+        if(!passwordRequestState.approvedAt){
+          setPasswordStatus('Aprueba la solicitud antes de confirmar la entrega.', 'warning');
+          showSettingsMessage('Aprueba la solicitud antes de confirmar la entrega.', 'warning');
+          return;
+        }
+        if(passwordRequestState.completedAt){
+          setPasswordStatus('La entrega ya fue confirmada.', 'info');
+          return;
+        }
+        passwordRequestState = {
+          ...passwordRequestState,
+          status: 'completed',
+          completedAt: Date.now(),
+          completedBy: getCurrentOperatorLabel()
+        };
+        persistPasswordRequestState();
+        updatePasswordInfo();
+        showSettingsMessage('Se confirmó la entrega de credenciales.', 'success');
+      });
+    }
+    const status = el('#settingsStatus');
+    if(status && !status.textContent.trim()){
+      status.textContent = 'Tus ajustes se guardan en este dispositivo.';
+    }
+  }
+  let panelHideTimer = null;
+  function showPanelOverlay(){
+    const overlay = el('#panelOverlay');
+    if(!overlay) return;
+    const panel = overlay.querySelector('.panel');
+    if(panelHideTimer){
+      clearTimeout(panelHideTimer);
+      panelHideTimer = null;
+    }
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden','false');
+    if(panel){
+      panel.classList.remove('show');
+      void panel.offsetWidth;
+      panel.classList.add('show');
+      panel.focus({ preventScroll: true });
+    }
+  }
+  function hidePanelOverlay(){
+    const overlay = el('#panelOverlay');
+    if(!overlay || !overlay.classList.contains('open')) return;
+    const panel = overlay.querySelector('.panel');
+    overlay.setAttribute('aria-hidden','true');
+    if(panel){
+      panel.classList.remove('show');
+    }
+    detailLeadContext = null;
+    leadTagContext.leadId = '';
+    hideLeadTagForm();
+    setLeadTagFeedback('');
+    renderLeadTagList(null);
+    updateAutoReassignDetail(null);
+    const leadTagAddBtn = el('#leadTagAdd');
+    if(leadTagAddBtn){
+      leadTagAddBtn.disabled = true;
+    }
+    getCalendarForms().forEach(ctx => {
+      if(ctx.statusEl){
+        ctx.statusEl.textContent = '';
+      }
+      if(ctx.button){
+        ctx.button.disabled = true;
+        ctx.button.dataset.href = '';
+      }
+    });
+    if(panelHideTimer){
+      clearTimeout(panelHideTimer);
+      panelHideTimer = null;
+    }
+    panelHideTimer = setTimeout(()=>{
+      overlay.classList.remove('open');
+      panelHideTimer = null;
+    }, 200);
+  }
+  const etapaLabel = value => {
+    const s = String(value || '').toLowerCase();
+    if(s === 'no contactado') return 'No Contactado';
+    if(s === 'contactado') return 'Contactado';
+    if(s === 'inscrito') return 'Inscrito';
+    if(s === 'descartado') return 'Descartado';
+    if(s === 'nuevo') return 'Nuevo';
+    return value || '';
+  };
+  const fillEtapaSelect = select => {
+    if(!select) return;
+    select.innerHTML = etapasUI.map(e=>`<option value="${e}">${e}</option>`).join('');
+  };
+  const fillEstadoOptions = (etapa, select) => {
+    const sel = select || el('#selEstado');
+    if(!sel) return;
+    const options = estadosByEtapa[etapa] || [];
+    sel.innerHTML = options.length ? options.map(s=>`<option value="${s}">${s}</option>`).join('') : '<option value="">—</option>';
+  };
+
+  // —— Agrupación de etapas para vista ——
+  const etapaGroup = e => {
+    const s = String(e || '').toLowerCase();
+    if(s === 'descartado') return 'Descartado';
+    if(s === 'inscrito') return 'Inscrito';
+    if(s === 'contactado') return 'Contactado';
+    if(s === 'no contactado') return 'No Contactado';
+    return 'Nuevo';
+  };
+
+  const etapaSlug = e => {
+    if(!e) return '';
+    const label = etapaGroup(e);
+    return label ? label.toLowerCase().replace(/\s+/g,'-') : '';
+  };
+
+  const etapaBackend = e => e === 'No Contactado' ? 'No contactado' : e;
+
+  // —— Render KPIs ——
+  function renderKPIs(rows){
+    const box = el('#kpiContainer');
+    if(!box) return;
+    box.innerHTML = '';
+    if(!rows || !rows.length){
+      const empty = document.createElement('p');
+      empty.className = 'kpi-empty';
+      const hasLeads = Array.isArray(leads) && leads.length > 0;
+      empty.innerHTML = hasLeads
+        ? 'No hay leads que cumplan los filtros seleccionados.'
+        : 'Selecciona una base desde el filtro <strong>Base</strong> en la vista Leads para cargar los indicadores.';
+      box.appendChild(empty);
+      return;
+    }
+    const role = getUserRole();
+    const allowed = KPI_ROLE_GROUPS[role] || Object.keys(KPI_GROUPS);
+    if(!allowed.length){
+      const empty = document.createElement('p');
+      empty.className = 'kpi-empty';
+      empty.textContent = 'Tu rol no tiene indicadores asignados por el momento.';
+      box.appendChild(empty);
+      return;
+    }
+    const ctx = buildKpiContext(rows);
+    allowed.forEach(groupKey => {
+      const group = KPI_GROUPS[groupKey];
+      if(!group) return;
+      const section = document.createElement('section');
+      section.className = 'kpi-group';
+      section.dataset.group = groupKey;
+      const header = document.createElement('header');
+      const title = document.createElement('h4');
+      title.textContent = group.label;
+      header.appendChild(title);
+      if(group.description){
+        const desc = document.createElement('p');
+        desc.textContent = group.description;
+        header.appendChild(desc);
+      }
+      section.appendChild(header);
+      const grid = document.createElement('div');
+      grid.className = 'kpi-grid';
+      group.metrics.forEach(metric => {
+        const metricEl = document.createElement('article');
+        metricEl.className = 'kpi-metric';
+        metricEl.dataset.metric = metric.key;
+        const nameEl = document.createElement('span');
+        nameEl.className = 'metric-name';
+        nameEl.textContent = metric.label;
+        metricEl.appendChild(nameEl);
+        const result = resolveKpiMetric(metric, ctx);
+        const valueEl = document.createElement('span');
+        valueEl.className = 'metric-value';
+        const valueText = result.value === undefined || result.value === null || result.value === '' ? '—' : String(result.value);
+        valueEl.textContent = valueText;
+        metricEl.appendChild(valueEl);
+        if(result.extra){
+          const extraEl = document.createElement('span');
+          extraEl.className = 'metric-extra';
+          extraEl.textContent = result.extra;
+          metricEl.appendChild(extraEl);
+        }
+        if(Array.isArray(result.list) && result.list.length){
+          const listEl = document.createElement('ul');
+          result.list.forEach(item => {
+            const li = document.createElement('li');
+            li.textContent = item;
+            listEl.appendChild(li);
+          });
+          metricEl.appendChild(listEl);
+        }
+        if(metric.description){
+          const descEl = document.createElement('p');
+          descEl.className = 'metric-desc';
+          descEl.textContent = metric.description;
+          metricEl.appendChild(descEl);
+        }
+        if(result.note){
+          const noteEl = document.createElement('p');
+          noteEl.className = 'metric-note';
+          noteEl.textContent = result.note;
+          metricEl.appendChild(noteEl);
+        }
+        grid.appendChild(metricEl);
+      });
+      section.appendChild(grid);
+      box.appendChild(section);
+    });
+  }
+
+  function buildKpiContext(rows){
+    const stageCounts = { Nuevo: 0, Contactado: 0, 'No Contactado': 0, Inscrito: 0, Descartado: 0 };
+    let reimpactados = 0;
+    let responded = 0;
+    let inscritos = 0;
+    let descartados = 0;
+    let interesados = 0;
+    const asesorMap = {};
+    rows.forEach(row => {
+      const stage = etapaGroup(row.etapa);
+      stageCounts[stage] = (stageCounts[stage] || 0) + 1;
+      if(stage !== 'Nuevo') reimpactados++;
+      if(stage === 'Contactado' || stage === 'Inscrito') responded++;
+      if(stage === 'Inscrito') inscritos++;
+      if(stage === 'Descartado') descartados++;
+      const estado = String(row.estado || '').trim().toLowerCase();
+      const isInterested = estado.includes('interes') || estado.includes('labor de venta') || KPI_INTEREST_STATES.has(estado);
+      if(isInterested) interesados++;
+      const asesorKey = normalizeAsesorName(row.asesor);
+      if(asesorKey){
+        if(!asesorMap[asesorKey]){
+          const displayName = displayAsesorName(row.asesor);
+          asesorMap[asesorKey] = { name: displayName, total: 0, reimpactados: 0, responded: 0, interesados: 0, inscritos: 0 };
+        }
+        const stats = asesorMap[asesorKey];
+        stats.total++;
+        if(stage !== 'Nuevo') stats.reimpactados++;
+        if(stage === 'Contactado' || stage === 'Inscrito') stats.responded++;
+        if(stage === 'Inscrito') stats.inscritos++;
+        if(isInterested) stats.interesados++;
+      }
+    });
+    const total = rows.length;
+    const basePendiente = stageCounts['Nuevo'] || Math.max(0, total - reimpactados);
+    const reactivados = interesados + inscritos;
+    const asesorList = Object.values(asesorMap);
+    return {
+      total,
+      stageCounts,
+      reimpactados,
+      responded,
+      interesados,
+      inscritos,
+      descartados,
+      basePendiente,
+      reactivados,
+      asesorList
+    };
+  }
+
+  function resolveKpiMetric(metric, ctx){
+    if(!metric || typeof metric.compute !== 'function'){
+      return { value: '—' };
+    }
+    try{
+      const raw = metric.compute(ctx);
+      if(raw === null || raw === undefined){
+        return { value: '—' };
+      }
+      if(typeof raw === 'string'){
+        return { value: raw };
+      }
+      if(typeof raw === 'number'){
+        return { value: formatKpiNumber(raw) };
+      }
+      if(typeof raw === 'object'){
+        const valueProvided = raw.value !== undefined && raw.value !== null && raw.value !== '';
+        const extraProvided = raw.extra !== undefined && raw.extra !== null && raw.extra !== '';
+        const noteProvided = raw.note !== undefined && raw.note !== null && raw.note !== '';
+        const result = {
+          value: valueProvided ? raw.value : '—'
+        };
+        if(typeof result.value === 'number'){
+          result.value = formatKpiNumber(result.value);
+        }
+        if(extraProvided){
+          const extraValue = typeof raw.extra === 'number' ? formatKpiNumber(raw.extra) : raw.extra;
+          result.extra = String(extraValue);
+        }
+        if(Array.isArray(raw.list) && raw.list.length){
+          result.list = raw.list.map(item => String(item));
+        }
+        if(noteProvided){
+          result.note = String(raw.note);
+        }
+        return result;
+      }
+    }catch(err){
+      console.warn('Error al calcular KPI', metric.key, err);
+      return { value: '—', note: 'No se pudo calcular este KPI.' };
+    }
+    return { value: '—' };
+  }
+
+  function formatKpiNumber(value){
+    if(typeof value !== 'number' || !isFinite(value)) return '—';
+    return KPI_NUMBER_FORMAT.format(Math.round(value));
+  }
+
+  function formatKpiPercent(value){
+    if(typeof value !== 'number' || !isFinite(value)) return '—';
+    return KPI_PERCENT_FORMAT.format(value);
+  }
+
+  function safeDivide(num, denom){
+    if(typeof num !== 'number' || typeof denom !== 'number') return null;
+    if(!isFinite(num) || !isFinite(denom) || denom === 0) return null;
+    return num / denom;
+  }
+
+  function normalizeAsesorName(name){
+    const value = String(name || '').trim();
+    if(!value) return '';
+    const lower = value.toLowerCase();
+    if(lower.includes('sistema') || lower === 'sin asignar' || lower === 'sinasesor') return '';
+    const normalized = value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return normalized;
+  }
+
+  function displayAsesorName(value){
+    const raw = String(value || '').trim();
+    if(!raw) return 'Sin asignar';
+    const lower = raw.toLowerCase();
+    if(lower.includes('sistema') || lower === 'sin asignar' || lower === 'sinasesor'){
+      return 'Sin asignar';
+    }
+    return raw;
+  }
+
+  function formatContactTimestamp(date = new Date()){
+    const target = date instanceof Date ? date : new Date(date);
+    if(CONTACT_TIMESTAMP_FORMAT){
+      try{
+        return CONTACT_TIMESTAMP_FORMAT.format(target);
+      }catch(err){
+        /* fallback */
+      }
+    }
+    return target.toLocaleString('es-MX');
+  }
+
+  function computeLeadPriorityScore(row){
+    if(!row) return 0;
+    let score = 0;
+    const stage = etapaGroup(row.etapa);
+    if(stage === 'Nuevo') score += 3;
+    else if(stage === 'No Contactado') score += 2;
+    else if(stage === 'Contactado') score += 1;
+    const estadoNorm = String(row.estado || '').trim().toLowerCase();
+    if(KPI_INTEREST_STATES.has(estadoNorm)) score += 4;
+    if(row.campus) score += 0.5;
+    if(row.modalidad) score += 0.5;
+    return score;
+  }
+
+  function resolveLeadPriorityLevel(score){
+    if(score >= LEAD_PRIORITY_THRESHOLDS.high) return 'alta';
+    if(score >= LEAD_PRIORITY_THRESHOLDS.medium) return 'media';
+    if(score > 0) return 'baja';
+    return '';
+  }
+
+  function formatLeadPriorityLabel(level){
+    if(level === 'alta') return 'Alta prioridad';
+    if(level === 'media') return 'Seguimiento';
+    if(level === 'baja') return 'Primer contacto';
+    return '';
+  }
+
+  function buildContactScripts(lead){
+    const firstName = String(lead?.nombre || '').trim().split(/\s+/)[0] || '';
+    const asesorName = currentUser && currentUser.name ? String(currentUser.name).trim() : 'tu asesor de UNIDEP';
+    const campusText = lead?.campus ? ` de UNIDEP ${lead.campus}` : ' de UNIDEP';
+    const programaText = lead?.programa ? ` ${lead.programa}` : ' tu interés';
+    const modalidadText = lead?.modalidad ? ` (${lead.modalidad})` : '';
+    const saludo = firstName ? `Hola ${firstName},` : 'Hola,';
+    const greeting = firstName ? `Hola ${firstName}!` : 'Hola!';
+    const callScript = `${saludo} te habla ${asesorName}${campusText}. Me gustaría acompañarte${programaText}${modalidadText} y revisar contigo los siguientes pasos. ¿Tienes unos minutos hoy para que lo revisemos?`;
+    const whatsappScript = `${greeting} Soy ${asesorName}${campusText}. Te escribo${programaText}${modalidadText} para ayudarte con los siguientes pasos. ¿Agendamos una llamada breve hoy para revisar becas y asegurar tu lugar?`;
+    const subject = `Asunto: Seguimiento UNIDEP ${lead?.programa || 'tu inscripción'}`;
+    const emailGreeting = firstName ? `Hola ${firstName},` : 'Hola,';
+    const emailBody = `${subject}\n\n${emailGreeting}\n\nSoy ${asesorName}${campusText}. Gracias por tu interés${programaText}${modalidadText}. Te comparto los pasos para asegurar tu inscripción y las becas disponibles. ¿Qué día te gustaría que confirmemos juntos tu registro?\n\nQuedo al pendiente,\n${asesorName}\nUNIDEP`;
+    return { call: callScript, whatsapp: whatsappScript, email: emailBody };
+  }
+
+  function createContactNote(type, lead){
+    const timestamp = formatContactTimestamp();
+    const channel = CONTACT_CHANNEL_LABELS[type] || 'Contacto';
+    const programa = lead?.programa ? ` ${lead.programa}` : '';
+    const modalidad = lead?.modalidad ? ` (${lead.modalidad})` : '';
+    const campus = lead?.campus ? ` - ${lead.campus}` : '';
+    if(type === 'call'){
+      return `${timestamp} · ${channel}: llamada de seguimiento${programa}${modalidad}${campus}.`;
+    }
+    if(type === 'whatsapp'){
+      return `${timestamp} · ${channel}: mensaje inicial enviado, pendiente de respuesta.`;
+    }
+    if(type === 'email'){
+      return `${timestamp} · ${channel}: correo con información y próximos pasos enviado.`;
+    }
+    return `${timestamp} · ${channel}: contacto registrado.`;
+  }
+
+  const MOBILE_CALL_USER_AGENT = /android|iphone|ipad|ipod|iemobile|opera mini|blackberry|silk/i;
+
+  function isMobileCallEnvironment(){
+    if(typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || navigator.vendor || '';
+    return MOBILE_CALL_USER_AGENT.test(ua);
+  }
+
+  function normalizeE164(value){
+    if(!value) return '';
+    const digits = String(value).trim();
+    if(!digits) return '';
+    return digits.startsWith('+') ? digits : `+${digits.replace(/^\+/, '')}`;
+  }
+
+  function openAircallLink(options = {}){
+    const normalized = normalizeE164(options.e164 || '');
+    const fallbackUrl = options.fallbackUrl || '';
+    const telUrl = options.telUrl || '';
+    const hasTel = Boolean(telUrl);
+    const hasFallback = Boolean(fallbackUrl);
+    const launchFallback = () => {
+      if(hasFallback){
+        window.open(fallbackUrl, '_blank', 'noopener');
+      }else if(hasTel){
+        window.location.href = telUrl;
+      }
+    };
+    if(isMobileCallEnvironment()){
+      if(hasTel){
+        window.location.href = telUrl;
+        return;
+      }
+      if(hasFallback){
+        window.open(fallbackUrl, '_blank', 'noopener');
+      }
+      return;
+    }
+    if(!normalized){
+      launchFallback();
+      return;
+    }
+    const protocolUrl = `aircall://call?number=${encodeURIComponent(normalized)}`;
+    let iframe = null;
+    let didFallback = false;
+    const cleanup = () => {
+      if(iframe && iframe.parentNode){
+        iframe.parentNode.removeChild(iframe);
+      }
+      iframe = null;
+    };
+    const triggerFallback = () => {
+      if(didFallback) return;
+      didFallback = true;
+      cleanup();
+      launchFallback();
+    };
+    const blurHandler = () => {
+      didFallback = true;
+      clearTimeout(timerId);
+      cleanup();
+      window.removeEventListener('blur', blurHandler);
+    };
+    const timerId = setTimeout(() => {
+      window.removeEventListener('blur', blurHandler);
+      triggerFallback();
+    }, 1800);
+    window.addEventListener('blur', blurHandler, { once: true });
+    try{
+      iframe = document.createElement('iframe');
+      iframe.style.display = 'none';
+      iframe.style.width = '0';
+      iframe.style.height = '0';
+      iframe.onload = () => {
+        clearTimeout(timerId);
+        window.removeEventListener('blur', blurHandler);
+        cleanup();
+      };
+      iframe.onerror = () => {
+        clearTimeout(timerId);
+        window.removeEventListener('blur', blurHandler);
+        triggerFallback();
+      };
+      iframe.src = protocolUrl;
+      document.body.appendChild(iframe);
+    }catch(err){
+      clearTimeout(timerId);
+      window.removeEventListener('blur', blurHandler);
+      triggerFallback();
+    }
+    setTimeout(() => {
+      window.removeEventListener('blur', blurHandler);
+      cleanup();
+    }, 4000);
+  }
+
+  async function copyToClipboard(text){
+    if(!text) return false;
+    try{
+      if(typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText){
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+    }catch(err){
+      /* fallback below */
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly','');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    let success = false;
+    try{
+      success = document.execCommand('copy');
+    }catch(err){
+      success = false;
+    }
+    document.body.removeChild(textarea);
+    return success;
+  }
+
+  function aggregateDailyShortcuts(rows, type){
+    if(!Array.isArray(rows) || !rows.length) return [];
+    const map = new Map();
+    if(type === 'campus'){
+      rows.forEach(row => {
+        const campus = String(row.campus || '').trim();
+        if(!campus) return;
+        const score = computeLeadPriorityScore(row);
+        if(score <= 0) return;
+        const entry = map.get(campus) || { key: campus, label: campus, value: campus, count: 0, score: 0 };
+        entry.count += 1;
+        entry.score += score;
+        map.set(campus, entry);
+      });
+    }else if(type === 'asesor'){
+      rows.forEach(row => {
+        const raw = String(row.asesor || '').trim();
+        const normalized = normalizeAsesorName(raw);
+        if(!normalized) return;
+        const score = computeLeadPriorityScore(row);
+        if(score <= 0) return;
+        const label = displayAsesorName(raw);
+        const entry = map.get(normalized) || { key: normalized, label, value: raw, count: 0, score: 0 };
+        entry.count += 1;
+        entry.score += score;
+        if(!entry.value && raw) entry.value = raw;
+        if(!entry.label && label) entry.label = label;
+        map.set(normalized, entry);
+      });
+    }
+    return Array.from(map.values())
+      .sort((a,b) => {
+        if(b.score !== a.score) return b.score - a.score;
+        if(b.count !== a.count) return b.count - a.count;
+        return (a.label || '').localeCompare(b.label || '', 'es', { sensitivity: 'base' });
+      })
+      .slice(0, DAILY_SHORTCUT_LIMIT);
+  }
+
+  function renderShortcutButton(type, entry){
+    const classes = ['daily-shortcuts__btn'];
+    let isActive = false;
+    if(type === 'campus'){
+      isActive = Boolean(state.campus) && state.campus === entry.value;
+    }else if(type === 'asesor'){
+      const selected = getAsesorFilter();
+      isActive = selected.length === 1 && normalizeAsesorName(selected[0]) === entry.key;
+    }
+    if(isActive) classes.push('is-active');
+    const countLabel = `${entry.count} ${entry.count === 1 ? 'lead' : 'leads'}`;
+    const title = `Prioridad combinada: ${Math.round(entry.score || 0)} pts`;
+    return `<button type="button" class="${classes.join(' ')}" data-type="${type}" data-value="${escapeHtml(entry.value || '')}" aria-pressed="${isActive ? 'true' : 'false'}" title="${escapeHtml(title)}"><span>${escapeHtml(entry.label || '')}</span><span>${escapeHtml(countLabel)}</span></button>`;
+  }
+
+  function renderDailyShortcuts(rows){
+    const container = el('#dailyShortcuts');
+    if(!container) return;
+    const list = Array.isArray(rows) ? rows : [];
+    const viable = list.filter(row => computeLeadPriorityScore(row) > 0);
+    const campusEntries = aggregateDailyShortcuts(viable, 'campus');
+    const asesorEntries = aggregateDailyShortcuts(viable, 'asesor');
+    const parts = ['<div class="daily-shortcuts__header">Listas diarias sugeridas</div>'];
+    if(campusEntries.length){
+      parts.push(`<div class="daily-shortcuts__group" data-group="campus"><span class="daily-shortcuts__label">Por campus</span>${campusEntries.map(entry => renderShortcutButton('campus', entry)).join('')}</div>`);
+    }
+    if(asesorEntries.length){
+      parts.push(`<div class="daily-shortcuts__group" data-group="asesor"><span class="daily-shortcuts__label">Por asesor</span>${asesorEntries.map(entry => renderShortcutButton('asesor', entry)).join('')}</div>`);
+    }
+    if(!campusEntries.length && !asesorEntries.length){
+      parts.push('<div class="daily-shortcuts__empty">Sin recomendaciones con los filtros actuales.</div>');
+    }
+    container.innerHTML = parts.join('');
+  }
+
+  // —— Filtro base ——
+  function applyFilters(){
+    const q = state.query.toLowerCase();
+    const qDigits = q.replace(/\D/g,'');
+    const colFilters = state.colFilters;
+    const selectedAsesores = getAsesorFilter();
+    const selectedAsesorSet = new Set(selectedAsesores.map(normalizeAsesorName).filter(Boolean));
+    const rows = leads.filter(r => {
+      const text = columns.map(k=>r[k]||'').join(' ').toLowerCase();
+      const phoneForSearch = r.telefonoNormalizado || r.telefono || '';
+      const tDigits = String(phoneForSearch).replace(/\D/g,'');
+      const passesQ = !q || text.includes(q) || (qDigits && tDigits.includes(qDigits));
+      const passCols = columns.every(k => {
+        const val = colFilters[k];
+        return !val || String(r[k]||'').toLowerCase().includes(val);
+      });
+      const passAsesor = !selectedAsesorSet.size || selectedAsesorSet.has(normalizeAsesorName(r.asesor));
+      const passCampus = !state.campus || r.campus===state.campus;
+      return passesQ && passCols && passAsesor && passCampus;
+    });
+    renderKPIs(rows);
+    return rows;
+  }
+
+  function renderPagination(total){
+    const container = el('#paginator');
+    if(!container) return;
+    const pageSize = Number.isFinite(state.pageSize) && state.pageSize > 0 ? state.pageSize : 0;
+    if(!pageSize){
+      container.innerHTML = '';
+      container.classList.add('is-hidden');
+      if(state.page !== 0){
+        state.page = 0;
+      }
+      return;
+    }
+    container.classList.remove('is-hidden');
+    const pages = Math.max(1, Math.ceil(total / pageSize));
+    if(state.page >= pages) state.page = pages - 1;
+    const current = state.page;
+    container.innerHTML = '';
+    const prev = document.createElement('button');
+    prev.textContent = 'Página anterior';
+    prev.disabled = current === 0;
+    prev.addEventListener('click', ()=>{ if(state.page>0){ state.page--; refresh(); } });
+    container.appendChild(prev);
+    const start = Math.max(0, current - 1);
+    const end = Math.min(pages, start + 5);
+    for(let i=start;i<end;i++){
+      const b=document.createElement('button');
+      b.textContent=String(i+1);
+      if(i===current) b.classList.add('active');
+      b.addEventListener('click',()=>{ state.page=i; refresh(); });
+      container.appendChild(b);
+    }
+    if(end < pages){
+      const ell=document.createElement('span');
+      ell.textContent='…';
+      container.appendChild(ell);
+    }
+    const next = document.createElement('button');
+    next.textContent = 'Página siguiente';
+    next.disabled = current >= pages-1;
+    next.addEventListener('click', ()=>{ if(state.page<pages-1){ state.page++; refresh(); } });
+    container.appendChild(next);
+  }
+
+  // —— Render Kanban ——
+  function renderKanban(rows, totals){
+    const container = el('#viewKanban');
+    container.innerHTML = '';
+    const isMobileBoard = boardMobileQuery.matches;
+    if(!state.mobileColumns) state.mobileColumns = {};
+
+    etapasUI.forEach(step => {
+      const col = document.createElement('div');
+      col.className = 'column';
+      col.dataset.step = step;
+      const items = rows.filter(r=>etapaGroup(r.etapa)===step);
+      const totalCount = totals && typeof totals[step] === 'number' ? totals[step] : items.length;
+      col.innerHTML = `
+        <header>
+          <div class=\"row gap8 stage-title\"><strong>${step}</strong><span class=\"count\" title=\"Total de leads en ${step}\">${totalCount}</span></div>
+          <button type=\"button\" class=\"column-toggle\" aria-expanded=\"true\" aria-label=\"Contraer etapa ${step}\">
+            <i class=\"bi bi-chevron-down column-toggle-icon\" aria-hidden=\"true\"></i>
+          </button>
+        </header>
+        <div class=\"list\" aria-label=\"Leads en etapa ${step}\"></div>
+      `;
+      const list = col.querySelector('.list');
+      const header = col.querySelector('header');
+      const toggleBtn = col.querySelector('.column-toggle');
+      let loadMoreBtn = null;
+      if(list){
+        const limit = getColumnLimit(step, items.length);
+        const visibleItems = limit >= items.length ? items : items.slice(0, limit);
+        visibleItems.forEach(r => list.appendChild(cardLead(r)));
+        if(items.length > limit){
+          const remaining = items.length - limit;
+          const batch = Math.min(COLUMN_BATCH_SIZE, remaining);
+          loadMoreBtn = document.createElement('button');
+          loadMoreBtn.type = 'button';
+          loadMoreBtn.className = 'column-load-more';
+          loadMoreBtn.textContent = `Mostrar ${batch} más`;
+          loadMoreBtn.setAttribute('aria-label', `Mostrar ${batch} leads adicionales en ${step}`);
+          loadMoreBtn.addEventListener('click', () => {
+            increaseColumnLimit(step, items.length);
+            renderKanban(rows, totals);
+          });
+          col.appendChild(loadMoreBtn);
+        }
+      }
+
+      const applyExpansion = expanded => {
+        const isExpanded = !isMobileBoard || Boolean(expanded);
+        col.classList.toggle('mobile-collapsible', isMobileBoard);
+        col.classList.toggle('expanded', isMobileBoard && isExpanded);
+        col.classList.toggle('collapsed', isMobileBoard && !isExpanded);
+        if(toggleBtn){
+          toggleBtn.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+          toggleBtn.setAttribute('aria-label', `${isExpanded ? 'Contraer' : 'Expandir'} etapa ${step}`);
+          toggleBtn.setAttribute('aria-hidden', isMobileBoard ? 'false' : 'true');
+          toggleBtn.tabIndex = isMobileBoard ? 0 : -1;
+        }
+        if(list){
+          list.setAttribute('aria-hidden', isMobileBoard && !isExpanded ? 'true' : 'false');
+        }
+        if(loadMoreBtn){
+          loadMoreBtn.hidden = isMobileBoard && !isExpanded;
+        }
+        if(header && !isMobileBoard){
+          header.removeAttribute('role');
+          header.removeAttribute('tabindex');
+        }
+      };
+
+      if(isMobileBoard){
+        const expanded = Boolean(state.mobileColumns[step]);
+        applyExpansion(expanded);
+        const toggle = () => {
+          const next = !col.classList.contains('expanded');
+          if(next){
+            state.mobileColumns[step] = true;
+          }else{
+            delete state.mobileColumns[step];
+          }
+          applyExpansion(next);
+        };
+        if(toggleBtn){
+          toggleBtn.addEventListener('click', e=>{ e.stopPropagation(); toggle(); });
+        }
+        if(header){
+          header.setAttribute('role','button');
+          header.tabIndex = 0;
+          header.addEventListener('click', e=>{
+            if(e.target.closest('.column-toggle')) return;
+            toggle();
+          });
+          header.addEventListener('keypress', e=>{
+            if(e.key === 'Enter' || e.key === ' '){
+              e.preventDefault();
+              toggle();
+            }
+          });
+        }
+      }else{
+        applyExpansion(true);
+      }
+
+      container.appendChild(col);
+    });
+  }
+
+  function cardLead(r){
+    const d = document.createElement('article');
+    d.className = 'card-lead';
+    d.tabIndex = 0;
+    d.setAttribute('role','button');
+    d.dataset.id = r.id;
+    d.dataset.step = etapaGroup(r.etapa);
+    const priorityScore = computeLeadPriorityScore(r);
+    const priorityLevel = resolveLeadPriorityLevel(priorityScore);
+    if(priorityLevel){
+      d.dataset.priority = priorityLevel;
+    }else{
+      delete d.dataset.priority;
+    }
+    const priorityLabel = formatLeadPriorityLabel(priorityLevel);
+    const priorityPill = priorityLabel ? `<span class="pill priority-pill priority-${priorityLevel}">${priorityLabel}</span>` : '';
+    const campusLabel = [r.campus, r.modalidad].filter(Boolean).join(' · ');
+    const campusTag = campusLabel ? `<span class="tag">${escapeHtml(campusLabel)}</span>` : '';
+    const idPill = userPreferences.showLeadId && r.id ? `<span class="pill id-pill">ID ${escapeHtml(String(r.id))}</span>` : '';
+    const phoneValue = fmtPhone(r.telefono || r.telefonoNormalizado);
+    const phonePill = phoneValue ? `<span class="pill">${escapeHtml(phoneValue)}</span>` : '';
+    const mailPill = r.correo ? `<span class="pill">${escapeHtml(r.correo)}</span>` : '';
+    const programLine = r.programa ? `<div class="muted">${escapeHtml(r.programa)}</div>` : '';
+    const estadoLine = `<div class="muted">${escapeHtml(r.estado || '—')} · ${escapeHtml(displayAsesorName(r.asesor))}</div>`;
+    const reassignBadge = renderAutoReassignBadge(r);
+    const customTagBadges = renderLeadTagBadges(r);
+    const tagRow = customTagBadges ? `<div class="card-tags">${customTagBadges}</div>` : '';
+    d.innerHTML = `
+      <div class="row between align-start">
+        <strong>${escapeHtml(r.nombre || 'Sin nombre')}</strong>
+        <div class="row gap6 align-center">
+          ${priorityPill}
+          ${campusTag}
+        </div>
+      </div>
+      ${programLine}
+      ${estadoLine}
+      ${reassignBadge ? reassignBadge : ''}
+      ${tagRow}
+      <div class="row gap8" style="margin-top:8px">
+        ${idPill}
+        ${phonePill}
+        ${mailPill}
+      </div>
+    `;
+    d.addEventListener('click', ()=>openDetails(r));
+    d.addEventListener('keypress',e=>{ if(e.key==="Enter") openDetails(r) });
+    return d;
+  }
+
+  // —— Render Tabla ——
+  function renderTabla(rows){
+    const tbody = el('#tbody');
+    if(!tbody) return;
+    tbody.innerHTML = '';
+    if(!Array.isArray(rows) || !rows.length){
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = columns.length;
+      td.className = 'table-empty';
+      td.textContent = 'No hay leads que cumplan los filtros seleccionados.';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    const formatValue = value => {
+      if(value === undefined || value === null || value === '') return '—';
+      return escapeHtml(String(value));
+    };
+    rows.forEach(r => {
+      const etapaLabel = r.etapa || '—';
+      const etapaClass = etapaLabel === 'Inscrito' ? 'ok' : etapaLabel === 'Descartado' ? 'bad' : '';
+      const tr = document.createElement('tr');
+      const tagBadges = renderLeadTagBadges(r);
+      const reassignBadge = renderAutoReassignBadge(r);
+      tr.innerHTML = `
+        <td>${r.id}</td>
+        <td>${r.nombre}</td>
+        <td>${r.matricula}</td>
+        <td>${r.correo}</td>
+        <td>${fmtPhone(r.telefono || r.telefonoNormalizado)}</td>
+        <td>${r.campus}</td>
+        <td>${r.modalidad}</td>
+        <td>${r.programa}</td>
+        <td><span class="tag ${r.etapa==='Inscrito'?'ok':''} ${r.etapa==='Descartado'?'bad':''}">${r.etapa}</span></td>
+        <td>${r.estado}</td>
+        <td>${displayAsesorName(r.asesor)}${reassignBadge ? reassignBadge : ''}</td>
+        <td>${r.comentario}${tagBadges ? `<div class="card-tags">${tagBadges}</div>` : ''}</td>
+        <td>${r.asignacion}</td>
+      `;
+      tr.addEventListener('click', ()=>openDetails(r));
+      tr.addEventListener('keypress', e=>{ if(e.key === 'Enter'){ openDetails(r); } });
+      tr.tabIndex = 0;
+      tbody.appendChild(tr);
+    });
+  }
+
+  // —— Detalle ——
+  function openDetails(r){
+    detailLeadContext = r;
+    el('#d-nombre').textContent = r.nombre || '—';
+    const basePhone = r.telefono || r.telefonoNormalizado || '';
+    currentLeadRecord = r;
+    updateFavoriteToggleState();
+    rememberRecentLead(r);
+    const showField = (val,labelId,valueId,fmt)=>{
+      const has = Boolean(val);
+      const labelEl = el('#'+labelId);
+      const valueEl = el('#'+valueId);
+      if(labelEl){
+        labelEl.classList.toggle('hidden', !has);
+      }
+      if(valueEl){
+        valueEl.classList.toggle('hidden', !has);
+        if(has) valueEl.textContent = fmt ? fmt(val) : val;
+      }
+    };
+    showField(r.matricula,'lab-matricula','d-matricula');
+    showField(basePhone,'lab-tel','d-tel',fmtPhone);
+    showField(r.correo,'lab-mail','d-mail');
+    showField(r.campus,'lab-campus','d-campus');
+    showField(r.modalidad,'lab-modalidad','d-modalidad');
+    showField(r.programa,'lab-programa','d-programa');
+    updateLeadDetailAssignmentDisplay(r);
+    updateLeadTagsSection(r);
+    updateAutoReassignDetail(r);
+
+    const stageEl = el('#d-etapa');
+    const panelEl = el('#panelOverlay .panel');
+
+    const updateDetailState = () => {
+      const etapaTexto = r.etapa || '—';
+      if(stageEl){
+        stageEl.textContent = etapaTexto;
+        stageEl.classList.toggle('is-empty', !r.etapa);
+      }
+      showField(r.estado,'lab-estado','d-estado');
+      const drawerEtapa = document.getElementById('drawerEtapaVal');
+      if(drawerEtapa){
+        drawerEtapa.textContent = r.etapa || '—';
+      }
+      const drawerEstado = document.getElementById('drawerEstadoVal');
+      if(drawerEstado){
+        drawerEstado.textContent = r.estado || '—';
+      }
+      if(panelEl){
+        const slug = etapaSlug(r.etapa);
+        if(slug){
+          panelEl.setAttribute('data-etapa', slug);
+        }else{
+          panelEl.removeAttribute('data-etapa');
+        }
+      }
+    };
+    updateDetailState();
+
+    if(!window.matchMedia('(max-width: 1200px)').matches){
+      showPanelOverlay();
+    }else{
+      hidePanelOverlay();
+    }
+
+    let contactScripts = buildContactScripts(r);
+
+    const registerContactNote = type => {
+      const note = createContactNote(type, r);
+      if(!note) return;
+      const existing = String(r.comentario || '').trim();
+      const lines = existing ? existing.split(/\n+/).map(line => line.trim()).filter(Boolean) : [];
+      if(lines.includes(note)) return;
+      lines.push(note);
+      r.comentario = lines.join('\n');
+      formSets.forEach(set => {
+        if(set.comentarioInput){
+          set.comentarioInput.value = r.comentario;
+        }
+      });
+      syncSaveAvailability();
+    };
+
+    const formSets = [];
+    const canEditLead = canPerform('updateLead');
+    const COMMENT_REQUIRED_TITLE = 'Agrega una nota de seguimiento';
+    const COMMENT_REQUIRED_BODY = 'Describe brevemente la conversación y la próxima acción antes de guardar los cambios.';
+
+    const clearFormMessage = controls => {
+      if(!controls || !controls.feedbackEl) return;
+      controls.feedbackEl.classList.add('hidden');
+      controls.feedbackEl.removeAttribute('data-tone');
+      if(controls.feedbackTitleEl) controls.feedbackTitleEl.textContent = '';
+      if(controls.feedbackMessageEl) controls.feedbackMessageEl.textContent = '';
+    };
+
+    const showFormMessage = (controls, tone, title, message) => {
+      if(!controls || !controls.feedbackEl) return;
+      if(tone){
+        controls.feedbackEl.setAttribute('data-tone', tone);
+      }else{
+        controls.feedbackEl.removeAttribute('data-tone');
+      }
+      controls.feedbackEl.classList.remove('hidden');
+      if(controls.feedbackTitleEl) controls.feedbackTitleEl.textContent = title || '';
+      if(controls.feedbackMessageEl) controls.feedbackMessageEl.textContent = message || '';
+    };
+
+    const clearAllMessages = () => { formSets.forEach(clearFormMessage); };
+    const broadcastMessage = (tone, title, message) => { formSets.forEach(set => showFormMessage(set, tone, title, message)); };
+
+    const applyFormState = controls => {
+      if(!controls) return;
+      if(controls.etapaSelect){
+        controls.etapaSelect.value = r.etapa || '';
+      }
+      if(controls.estadoSelect){
+        fillEstadoOptions(r.etapa, controls.estadoSelect);
+        const hasOption = Array.from(controls.estadoSelect.options || []).some(opt => opt.value === r.estado);
+        controls.estadoSelect.value = hasOption ? r.estado : (controls.estadoSelect.options[0]?.value || '');
+        if(!hasOption){
+          r.estado = controls.estadoSelect.value || r.estado;
+          updateDetailState();
+        }
+      }
+      if(controls.comentarioInput){
+        controls.comentarioInput.value = r.comentario || '';
+      }
+    };
+
+    const refreshForms = () => {
+      formSets.forEach(applyFormState);
+      syncSaveAvailability();
+    };
+
+    let isSaving = false;
+    const handleUpdate = async button => {
+      if(isSaving) return;
+      if(!canPerform('updateLead')){
+        alert('No tienes permisos para actualizar leads.');
+        return;
+      }
+      clearAllMessages();
+      const etapaChanged = r.etapa !== r._originalEtapa;
+      const estadoChanged = r.estado !== r._originalEstado;
+      const comentarioActual = (r.comentario || '').trim();
+      const comentarioChanged = comentarioActual !== (r._originalComentario || '').trim();
+      if(!etapaChanged && !estadoChanged && !comentarioChanged){
+        alert('No hay cambios para guardar');
+        return;
+      }
+      const commentText = (r.comentario || '').trim();
+      if(!commentText){
+        broadcastScriptStatus('Agrega una nota en el comentario antes de guardar.');
+        const commentControl = formSets.find(set => set.comentarioInput)?.comentarioInput;
+        if(commentControl){
+          commentControl.focus();
+        }
+        alert('Agrega un comentario antes de guardar.');
+        return;
+      }
+      const registrarToque = etapaChanged || estadoChanged;
+      if(registrarToque && !comentarioActual){
+        broadcastMessage('error', COMMENT_REQUIRED_TITLE, COMMENT_REQUIRED_BODY);
+        const currentSet = formSets.find(set => set.updateBtn === button);
+        if(currentSet?.comentarioInput){
+          currentSet.comentarioInput.focus();
+        }
+        return;
+      }
+      const targetSheet = state.sheet === ALL_SHEETS_VALUE ? (r.base || '') : state.sheet;
+      if(!targetSheet){
+        alert('No se pudo determinar la base del lead.');
+        return;
+      }
+      const params = new URLSearchParams({
+        action: 'updateLead',
+        id: r.id,
+        sheet: targetSheet,
+        etapa: etapaBackend(r.etapa),
+        estado: r.estado,
+        comentario: comentarioActual,
+        registrarToque: registrarToque ? 'true' : 'false'
+      });
+      if(registrarToque){
+        params.set('fecha', new Date().toISOString());
+      }
+      const buttons = formSets.map(set => set.updateBtn).filter(Boolean);
+      try{
+        isSaving = true;
+        buttons.forEach(btn => { btn.disabled = true; });
+        const res = await apiFetch(`${API_URL}?${params.toString()}`);
+        if(!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if(data?.error) throw new Error(data.error);
+        const updated = data?.lead || {};
+        if(updated.etapa !== undefined) r.etapa = etapaLabel(updated.etapa);
+        if(updated.estado !== undefined) r.estado = updated.estado;
+        if(updated.comentario !== undefined) r.comentario = updated.comentario;
+        if(updated.asignacion !== undefined) r.asignacion = updated.asignacion;
+        if(updated.resolucion !== undefined) r.resolucion = updated.resolucion;
+        if(Array.isArray(updated.toques)){
+          ['toque1','toque2','toque3','toque4'].forEach((k,idx) => {
+            if(updated.toques[idx] !== undefined) r[k] = updated.toques[idx];
+          });
+        }
+        r._originalEtapa = r.etapa;
+        r._originalEstado = r.estado;
+        r._originalComentario = (r.comentario || '').trim();
+        updateDetailState();
+        refreshForms();
+        alert('Actualizado');
+        refresh();
+      }catch(err){
+        console.error('Error al actualizar', err);
+        const message = resolveErrorMessage(err, 'No se pudo actualizar el lead.');
+        broadcastMessage('error', 'No se pudo actualizar el lead', message);
+      }finally{
+        buttons.forEach(btn => { btn.disabled = false; });
+        isSaving = false;
+      }
+    };
+
+    const attachListeners = controls => {
+      if(!controls) return;
+      if(controls.comentarioInput){
+        controls.comentarioInput.oninput = () => {
+          r.comentario = controls.comentarioInput.value;
+          clearAllMessages();
+          formSets.forEach(set=>{
+            if(set !== controls && set.comentarioInput){
+              set.comentarioInput.value = r.comentario || '';
+            }
+          });
+        };
+      }
+      if(controls.etapaSelect){
+        controls.etapaSelect.onchange = () => {
+          r.etapa = controls.etapaSelect.value;
+          const nextEstado = (estadosByEtapa[r.etapa] || [''])[0] || '';
+          r.estado = nextEstado;
+          clearAllMessages();
+          updateDetailState();
+          formSets.forEach(set => {
+            if(set.etapaSelect){
+              set.etapaSelect.value = r.etapa;
+            }
+            if(set.estadoSelect){
+              fillEstadoOptions(r.etapa, set.estadoSelect);
+              const hasOpt = Array.from(set.estadoSelect.options || []).some(opt => opt.value === r.estado);
+              set.estadoSelect.value = hasOpt ? r.estado : (set.estadoSelect.options[0]?.value || '');
+              if(!hasOpt){
+                r.estado = set.estadoSelect.value || '';
+                updateDetailState();
+              }
+            }
+          });
+          refresh();
+        };
+      }
+      if(controls.estadoSelect){
+        controls.estadoSelect.onchange = () => {
+          r.estado = controls.estadoSelect.value;
+          clearAllMessages();
+          updateDetailState();
+          formSets.forEach(set => {
+            if(set !== controls && set.estadoSelect){
+              const hasOpt = Array.from(set.estadoSelect.options || []).some(opt => opt.value === r.estado);
+              if(hasOpt){
+                set.estadoSelect.value = r.estado;
+              }
+            }
+          });
+          refresh();
+        };
+      }
+      if(controls.updateBtn){
+        controls.updateBtn.onclick = () => handleUpdate(controls.updateBtn);
+      }
+    };
+
+    const registerForm = controls => {
+      if(!controls) return;
+      const hasControl = Boolean(controls.etapaSelect || controls.estadoSelect || controls.comentarioInput || controls.updateBtn);
+      if(!hasControl) return;
+      if(controls.etapaSelect){
+        fillEtapaSelect(controls.etapaSelect);
+      }
+      formSets.push(controls);
+      applyFormState(controls);
+      clearFormMessage(controls);
+      if(!canEditLead){
+        if(controls.etapaSelect) controls.etapaSelect.disabled = true;
+        if(controls.estadoSelect) controls.estadoSelect.disabled = true;
+        if(controls.comentarioInput){
+          controls.comentarioInput.disabled = true;
+        }
+        if(controls.updateBtn){
+          controls.updateBtn.disabled = true;
+          controls.updateBtn.title = 'No tienes permisos para actualizar leads.';
+        }
+        return;
+      }
+      attachListeners(controls);
+      syncSaveAvailability();
+    };
+
+    const applyContactScripts = () => {
+      contactScripts = buildContactScripts(r);
+      broadcastScriptStatus('');
+      ['contactScripts','drawerContactScripts'].forEach(id => {
+        const container = document.getElementById(id);
+        if(!container) return;
+        CONTACT_SCRIPT_TYPES.forEach(type => {
+          const textEl = container.querySelector(`[data-script-text="${type}"]`);
+          if(textEl){
+            textEl.value = contactScripts[type] || 'No hay guion disponible para este lead.';
+          }
+          const actionBtn = container.querySelector(`[data-script-apply="${type}"]`);
+          if(actionBtn){
+            actionBtn.disabled = !contactScripts[type];
+            actionBtn.onclick = async event => {
+              event.preventDefault();
+              if(!contactScripts[type]) return;
+              const copied = await copyToClipboard(contactScripts[type]);
+              registerContactNote(type);
+              broadcastScriptStatus(copied ? `${CONTACT_CHANNEL_LABELS[type]} copiado. Completa la nota y guarda el lead.` : `${CONTACT_CHANNEL_LABELS[type]} registrado. Copia el guion manualmente si lo necesitas.`);
+            };
+          }
+        });
+      });
+    };
+
+    registerForm({
+      etapaSelect: el('#selEtapa'),
+      estadoSelect: el('#selEstado'),
+      comentarioInput: el('#txtComentario'),
+      updateBtn: el('#updateBtn'),
+      feedbackEl: el('#panelFeedback'),
+      feedbackTitleEl: el('#panelFeedbackTitle'),
+      feedbackMessageEl: el('#panelFeedbackMessage')
+    });
+
+    const leadUpdateFormEl = el('#leadUpdateForm');
+    if(leadUpdateFormEl){
+      leadUpdateFormEl.addEventListener('submit', event => {
+        event.preventDefault();
+        const updateButton = el('#updateBtn');
+        if(updateButton && !updateButton.disabled){
+          updateButton.click();
+        }
+      });
+    }
+
+    const phone = parsePhone(basePhone);
+    const phoneDigits = phone.intl || phone.digits;
+    const waDigits = phone.wa || phoneDigits;
+    const phoneDisplay = fmtPhone(basePhone);
+    const normalizedIntl = phoneDigits ? `+${String(phoneDigits).replace(/^\+/, '')}` : '';
+    const e164Number = normalizedIntl || '';
+    const telUrl = phone.local
+      ? (phone.local.length === 10 ? `tel:+52${phone.local}` : `tel:${phone.local}`)
+      : (phoneDigits ? `tel:${normalizedIntl || phoneDigits}` : '');
+    const callFallbackUrl = r.callUrl || (phoneDigits && phoneDigits.length >= 10 ? `https://dashboard.aircall.io/call/${phoneDigits}` : '');
+    const waHref = r.whatsappUrl || (waDigits && waDigits.length >= 8 ? `https://wa.me/${waDigits}` : '');
+    const mailtoHref = r.correo ? `mailto:${encodeURIComponent(r.correo)}` : '';
+    const hasPhoneValue = Boolean(phoneDisplay);
+    const hasCallLink = Boolean(e164Number || callFallbackUrl || telUrl);
+    const hasWaLink = Boolean(waDigits && waDigits.length >= 8);
+    const hasMailLink = Boolean(r.correo);
+
+    const emailScript = contactScripts.email || '';
+    const emailLines = emailScript.split('\n');
+    const subjectLine = emailLines.length ? emailLines[0] : '';
+    const defaultEmailSubject = subjectLine && /^\s*Asunto:/i.test(subjectLine)
+      ? subjectLine.replace(/^\s*Asunto:\s*/i, '').trim()
+      : `Seguimiento UNIDEP ${r.programa || 'tu inscripción'}`;
+    const defaultEmailBody = emailLines.length > 1 ? emailLines.slice(1).join('\n').trim() : '';
+
+    const assignContactHandlers = (nodes, handler, linkOptions) => {
+      nodes.forEach(anchor => {
+        if(!anchor) return;
+        let hrefValue = '';
+        let targetValue = '';
+        let relValue = '';
+        let datasetValues = null;
+        if(typeof linkOptions === 'string'){
+          hrefValue = linkOptions;
+        }else if(linkOptions && typeof linkOptions === 'object'){
+          hrefValue = linkOptions.href || '';
+          targetValue = linkOptions.target || '';
+          relValue = linkOptions.rel || '';
+          datasetValues = linkOptions.dataset || null;
+        }
+        if(hrefValue){
+          anchor.href = hrefValue;
+        }else{
+          anchor.removeAttribute('href');
+        }
+        if(targetValue){
+          anchor.target = targetValue;
+        }else{
+          anchor.removeAttribute('target');
+        }
+        if(relValue){
+          anchor.rel = relValue;
+        }else{
+          anchor.removeAttribute('rel');
+        }
+        if(datasetValues && typeof datasetValues === 'object'){
+          Object.entries(datasetValues).forEach(([key, value]) => {
+            const dataKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+            if(value === undefined || value === null || value === ''){
+              delete anchor.dataset[key];
+              anchor.removeAttribute(`data-${dataKey}`);
+            }else{
+              anchor.dataset[key] = value;
+            }
+          });
+        }
+        if(handler){
+          anchor.classList.remove('hidden');
+          anchor.onclick = handler;
+        }else{
+          anchor.classList.add('hidden');
+          anchor.onclick = null;
+        }
+      });
+    };
+
+    const callHandler = hasCallLink ? event => {
+      event.preventDefault();
+      registerContactNote('call');
+      openAircallLink({ e164: e164Number, fallbackUrl: callFallbackUrl, telUrl });
+    } : null;
+
+    const whatsappHandler = hasWaLink ? event => {
+      event.preventDefault();
+      showWhatsAppModal({
+        lead: r,
+        digits: waDigits,
+        defaultMessage: contactScripts.whatsapp || '',
+        onSend: () => registerContactNote('whatsapp')
+      });
+    } : null;
+
+    const emailHandler = hasMailLink ? event => {
+      event.preventDefault();
+      showEmailModal({
+        lead: r,
+        email: r.correo,
+        defaultSubject: defaultEmailSubject,
+        defaultBody: defaultEmailBody,
+        mailtoFallback: mailtoHref,
+        onSend: () => registerContactNote('email')
+      });
+    } : null;
+
+    const applyPanelContactButtons = () => {
+      const panelEl = el('#panelOverlay .panel');
+      if(!panelEl) return;
+      const callButtons = Array.from(panelEl.querySelectorAll('[data-contact="call"]'));
+      const waButtons = Array.from(panelEl.querySelectorAll('[data-contact="whatsapp"]'));
+      const mailButtons = Array.from(panelEl.querySelectorAll('[data-contact="email"]'));
+      assignContactHandlers(callButtons, callHandler, {
+        href: callFallbackUrl || telUrl || '#',
+        dataset: {
+          fallbackHref: callFallbackUrl || '',
+          telHref: telUrl || ''
+        }
+      });
+      assignContactHandlers(waButtons, whatsappHandler, waHref || '#');
+      assignContactHandlers(mailButtons, emailHandler, mailtoHref || '#');
+    };
+
+    const applyDrawerContactButtons = () => {
+      const drawerContainer = document.getElementById('drawerContent');
+      if(!drawerContainer) return;
+      const callButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="call"]'));
+      const waButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="whatsapp"]'));
+      const mailButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="email"]'));
+      assignContactHandlers(callButtons, callHandler, {
+        href: callFallbackUrl || telUrl || '#',
+        dataset: {
+          fallbackHref: callFallbackUrl || '',
+          telHref: telUrl || ''
+        }
+      });
+      assignContactHandlers(waButtons, whatsappHandler, waHref || '#');
+      assignContactHandlers(mailButtons, emailHandler, mailtoHref || '#');
+    };
+
+    applyPanelContactButtons();
+
+    if (window.matchMedia('(max-width: 1200px)').matches){
+      const drawer = el('#drawer');
+      drawer.classList.add('open');
+      drawer.ariaHidden = 'false';
+      const summaryParts = [r.campus, r.modalidad, r.programa].filter(Boolean);
+      const summaryHtml = summaryParts.length ? `<div class="drawer-summary">${summaryParts.join(' · ')}</div>` : '';
+      const infoRows = [
+        r.matricula ? `<div class="muted">Matrícula</div><div>${r.matricula}</div>` : '',
+        hasPhoneValue ? `<div class="muted">Teléfono</div><div>${phoneDisplay}</div>` : '',
+        r.correo ? `<div class="muted">Correo</div><div>${r.correo}</div>` : '',
+        r.campus ? `<div class="muted">Plantel</div><div>${r.campus}</div>` : '',
+        r.modalidad ? `<div class="muted">Modalidad</div><div>${r.modalidad}</div>` : '',
+        r.programa ? `<div class="muted">Programa</div><div>${r.programa}</div>` : ''
+      ].filter(Boolean).join('');
+      el('#drawerContent').innerHTML = `
+        <h3>${r.nombre}</h3>
+        ${summaryHtml}
+        <div class="kv" style="margin:10px 0">
+          ${infoRows}
+          <div class="muted">Etapa</div><div id="drawerEtapaVal">${r.etapa || '—'}</div>
+          <div class="muted">Estado</div><div id="drawerEstadoVal">${r.estado || '—'}</div>
+        </div>
+        <section class="drawer-quick" aria-label="Actualiza y contacta">
+          <p class="drawer-quick__hint">Actualiza etapa y estado antes de abrir un nuevo contacto.</p>
+          <div class="drawer-quick__shortcuts" role="group" aria-label="Accesos rápidos de contacto">
+            ${hasCallLink?`<a class="btn" id="drawerActCall" data-drawer-contact="call" href="#"><i class='bi bi-telephone'></i> Llamar</a>`:''}
+            ${hasWaLink?`<a class="btn" id="drawerActWa" data-drawer-contact="whatsapp" href="#"><i class='bi bi-whatsapp'></i> WhatsApp</a>`:''}
+            ${hasMailLink?`<a class="btn" id="drawerActMail" data-drawer-contact="email" href="#"><i class='bi bi-envelope'></i> Email</a>`:''}
+          </div>
+          <label class="drawer-quick__field">Etapa
+            <select id="drawerEtapa" class="w100"></select>
+          </label>
+          <label class="drawer-quick__field">Estado
+            <select id="drawerEstado" class="w100"></select>
+          </label>
+          <label class="drawer-quick__field">Comentario
+            <textarea id="drawerComentario" class="w100" rows="3"></textarea>
+          </label>
+          <div class="drawer-quick__feedback hidden" id="drawerFeedback" role="alert" aria-live="assertive">
+            <strong id="drawerFeedbackTitle"></strong>
+            <p id="drawerFeedbackMessage"></p>
+          </div>
+          <div class="drawer-quick__actions">
+            <button class="btn primary" type="button" id="drawerUpdateBtn">Guardar actualización</button>
+          </div>
+          <p class="contact-scripts__status hidden" id="drawerContactScriptStatus" role="status" aria-live="polite"></p>
+        </section>
+        <section class="calendar-form drawer-calendar" data-calendar-form aria-label="Agendar recordatorio">
+          <h4>Agendar recordatorio</h4>
+          <p>Programa un seguimiento en Google Calendar con los datos del lead.</p>
+          <div class="calendar-form__grid">
+            <label>Fecha
+              <input type="date" id="drawerCalendarDate" data-calendar-date required />
+            </label>
+            <label>Hora
+              <input type="time" id="drawerCalendarTime" data-calendar-time required />
+            </label>
+            <label>Duración
+              <select id="drawerCalendarDuration" data-calendar-duration>
+                <option value="15">15 minutos</option>
+                <option value="30">30 minutos</option>
+                <option value="45">45 minutos</option>
+                <option value="60">60 minutos</option>
+              </select>
+            </label>
+          </div>
+          <div class="calendar-form__actions">
+            <button class="btn outline" type="button" id="drawerCalendarCreateBtn" data-calendar-create disabled>
+              <i class='bi bi-calendar-plus'></i> Crear recordatorio
+            </button>
+          </div>
+          <p class="calendar-form__status" id="drawerCalendarStatus" data-calendar-status role="status" aria-live="polite"></p>
+        </section>`;
+      applyDrawerContactButtons();
+      registerForm({
+        etapaSelect: el('#drawerEtapa'),
+        estadoSelect: el('#drawerEstado'),
+        comentarioInput: el('#drawerComentario'),
+        updateBtn: el('#drawerUpdateBtn'),
+        feedbackEl: el('#drawerFeedback'),
+        feedbackTitleEl: el('#drawerFeedbackTitle'),
+        feedbackMessageEl: el('#drawerFeedbackMessage')
+      });
+    }
+    prepareCalendarForm(r);
+    applyContactScripts();
+    syncSaveAvailability();
+  }
+
+
+  // —— Util ——
+  const parsePhone = raw => {
+    const normalized = cleanValue(raw);
+    if(!normalized) return { raw: '', digits: '', local: '', intl: '', wa: '' };
+    const digitsOriginal = normalized.replace(/\D/g,'');
+    if(!digitsOriginal) return { raw: normalized, digits: '', local: '', intl: '', wa: '' };
+    let digits = digitsOriginal;
+    if(digits.startsWith('0052')){
+      digits = digits.slice(4);
+    }
+    if(digits.startsWith('521')){
+      digits = digits.slice(3);
+    }else if(digits.startsWith('52')){
+      digits = digits.slice(2);
+    }
+    if(digits.length > 10 && (digits.startsWith('044') || digits.startsWith('045'))){
+      digits = digits.slice(3);
+    }
+    if(digits.length > 10 && digits.startsWith('01')){
+      digits = digits.slice(2);
+    }
+    if(digits.length === 11 && digits.startsWith('1')){
+      digits = digits.slice(1);
+    }
+    if(digits.startsWith('0') && digits.length > 10){
+      digits = digits.replace(/^0+/, '');
+    }
+    let local = digits;
+    if(local.length > 10){
+      local = local.slice(0, 10);
+    }
+    if(local.length < 7){
+      return { raw: normalized, digits: '', local: '', intl: '', wa: '' };
+    }
+    const intl = local.length === 10 ? `52${local}` : digitsOriginal;
+    const wa = local.length === 10 ? `521${local}` : digitsOriginal;
+    return { raw: normalized, digits: digitsOriginal, local, intl, wa };
+  };
+
+  const fmtPhone = p => {
+    const phone = parsePhone(p);
+    const local = phone.local;
+    if(local){
+      if(local.length === 10){
+        return `${local.slice(0,3)} ${local.slice(3,6)} ${local.slice(6)}`;
+      }
+      return local;
+    }
+    return phone.raw || '';
+  };
+
+  function updateLeadDetailAssignmentDisplay(lead){
+    const labelEl = el('#lab-asesor');
+    const valueEl = el('#d-asesor');
+    const value = displayAsesorName(lead && lead.asesor);
+    const hasValue = Boolean(value);
+    if(labelEl){
+      labelEl.classList.toggle('hidden', !hasValue);
+    }
+    if(valueEl){
+      valueEl.classList.toggle('hidden', !hasValue);
+      valueEl.textContent = hasValue ? value : '—';
+    }
+  }
+
+  function renderLeadTagBadges(lead){
+    const tags = getLeadTagsForLead(lead ? lead.id : '');
+    if(!tags.length) return '';
+    return tags
+      .map(tag => `<span class="tag tag-custom" style="--tag-color:${sanitizeTagColor(tag.color)}">${escapeHtml(tag.label)}</span>`)
+      .join('');
+  }
+
+  function updateLeadTagsSection(lead){
+    leadTagContext.leadId = lead && lead.id ? String(lead.id) : '';
+    leadTagContext.editingIndex = -1;
+    const addBtn = el('#leadTagAdd');
+    if(addBtn){
+      addBtn.disabled = !leadTagContext.leadId;
+    }
+    hideLeadTagForm();
+    setLeadTagFeedback('');
+    renderLeadTagList(lead);
+  }
+
+  function renderLeadTagList(lead){
+    const listEl = el('#leadTagList');
+    if(!listEl) return;
+    const tags = getLeadTagsForLead(lead ? lead.id : leadTagContext.leadId);
+    if(!tags.length){
+      listEl.classList.add('is-empty');
+      listEl.innerHTML = '<span>Sin etiquetas personalizadas.</span>';
+      return;
+    }
+    listEl.classList.remove('is-empty');
+    listEl.innerHTML = tags
+      .map((tag, index) => {
+        const color = sanitizeTagColor(tag.color);
+        const label = escapeHtml(tag.label);
+        return `<span class="panel-tags__chip" data-tag-index="${index}" style="--tag-color:${color}"><span class="panel-tags__dot" aria-hidden="true"></span><span class="panel-tags__label">${label}</span><button type="button" class="panel-tags__remove" data-remove-index="${index}" aria-label="Eliminar etiqueta ${label}"><i class="bi bi-x"></i></button></span>`;
+      })
+      .join('');
+  }
+
+  function setLeadTagFeedback(message){
+    const feedback = el('#leadTagFeedback');
+    if(!feedback) return;
+    if(message){
+      feedback.textContent = message;
+      feedback.classList.remove('hidden');
+    }else{
+      feedback.textContent = '';
+      feedback.classList.add('hidden');
+    }
+  }
+
+  function startLeadTagCreation(){
+    if(!leadTagContext.leadId) return;
+    leadTagContext.editingIndex = -1;
+    const form = el('#leadTagForm');
+    const nameInput = el('#leadTagName');
+    const colorInput = el('#leadTagColor');
+    if(form) form.classList.remove('hidden');
+    if(colorInput) colorInput.value = DEFAULT_TAG_COLOR;
+    if(nameInput){
+      nameInput.value = '';
+      nameInput.focus();
+    }
+    setLeadTagFeedback('');
+  }
+
+  function startLeadTagEdit(index){
+    if(!leadTagContext.leadId) return;
+    const tags = getLeadTagsForLead(leadTagContext.leadId);
+    if(index < 0 || index >= tags.length) return;
+    leadTagContext.editingIndex = index;
+    const tag = tags[index];
+    const form = el('#leadTagForm');
+    const nameInput = el('#leadTagName');
+    const colorInput = el('#leadTagColor');
+    if(form) form.classList.remove('hidden');
+    if(nameInput){
+      nameInput.value = tag.label;
+      nameInput.focus();
+      nameInput.select();
+    }
+    if(colorInput) colorInput.value = sanitizeTagColor(tag.color);
+    setLeadTagFeedback('');
+  }
+
+  function hideLeadTagForm(){
+    const form = el('#leadTagForm');
+    if(form) form.classList.add('hidden');
+    leadTagContext.editingIndex = -1;
+  }
+
+  function handleLeadTagSubmit(event){
+    event.preventDefault();
+    if(!leadTagContext.leadId) return;
+    const nameInput = el('#leadTagName');
+    const colorInput = el('#leadTagColor');
+    const label = nameInput ? nameInput.value.trim() : '';
+    if(!label){
+      setLeadTagFeedback('Escribe un nombre para la etiqueta.');
+      if(nameInput) nameInput.focus();
+      return;
+    }
+    const color = colorInput ? sanitizeTagColor(colorInput.value) : DEFAULT_TAG_COLOR;
+    const tags = getLeadTagsForLead(leadTagContext.leadId);
+    if(leadTagContext.editingIndex >= 0 && leadTagContext.editingIndex < tags.length){
+      tags[leadTagContext.editingIndex] = { ...tags[leadTagContext.editingIndex], label, color };
+    }else{
+      tags.push({ id: generateTagId(), label, color });
+    }
+    saveLeadTagsForLead(leadTagContext.leadId, tags);
+    hideLeadTagForm();
+    setLeadTagFeedback('Etiqueta guardada.');
+    renderLeadTagList(detailLeadContext);
+    refresh();
+  }
+
+  function handleLeadTagListClick(event){
+    const removeBtn = event.target.closest('[data-remove-index]');
+    if(removeBtn){
+      const index = Number(removeBtn.getAttribute('data-remove-index'));
+      if(Number.isFinite(index) && leadTagContext.leadId){
+        const tags = getLeadTagsForLead(leadTagContext.leadId);
+        if(index >= 0 && index < tags.length){
+          tags.splice(index, 1);
+          saveLeadTagsForLead(leadTagContext.leadId, tags);
+          renderLeadTagList(detailLeadContext);
+          setLeadTagFeedback('Etiqueta eliminada.');
+          refresh();
+        }
+      }
+      return;
+    }
+    const chip = event.target.closest('[data-tag-index]');
+    if(chip){
+      const index = Number(chip.getAttribute('data-tag-index'));
+      if(Number.isFinite(index)){
+        startLeadTagEdit(index);
+      }
+    }
+  }
+
+  function leadReassignmentScore(lead){
+    const stage = etapaGroup(lead && lead.etapa);
+    switch(stage){
+      case 'Nuevo': return 3;
+      case 'No Contactado': return 2;
+      case 'Contactado': return 1;
+      case 'Inscrito': return -1;
+      case 'Descartado': return -2;
+      default: return 0;
+    }
+  }
+
+  function isLeadEligibleForReassignment(lead){
+    if(!lead || !lead.id) return false;
+    const stage = etapaGroup(lead.etapa);
+    if(stage === 'Inscrito' || stage === 'Descartado') return false;
+    return true;
+  }
+
+  function buildAutoReassignmentPlan(rows){
+    const plan = {
+      stats: {
+        totalLeads: 0,
+        advisorCount: 0,
+        average: 0,
+        overloaded: [],
+        underloaded: [],
+        unassigned: 0
+      },
+      suggestions: []
+    };
+    const advisorMap = new Map();
+    const dataset = Array.isArray(rows) ? rows : [];
+    dataset.forEach(lead => {
+      if(!lead || !lead.id) return;
+      const key = normalizeAsesorName(lead.asesor);
+      if(!key){
+        plan.stats.unassigned++;
+        return;
+      }
+      if(!advisorMap.has(key)){
+        advisorMap.set(key, { key, name: displayAsesorName(lead.asesor), total: 0, leads: [] });
+      }
+      const entry = advisorMap.get(key);
+      entry.total++;
+      entry.leads.push(lead);
+    });
+    const entries = Array.from(advisorMap.values());
+    plan.stats.totalLeads = entries.reduce((sum, entry) => sum + entry.total, 0);
+    plan.stats.advisorCount = entries.length;
+    if(!entries.length || !plan.stats.totalLeads){
+      return plan;
+    }
+    const average = plan.stats.totalLeads / entries.length;
+    plan.stats.average = average;
+    const overloaded = entries.filter(entry => entry.total - average >= AUTO_REASSIGN_DIFFERENCE_THRESHOLD);
+    const underloaded = entries.filter(entry => average - entry.total >= AUTO_REASSIGN_DIFFERENCE_THRESHOLD);
+    plan.stats.overloaded = overloaded.map(entry => ({ key: entry.key, name: entry.name, total: entry.total })).sort((a,b) => b.total - a.total);
+    plan.stats.underloaded = underloaded.map(entry => ({ key: entry.key, name: entry.name, total: entry.total })).sort((a,b) => a.total - b.total);
+    if(!overloaded.length || !underloaded.length){
+      return plan;
+    }
+    const overQueue = overloaded
+      .map(entry => ({
+        key: entry.key,
+        name: entry.name,
+        total: entry.total,
+        leads: entries.find(e => e.key === entry.key)?.leads
+          .filter(isLeadEligibleForReassignment)
+          .sort((a, b) => leadReassignmentScore(b) - leadReassignmentScore(a)) || []
+      }))
+      .filter(entry => entry.leads.length);
+    const underQueue = underloaded.map(entry => ({ key: entry.key, name: entry.name, total: entry.total }));
+    const suggestions = [];
+    while(overQueue.length && underQueue.length){
+      overQueue.sort((a, b) => (b.total - average) - (a.total - average));
+      underQueue.sort((a, b) => (a.total - average) - (b.total - average));
+      const source = overQueue[0];
+      const target = underQueue[0];
+      if(!source || !target){
+        break;
+      }
+      let lead = null;
+      while(source.leads.length){
+        const candidate = source.leads.shift();
+        const decision = getStoredReassignmentDecision(candidate.id);
+        if(decision && decision.status === 'dismissed'){
+          continue;
+        }
+        if(decision && decision.status === 'applied'){
+          continue;
+        }
+        lead = candidate;
+        break;
+      }
+      if(!lead){
+        overQueue.shift();
+        continue;
+      }
+      if(source.key === target.key){
+        continue;
+      }
+      suggestions.push({
+        leadId: lead.id,
+        lead,
+        fromKey: source.key,
+        fromName: source.name,
+        toKey: target.key,
+        toName: target.name
+      });
+      source.total -= 1;
+      target.total += 1;
+      if(source.total - average < AUTO_REASSIGN_DIFFERENCE_THRESHOLD || !source.leads.length){
+        overQueue.shift();
+      }
+      if(average - target.total < AUTO_REASSIGN_DIFFERENCE_THRESHOLD){
+        underQueue.shift();
+      }
+    }
+    plan.suggestions = suggestions;
+    return plan;
+  }
+
+  function applyAutoReassignmentAnnotations(){
+    const suggestionMap = new Map();
+    (autoReassignmentPlan?.suggestions || []).forEach(item => {
+      if(item && item.leadId){
+        suggestionMap.set(String(item.leadId), item);
+      }
+    });
+    leads.forEach(lead => {
+      const id = String(lead.id || '');
+      if(!id) return;
+      const decision = getStoredReassignmentDecision(id);
+      if(decision && decision.status === 'applied' && decision.toName){
+        if(!lead._originalAsesor) lead._originalAsesor = lead._originalAsesor || lead.asesor;
+        lead.asesor = decision.toName;
+        lead.autoReassign = {
+          status: 'applied',
+          toName: decision.toName,
+          toKey: decision.toKey || normalizeAsesorName(decision.toName),
+          fromName: decision.fromName || lead._originalAsesor || '',
+          fromKey: decision.fromKey || normalizeAsesorName(decision.fromName || lead._originalAsesor || ''),
+          appliedAt: decision.updatedAt || Date.now()
+        };
+        return;
+      }
+      if(decision && decision.status === 'dismissed'){
+        delete lead.autoReassign;
+        return;
+      }
+      const suggestion = suggestionMap.get(id);
+      if(suggestion){
+        lead.autoReassign = {
+          status: 'pending',
+          toName: suggestion.toName,
+          toKey: suggestion.toKey,
+          fromName: suggestion.fromName,
+          fromKey: suggestion.fromKey
+        };
+      }else{
+        delete lead.autoReassign;
+      }
+    });
+  }
+
+  function formatAutoReassignSummary(stats, suggestionCount){
+    if(!stats) return 'Las cargas por asesor están equilibradas.';
+    const advisors = stats.advisorCount || 0;
+    if(!advisors) return 'Aún no hay asesores con leads asignados.';
+    const avg = stats.average || 0;
+    const averageLabel = `${avg.toFixed(1)} leads por asesor (${advisors} asesores analizados)`;
+    const suggestionLabel = suggestionCount
+      ? `${suggestionCount} reasignación${suggestionCount === 1 ? '' : 'es'} sugerida${suggestionCount === 1 ? '' : 's'}`
+      : 'Sin reasignaciones pendientes';
+    const unassigned = stats.unassigned || 0;
+    const unassignedLabel = unassigned ? ` · ${unassigned} lead${unassigned === 1 ? '' : 's'} sin asignar` : '';
+    return `${averageLabel} · ${suggestionLabel}${unassignedLabel}`;
+  }
+
+  function renderAutoReassignmentPanel(filteredRows){
+    const section = el('#autoReassignSection');
+    if(!section) return;
+    const summaryEl = el('#autoReassignSummary');
+    const listEl = el('#autoReassignList');
+    const paginationEl = el('#autoReassignPagination');
+    const suggestions = Array.isArray(autoReassignmentPlan?.suggestions) ? autoReassignmentPlan.suggestions : [];
+    let visibleSuggestions = suggestions;
+    let filteredOutByView = false;
+    if(Array.isArray(filteredRows) && filteredRows.length){
+      const allowedIds = new Set(filteredRows.map(row => String(row?.id || '')).filter(Boolean));
+      const subset = suggestions.filter(item => allowedIds.has(String(item?.leadId || '')));
+      if(subset.length){
+        visibleSuggestions = subset;
+      }else if(suggestions.length){
+        visibleSuggestions = [];
+        filteredOutByView = true;
+      }
+    }
+    const signature = JSON.stringify(visibleSuggestions.map(item => item?.leadId).filter(Boolean));
+    if(signature !== state.autoReassignSignature){
+      state.autoReassignSignature = signature;
+      state.autoReassignPage = 0;
+    }
+    const hasOverload = (autoReassignmentPlan?.stats?.overloaded || []).length > 0;
+    const totalSuggestions = suggestions.length;
+    if(summaryEl){
+      if(totalSuggestions){
+        let summaryText = formatAutoReassignSummary(autoReassignmentPlan?.stats, totalSuggestions);
+        if(filteredOutByView){
+          summaryText += ' · Ajusta los filtros para ver estas sugerencias.';
+        }
+        summaryEl.textContent = summaryText;
+      }else if(filteredOutByView){
+        summaryEl.textContent = 'No hay sugerencias que coincidan con los filtros activos.';
+      }else{
+        summaryEl.textContent = hasOverload
+          ? formatAutoReassignSummary(autoReassignmentPlan?.stats, 0)
+          : 'Las cargas actuales por asesor están equilibradas.';
+      }
+    }
+    if(!visibleSuggestions.length){
+      if(listEl){
+        if(filteredOutByView){
+          listEl.innerHTML = '<li class="auto-reassign-item"><div><strong>Sin coincidencias</strong><div class="auto-reassign-meta">Ajusta los filtros actuales para ver las reasignaciones sugeridas.</div></div></li>';
+        }else{
+          listEl.innerHTML = hasOverload
+            ? '<li class="auto-reassign-item"><div><strong>Seguimiento equilibrado</strong><div class="auto-reassign-meta">Las sugerencias anteriores se han aplicado o descartado.</div></div></li>'
+            : '';
+        }
+      }
+      const shouldShow = filteredOutByView || hasOverload;
+      section.classList.toggle('hidden', !shouldShow);
+      section.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+      if(paginationEl){
+        paginationEl.classList.add('hidden');
+        paginationEl.innerHTML = '';
+        paginationEl.removeAttribute('data-total-pages');
+        paginationEl.setAttribute('aria-hidden', 'true');
+      }
+      return;
+    }
+    section.classList.remove('hidden');
+    section.setAttribute('aria-hidden', 'false');
+    const totalPages = Math.max(1, Math.ceil(visibleSuggestions.length / AUTO_REASSIGN_PAGE_SIZE));
+    if(state.autoReassignPage >= totalPages){
+      state.autoReassignPage = totalPages - 1;
+    }
+    if(state.autoReassignPage < 0){
+      state.autoReassignPage = 0;
+    }
+    const currentPage = state.autoReassignPage;
+    const start = currentPage * AUTO_REASSIGN_PAGE_SIZE;
+    const end = start + AUTO_REASSIGN_PAGE_SIZE;
+    const pageItems = visibleSuggestions.slice(start, end);
+    if(listEl){
+      listEl.innerHTML = pageItems
+        .map(item => {
+          const lead = item.lead;
+          const stage = etapaGroup(lead && lead.etapa);
+          const name = escapeHtml(lead && lead.nombre ? lead.nombre : (lead && lead.id ? String(lead.id) : 'Lead sin nombre'));
+          const from = escapeHtml(item.fromName || 'Sin asesor');
+          const to = escapeHtml(item.toName || 'Sin asignar');
+          const stageLabel = escapeHtml(stage || '—');
+          const leadId = escapeHtml(String(item.leadId || ''));
+          return `<li class="auto-reassign-item" data-lead-id="${leadId}"><div><strong>${name}</strong><div class="auto-reassign-meta"><span><i class="bi bi-arrow-left-right"></i> ${from} → ${to}</span><span><i class="bi bi-kanban"></i> Etapa: ${stageLabel}</span></div></div><div class="auto-reassign-actions"><button class="btn primary" type="button" data-auto-apply="${leadId}"><i class="bi bi-check2-circle"></i> Aplicar</button><button class="btn outline" type="button" data-auto-dismiss="${leadId}"><i class="bi bi-x-lg"></i> Omitir</button><button class="btn outline" type="button" data-lead-open="${leadId}"><i class="bi bi-search"></i> Revisar lead</button></div></li>`;
+        })
+        .join('');
+    }
+    if(paginationEl){
+      const fromIndex = start + 1;
+      const toIndex = Math.min(end, visibleSuggestions.length);
+      const totalLabel = visibleSuggestions.length === 1 ? 'sugerencia' : 'sugerencias';
+      const infoText = `Mostrando ${fromIndex}–${toIndex} de ${visibleSuggestions.length} ${totalLabel}.`;
+      const pageLabel = `Página ${currentPage + 1} de ${totalPages}`;
+      paginationEl.innerHTML = `
+        <div class="auto-reassign-pagination__info" aria-live="polite">${infoText}</div>
+        <div class="auto-reassign-pagination__controls">
+          <button class="btn outline" type="button" data-auto-page="prev" ${currentPage === 0 ? 'disabled' : ''}>
+            <i class="bi bi-chevron-left" aria-hidden="true"></i><span>Anterior</span>
+          </button>
+          <span class="auto-reassign-pagination__page">${pageLabel}</span>
+          <button class="btn outline" type="button" data-auto-page="next" ${currentPage >= totalPages - 1 ? 'disabled' : ''}>
+            <span>Siguiente</span><i class="bi bi-chevron-right" aria-hidden="true"></i>
+          </button>
+        </div>`;
+      paginationEl.classList.remove('hidden');
+      paginationEl.setAttribute('aria-hidden', 'false');
+      paginationEl.setAttribute('data-total-pages', String(totalPages));
+    }
+  }
+
+  function renderAutoReassignBadge(lead){
+    if(!lead || !lead.autoReassign) return '';
+    const info = lead.autoReassign;
+    if(info.status === 'pending'){
+      return `<div class="auto-reassign-badge" data-status="pending"><i class="bi bi-arrow-left-right"></i> Reasignar a ${escapeHtml(info.toName || 'otro asesor')}</div>`;
+    }
+    if(info.status === 'applied'){
+      return `<div class="auto-reassign-badge" data-status="applied"><i class="bi bi-check2-circle"></i> Reasignado a ${escapeHtml(info.toName || 'nuevo asesor')}</div>`;
+    }
+    return '';
+  }
+
+  function updateAutoReassignDetail(lead){
+    const container = el('#autoReassignDetail');
+    if(!container){
+      return;
+    }
+    const titleEl = el('#autoReassignDetailTitle');
+    const messageEl = el('#autoReassignDetailMessage');
+    const applyBtn = el('#autoReassignApply');
+    const keepBtn = el('#autoReassignKeep');
+    if(!lead || !lead.autoReassign){
+      container.classList.add('hidden');
+      container.removeAttribute('data-tone');
+      if(applyBtn) applyBtn.disabled = true;
+      return;
+    }
+    const info = lead.autoReassign;
+    container.classList.remove('hidden');
+    container.removeAttribute('data-tone');
+    if(info.status === 'pending'){
+      if(titleEl) titleEl.textContent = 'Reasignación sugerida';
+      if(messageEl) messageEl.textContent = `Se recomienda mover este lead de ${info.fromName || 'tu equipo'} a ${info.toName || 'otro asesor'} para equilibrar la carga.`;
+      if(applyBtn) applyBtn.disabled = false;
+      if(keepBtn) keepBtn.textContent = 'Mantener asignación actual';
+    }else if(info.status === 'applied'){
+      container.setAttribute('data-tone', 'success');
+      if(titleEl) titleEl.textContent = 'Reasignación aplicada';
+      if(messageEl) messageEl.textContent = `Marcaste localmente este lead con ${info.toName || 'otro asesor'}. Puedes revertir el cambio cuando lo necesites.`;
+      if(applyBtn) applyBtn.disabled = true;
+      if(keepBtn) keepBtn.textContent = 'Deshacer reasignación';
+    }else{
+      container.classList.add('hidden');
+      if(applyBtn) applyBtn.disabled = true;
+    }
+  }
+
+  function handleAutoReassignApply(){
+    const lead = detailLeadContext;
+    if(!lead || !lead.autoReassign || lead.autoReassign.status !== 'pending') return;
+    const info = lead.autoReassign;
+    lead._originalAsesor = lead._originalAsesor || lead.asesor;
+    lead.asesor = info.toName || lead.asesor;
+    saveReassignmentDecision(lead.id, {
+      status: 'applied',
+      toName: lead.asesor,
+      toKey: info.toKey || normalizeAsesorName(lead.asesor),
+      fromName: info.fromName || lead._originalAsesor || '',
+      fromKey: info.fromKey || normalizeAsesorName(info.fromName || lead._originalAsesor || '')
+    });
+    autoReassignmentPlan = buildAutoReassignmentPlan(leads);
+    applyAutoReassignmentAnnotations();
+    updateLeadDetailAssignmentDisplay(lead);
+    updateAutoReassignDetail(lead);
+    refresh();
+  }
+
+  function handleAutoReassignKeep(){
+    const lead = detailLeadContext;
+    if(!lead || !lead.autoReassign) return;
+    if(lead.autoReassign.status === 'pending'){
+      saveReassignmentDecision(lead.id, {
+        status: 'dismissed',
+        toName: lead.autoReassign.toName,
+        toKey: lead.autoReassign.toKey,
+        fromName: lead.autoReassign.fromName,
+        fromKey: lead.autoReassign.fromKey
+      });
+    }else if(lead.autoReassign.status === 'applied'){
+      lead.asesor = lead._originalAsesor || lead.autoReassign.fromName || lead.asesor;
+      clearReassignmentDecision(lead.id);
+    }
+    autoReassignmentPlan = buildAutoReassignmentPlan(leads);
+    applyAutoReassignmentAnnotations();
+    updateLeadDetailAssignmentDisplay(lead);
+    updateAutoReassignDetail(lead);
+    refresh();
+  }
+
+  function processAutoReassignAction(leadId, action){
+    const targetId = String(leadId || '');
+    if(!targetId) return;
+    const lead = leads.find(item => String(item.id || '') === targetId);
+    if(!lead) return;
+    const previousContext = detailLeadContext;
+    detailLeadContext = lead;
+    try{
+      if(action === 'apply'){
+        handleAutoReassignApply();
+      }else if(action === 'dismiss'){
+        handleAutoReassignKeep();
+      }
+    }finally{
+      detailLeadContext = previousContext;
+    }
+  }
+
+  function getDefaultCalendarStart(){
+    const now = new Date();
+    now.setMinutes(now.getMinutes() + 60);
+    now.setSeconds(0, 0);
+    return now;
+  }
+
+  function formatDateInput(date){
+    if(!(date instanceof Date)) return '';
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  function formatTimeInput(date){
+    if(!(date instanceof Date)) return '';
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${hours}:${minutes}`;
+  }
+
+  function parseCalendarDateTime(dateValue, timeValue){
+    if(!dateValue || !timeValue) return null;
+    const [year, month, day] = dateValue.split('-').map(Number);
+    const [hour, minute] = timeValue.split(':').map(Number);
+    if(!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day) || !Number.isFinite(hour) || !Number.isFinite(minute)){
+      return null;
+    }
+    const date = new Date(year, month - 1, day, hour, minute, 0, 0);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function buildCalendarEventLink(lead, start, end){
+    const formatCalDate = date => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      const seconds = String(date.getSeconds()).padStart(2, '0');
+      return `${year}${month}${day}T${hours}${minutes}${seconds}`;
+    };
+    const startStr = formatCalDate(start);
+    const endStr = formatCalDate(end);
+    const titleParts = ['Seguimiento'];
+    if(lead && lead.nombre) titleParts.push(lead.nombre);
+    const title = titleParts.join(' · ');
+    const detailLines = [];
+    if(lead && lead.nombre) detailLines.push(`Lead: ${lead.nombre}`);
+    if(lead && lead.programa) detailLines.push(`Programa: ${lead.programa}`);
+    if(lead && lead.modalidad) detailLines.push(`Modalidad: ${lead.modalidad}`);
+    if(lead && (lead.telefono || lead.telefonoNormalizado)) detailLines.push(`Teléfono: ${fmtPhone(lead.telefono || lead.telefonoNormalizado)}`);
+    if(lead && lead.correo) detailLines.push(`Correo: ${lead.correo}`);
+    if(lead && lead.comentario) detailLines.push(`Último comentario: ${lead.comentario}`);
+    const params = new URLSearchParams({ action: 'TEMPLATE', text: title });
+    if(detailLines.length){
+      params.set('details', detailLines.join('\n'));
+    }
+    params.set('dates', `${startStr}/${endStr}`);
+    if(lead && lead.correo){
+      params.append('add', lead.correo);
+    }
+    if(lead && lead.campus){
+      params.set('location', lead.campus);
+    }
+    return `https://calendar.google.com/calendar/render?${params.toString()}`;
+  }
+
+  function updateCalendarStatusMessage(lead){
+    const activeLead = lead || detailLeadContext || null;
+    getCalendarForms().forEach(ctx => {
+      const { dateInput, timeInput, durationSelect, statusEl, button } = ctx;
+      if(!dateInput || !timeInput || !durationSelect || !button) return;
+      const duration = Number(durationSelect.value) || CALENDAR_DEFAULT_DURATION;
+      const start = parseCalendarDateTime(dateInput.value, timeInput.value);
+      if(!start){
+        button.disabled = true;
+        button.dataset.href = '';
+        if(statusEl){
+          statusEl.textContent = 'Selecciona fecha y hora válidas para agendar el seguimiento.';
+        }
+        return;
+      }
+      const end = new Date(start.getTime() + duration * 60000);
+      const url = buildCalendarEventLink(activeLead, start, end);
+      button.disabled = false;
+      button.dataset.href = url;
+      if(statusEl){
+        let formatted;
+        try{
+          formatted = new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(start);
+        }catch(err){
+          formatted = `${dateInput.value} ${timeInput.value}`;
+        }
+        statusEl.textContent = `El recordatorio se programará el ${formatted} (${duration} minutos).`;
+      }
+    });
+  }
+
+  function prepareCalendarForm(lead){
+    const contexts = getCalendarForms();
+    if(!contexts.length) return;
+    const defaultStart = getDefaultCalendarStart();
+    contexts.forEach(ctx => {
+      if(ctx.dateInput){
+        ctx.dateInput.value = formatDateInput(defaultStart);
+      }
+      if(ctx.timeInput){
+        ctx.timeInput.value = formatTimeInput(defaultStart);
+      }
+      if(ctx.durationSelect){
+        const defaultValue = String(CALENDAR_DEFAULT_DURATION);
+        ctx.durationSelect.value = defaultValue;
+        if(ctx.durationSelect.value !== defaultValue && ctx.durationSelect.options.length){
+          ctx.durationSelect.value = ctx.durationSelect.options[0].value;
+        }
+      }
+      if(ctx.statusEl){
+        ctx.statusEl.textContent = '';
+      }
+      if(ctx.button){
+        ctx.button.disabled = true;
+        ctx.button.dataset.href = '';
+      }
+    });
+    updateCalendarStatusMessage(lead);
+  }
+
+  function handleCalendarCreate(target){
+    let button = null;
+    if(target){
+      if(typeof target.matches === 'function'){
+        button = target.matches('[data-calendar-create]') ? target : target.closest('[data-calendar-create]');
+      }else if(target.currentTarget && typeof target.currentTarget.matches === 'function'){
+        button = target.currentTarget;
+      }else if(target.target && typeof target.target.closest === 'function'){
+        button = target.target.closest('[data-calendar-create]');
+      }
+    }
+    if(!button){
+      const fallback = el('#calendarCreateBtn');
+      button = fallback && !fallback.disabled ? fallback : null;
+    }
+    if(!button || button.disabled) return;
+    const href = button.dataset.href;
+    if(!href){
+      updateCalendarStatusMessage(detailLeadContext);
+      return;
+    }
+    window.open(href, '_blank', 'noopener');
+  }
+
+  function isLeadSheetName(name){
+    if(typeof name !== 'string') return false;
+    const trimmed = name.trim();
+    if(!trimmed) return false;
+    const normalized = trimmed
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
+    if(normalized === 'catalogo') return false;
+    return true;
+  }
+
+  function sheetDisplayName(name){
+    if(typeof name !== 'string') return '';
+    return name.replace(/^\s*\*+\s*/, '').trim();
+  }
+
+  function colorForTone(tone){
+    return TONE_COLORS[tone] || TONE_COLORS.info;
+  }
+
+  function clearSolverLog(){
+    const logEl = el('#solverLog');
+    if(logEl){
+      logEl.innerHTML = '';
+    }
+  }
+
+  function appendSolverLog(message, tone = 'info'){
+    const logEl = el('#solverLog');
+    if(!logEl) return null;
+    const li = document.createElement('li');
+    li.textContent = message;
+    const color = colorForTone(tone);
+    if(color){
+      li.style.color = color;
+    }
+    logEl.appendChild(li);
+    const panel = logEl.parentElement;
+    if(panel){
+      panel.scrollTop = panel.scrollHeight;
+    }
+    return li;
+  }
+
+  function buildSolutionPlan(diagnostics){
+    if(!diagnostics) return null;
+    const plan = {
+      summary: 'Diagnóstico sin incidencias pendientes.',
+      severity: 'ok',
+      issues: [],
+      autoActions: [],
+      steps: [],
+      diagnosticRunId: currentDiagnosticsRunId
+    };
+    const pushIssue = (text, tone = 'info') => {
+      if(!text) return;
+      plan.issues.push({ text, tone });
+      if(tone === 'bad'){
+        plan.severity = 'bad';
+      }else if(tone === 'warn' && plan.severity !== 'bad'){
+        plan.severity = 'warn';
+      }else if(plan.severity === 'ok' && tone === 'info'){
+        plan.severity = 'info';
+      }
+    };
+    const addStep = (text, tone = 'info') => {
+      if(!text) return;
+      plan.steps.push({ text, tone });
+    };
+    const sheetRepairMap = new Map();
+    const ensureRepairEntry = sheet => {
+      if(!sheet || !sheet.name) return null;
+      const key = sheet.name;
+      if(!sheetRepairMap.has(key)){
+        sheetRepairMap.set(key, {
+          sheet,
+          missingColumns: new Set(),
+          hasInvalidRows: false,
+          ensureContactColumns: false
+        });
+      }
+      return sheetRepairMap.get(key);
+    };
+    if(!navigator.onLine){
+      pushIssue('El dispositivo está sin conexión a internet.', 'bad');
+      plan.autoActions.push({
+        id: 'wait-for-online',
+        label: 'Esperar reconexión de red',
+        auto: true,
+        handler: async log => {
+          if(navigator.onLine){
+            log('La conexión local ya está disponible.', 'ok');
+            return;
+          }
+          log('Esperando a que el dispositivo recupere la conexión…', 'warn');
+          await new Promise((resolve, reject) => {
+            let settled = false;
+            const cleanup = () => {
+              window.removeEventListener('online', handleOnline);
+              clearTimeout(timer);
+            };
+            const handleOnline = () => {
+              if(settled) return;
+              settled = true;
+              cleanup();
+              resolve();
+            };
+            const timer = setTimeout(() => {
+              if(settled) return;
+              settled = true;
+              cleanup();
+              reject(new Error('La conexión no se restableció en 30 segundos.'));
+            }, 30000);
+            window.addEventListener('online', handleOnline);
+          });
+          log('Conexión local restablecida.', 'ok');
+        }
+      });
+      addStep('Verifica tu conexión Wi-Fi o cable de red si la reconexión tarda más de 30 segundos.', 'info');
+    }
+
+    const connectionCheck = diagnostics.checks?.connection;
+    if((connectionCheck && !connectionCheck.ok) || diagnostics.connection === false || diagnostics.connectionFailed){
+      const msg = connectionCheck?.message ? `Conexión con Google Sheets: ${connectionCheck.message}` : 'La conexión con Google Sheets falló durante el diagnóstico.';
+      pushIssue(msg, 'bad');
+      plan.autoActions.push({
+        id: 'verify-connection',
+        label: 'Verificar conexión con Google Sheets',
+        auto: true,
+        handler: async log => {
+          const maxAttempts = 3;
+          for(let attempt = 1; attempt <= maxAttempts; attempt++){
+            if(!navigator.onLine){
+              log('Sin conexión local. Esperando reconexión antes de verificar el servicio…', 'warn');
+              await new Promise((resolve, reject) => {
+                let settled = false;
+                const cleanup = () => {
+                  window.removeEventListener('online', handleOnline);
+                  clearTimeout(timer);
+                };
+                const handleOnline = () => {
+                  if(settled) return;
+                  settled = true;
+                  cleanup();
+                  resolve();
+                };
+                const timer = setTimeout(() => {
+                  if(settled) return;
+                  settled = true;
+                  cleanup();
+                  reject(new Error('No se recuperó la conexión local en el tiempo esperado.'));
+                }, 15000);
+                window.addEventListener('online', handleOnline);
+              }).catch(err => {
+                throw err instanceof Error ? err : new Error(String(err));
+              });
+            }
+            log(`Validando conectividad con Google Sheets (intento ${attempt}/${maxAttempts})…`, 'info');
+            try{
+              const probe = await probeAppsScriptConnection({
+                action: 'listSheets',
+                authenticated: true,
+                label: 'diagnostics:connection-check'
+              });
+              if(probe.response.ok && !probe.data?.error){
+                log('Conexión con Google Sheets establecida correctamente.', 'ok');
+                return;
+              }
+              const snippet = sanitizeResponseSnippet(probe.data?.error || probe.data?.message || probe.rawText);
+              const label = probe.statusInfo || `HTTP ${probe.response.status}`;
+              const error = new Error(snippet ? `${label} · ${snippet}` : label);
+              error.responseStatus = label;
+              if(snippet) error.responseSnippet = snippet;
+              throw error;
+            }catch(err){
+              if(attempt === maxAttempts){
+                throw err instanceof Error ? err : new Error(String(err));
+              }
+              if(err && typeof err === 'object' && err !== null && err.responseStatus){
+                const snippet = typeof err.responseSnippet === 'string' && err.responseSnippet
+                  ? ` · ${sanitizeResponseSnippet(err.responseSnippet, 120)}`
+                  : '';
+                log(`Respuesta inesperada (${err.responseStatus}${snippet}). Reintentando…`, 'warn');
+              }else{
+                const detailText = err instanceof Error ? err.message : String(err || 'Error de red');
+                const detail = sanitizeResponseSnippet(detailText, 120) || 'Error de red';
+                log(`El intento falló por un error de red (${detail}). Reintentando…`, 'warn');
+              }
+              await new Promise(resolve => setTimeout(resolve, attempt * 2000));
+            }
+          }
+        }
+      });
+      addStep('Confirma que el Apps Script siga desplegado y que el libro de Google Sheets esté accesible y sin restricciones.', 'info');
+    }
+
+    const webhookCheck = diagnostics.checks?.webhook;
+    if(webhookCheck){
+      if(!webhookCheck.serviceOk){
+        pushIssue(webhookCheck.serviceMessage || 'No se pudo verificar la comunicación entre el webhook y Apps Script.', 'bad');
+        addStep(webhookCheck.serviceMessage || 'Revisa el token de verificación y el secreto configurados para el webhook en Apps Script.', 'bad');
+      }
+      if(!webhookCheck.htmlOk){
+        pushIssue(webhookCheck.htmlMessage || 'El HTML no recibió una URL válida del webhook.', 'warn');
+        addStep(webhookCheck.htmlMessage || 'Actualiza la URL del webhook y vuelve a desplegar la interfaz HTML.', 'warn');
+      }
+    }
+
+    const readCheck = diagnostics.checks?.read;
+    if(readCheck && !readCheck.ok){
+      pushIssue('La prueba de lectura falló en Google Sheets.', 'bad');
+      addStep(readCheck.message || 'Verifica que el libro no esté protegido y que el usuario tenga permiso de lectura.', 'bad');
+    }
+    const writeCheck = diagnostics.checks?.write;
+    if(writeCheck && !writeCheck.ok){
+      pushIssue('La prueba de escritura falló en Google Sheets.', 'bad');
+      addStep(writeCheck.message || 'Confirma permisos de edición y que la hoja no esté protegida.', 'bad');
+    }
+
+    if(diagnostics.failed){
+      const errorMessage = (Array.isArray(diagnostics.errors) && diagnostics.errors[0]) || diagnostics.errorMessage || 'El diagnóstico no se completó.';
+      pushIssue(errorMessage, 'bad');
+      addStep('Repite el diagnóstico después de resolver el problema indicado.', 'info');
+    }
+
+    if(Array.isArray(diagnostics.errors) && diagnostics.errors.length){
+      diagnostics.errors.forEach(err => {
+        pushIssue(err, 'bad');
+        addStep(`Corrige: ${err}`, 'bad');
+      });
+    }
+
+    if(Array.isArray(diagnostics.warnings) && diagnostics.warnings.length){
+      pushIssue('Se detectaron alertas durante el diagnóstico.', 'warn');
+      diagnostics.warnings.forEach(warn => {
+        addStep(`Atiende la alerta: ${warn}`, 'warn');
+      });
+    }
+
+    const sheetsWithDuplicates = (diagnostics.sheets || [])
+      .filter(sheet => (sheet?.duplicateIdTotal || 0) > 0 || (sheet?.duplicatePhoneTotal || 0) > 0);
+    if(sheetsWithDuplicates.length){
+      const sheetLabels = sheetsWithDuplicates.map(sheet => sheetDisplayName(sheet.name) || sheet.name);
+      pushIssue(`Duplicados detectados en ${sheetLabels.join(', ')}.`, 'warn');
+      if(canPerform('manageDuplicates')){
+        plan.autoActions.push({
+          id: 'resolve-duplicates',
+          label: `Limpiar duplicados (${sheetsWithDuplicates.length})`,
+          auto: true,
+          handler: async log => {
+            for(const sheet of sheetsWithDuplicates){
+              const displayName = sheetDisplayName(sheet.name) || sheet.name;
+              log(`Eliminando duplicados en "${displayName}"…`, 'warn');
+              const message = await performDuplicateCleanup(sheet.name);
+              log(`${displayName}: ${message}`, 'ok');
+            }
+          }
+        });
+      }else{
+        addStep('Solicita a una persona administradora que ejecute la limpieza de duplicados desde Desarrollador > Duplicados.', 'warn');
+      }
+      addStep('Revisa en Google Sheets que los registros depurados sigan con datos completos.', 'info');
+    }
+    const canRepairSheets = canPerform('repairSheetStructure');
+    const sheetsWithMissingColumns = (diagnostics.sheets || [])
+      .filter(sheet => Array.isArray(sheet?.missingColumns) && sheet.missingColumns.length);
+    sheetsWithMissingColumns.forEach(sheet => {
+      const columnsList = sheet.missingColumns.join(', ');
+      const displayName = sheetDisplayName(sheet.name) || sheet.name;
+      pushIssue(`Faltan columnas obligatorias en ${displayName}: ${columnsList}.`, 'bad');
+      const entry = ensureRepairEntry(sheet);
+      if(entry){
+        sheet.missingColumns.forEach(col => entry.missingColumns.add(col));
+        entry.ensureContactColumns = true;
+      }
+      if(canRepairSheets){
+        addStep(`El solucionador agregará automáticamente las columnas faltantes en ${displayName}.`, 'info');
+      }else{
+        addStep(`Agrega las columnas ${columnsList} en la hoja ${displayName} respetando el encabezado exacto.`, 'bad');
+      }
+    });
+
+    const sheetsWithUnknownColumns = (diagnostics.sheets || [])
+      .filter(sheet => Array.isArray(sheet?.unknownColumns) && sheet.unknownColumns.length);
+    sheetsWithUnknownColumns.forEach(sheet => {
+      const displayName = sheetDisplayName(sheet.name) || sheet.name;
+      const unknownList = sheet.unknownColumns.map(col => col.column ? `${col.name} (${col.column})` : col.name).join(', ');
+      pushIssue(`Encabezados no reconocidos en ${displayName}: ${unknownList}.`, 'warn');
+      addStep(`Revisa y corrige los encabezados no reconocidos en ${displayName} para evitar datos fuera de catálogo.`, 'warn');
+    });
+
+    const sheetsWithInvalidRows = (diagnostics.sheets || [])
+      .filter(sheet => (sheet?.invalidCount || 0) > 0);
+    sheetsWithInvalidRows.forEach(sheet => {
+      const displayName = sheetDisplayName(sheet.name) || sheet.name;
+      pushIssue(`Datos inválidos en ${displayName}: ${sheet.invalidCount} filas requieren corrección.`, 'warn');
+      const entry = ensureRepairEntry(sheet);
+      if(entry){
+        entry.hasInvalidRows = true;
+        entry.ensureContactColumns = true;
+      }
+      if(canRepairSheets){
+        addStep(`El solucionador corregirá automáticamente las filas inválidas detectadas en ${displayName}.`, 'info');
+      }else{
+        addStep(`Corrige las filas con datos inválidos en ${displayName} siguiendo las indicaciones del diagnóstico.`, 'warn');
+      }
+    });
+
+    if(canRepairSheets){
+      sheetRepairMap.forEach(entry => {
+        if(!entry) return;
+        const missingColumns = Array.from(entry.missingColumns);
+        const shouldRepair = missingColumns.length > 0 || entry.hasInvalidRows;
+        if(!shouldRepair) return;
+        const sheetName = entry.sheet.name;
+        const displayName = sheetDisplayName(sheetName) || sheetName;
+        plan.autoActions.push({
+          id: `repair-${sheetName}`,
+          label: `Reparar estructura en ${displayName}`,
+          auto: true,
+          handler: async log => {
+            log(`Reparando "${displayName}"…`, 'warn');
+            const payload = {
+              action: 'repairSheetStructure',
+              sheet: sheetName,
+              ensureColumns: missingColumns,
+              ensureContactColumns: Boolean(entry.ensureContactColumns),
+              fixInvalidRows: entry.hasInvalidRows,
+              rebuildContactLinks: entry.hasInvalidRows || Boolean(entry.ensureContactColumns)
+            };
+            const response = await apiFetch(API_URL, {
+              method: 'POST',
+              body: JSON.stringify(payload)
+            });
+            if(!response.ok){
+              const body = await response.text().catch(() => '');
+              throw new Error(body ? `${response.status} ${body}` : `HTTP ${response.status}`);
+            }
+            const data = await response.json().catch(() => null);
+            if(!data || data.ok === false){
+              throw new Error(data?.error || 'No se pudo reparar la hoja.');
+            }
+            const actions = Array.isArray(data.actions) ? data.actions : [];
+            if(actions.length){
+              actions.forEach(action => log(action, 'info'));
+            }else{
+              log('Reparación completada sin cambios adicionales.', 'ok');
+            }
+          }
+        });
+      });
+    }
+
+    if(diagnostics.system && diagnostics.system.status && diagnostics.system.status !== 'Operativo'){
+      pushIssue(`Estado del sistema: ${diagnostics.system.status}.`, diagnostics.system.status === 'Con incidencias' ? 'warn' : 'info');
+    }
+
+    if(diagnostics.login && !diagnostics.login.ok){
+      const loginMsg = diagnostics.login.message || 'El inicio de sesión está desactivado temporalmente.';
+      pushIssue(`Inicio de sesión: ${loginMsg}`, diagnostics.login.enabled === false ? 'warn' : 'info');
+      addStep('Revisa la configuración de autenticación y restablece tokens o contraseñas si es necesario.', 'warn');
+    }
+
+    if(plan.issues.length){
+      const priorityIssue = plan.issues.find(issue => issue.tone === 'bad')
+        || plan.issues.find(issue => issue.tone === 'warn')
+        || plan.issues[0];
+      if(priorityIssue){
+        plan.summary = priorityIssue.text;
+        plan.severity = priorityIssue.tone;
+      }
+    }else{
+      plan.summary = 'Diagnóstico sin incidencias pendientes. No se requieren acciones adicionales.';
+      plan.severity = 'ok';
+    }
+
+    return plan;
+  }
+
+  function updateProblemSolverPanel(){
+    const statusEl = el('#solverStatus');
+    const autoBtn = el('#solverAutoBtn');
+    const stepsBtn = el('#solverStepsBtn');
+    if(!statusEl || !autoBtn || !stepsBtn) return;
+    if(diagInProgress){
+      currentSolutionPlan = null;
+      statusEl.textContent = 'Ejecutando diagnóstico…';
+      statusEl.style.color = colorForTone('info');
+      autoBtn.disabled = true;
+      stepsBtn.disabled = true;
+      return;
+    }
+    if(solvingInProgress){
+      autoBtn.disabled = true;
+      stepsBtn.disabled = true;
+    }
+    if(!lastDiagnostics){
+      currentSolutionPlan = null;
+      statusEl.textContent = 'Ejecuta el diagnóstico para generar recomendaciones.';
+      statusEl.style.color = colorForTone('info');
+      autoBtn.disabled = true;
+      stepsBtn.disabled = true;
+      return;
+    }
+    currentSolutionPlan = buildSolutionPlan(lastDiagnostics);
+    if(!currentSolutionPlan){
+      statusEl.textContent = 'No se pudo construir el plan de solución.';
+      statusEl.style.color = colorForTone('bad');
+      autoBtn.disabled = true;
+      stepsBtn.disabled = true;
+      return;
+    }
+    const color = colorForTone(currentSolutionPlan.severity || 'info');
+    const hasAuto = Array.isArray(currentSolutionPlan.autoActions) && currentSolutionPlan.autoActions.length;
+    const hasSteps = Array.isArray(currentSolutionPlan.steps) && currentSolutionPlan.steps.length;
+    const solverAllowed = canRunProblemSolver();
+    if(!solverAllowed && (hasAuto || hasSteps)){
+      statusEl.textContent = `${currentSolutionPlan.summary} · Solicita apoyo de Developer para ejecutar el solucionador.`;
+    }else{
+      statusEl.textContent = currentSolutionPlan.summary;
+    }
+    statusEl.style.color = color;
+    if(!solverAllowed){
+      autoBtn.disabled = true;
+      stepsBtn.disabled = true;
+      autoBtn.title = 'Disponible solo para Developer';
+      stepsBtn.title = 'Disponible solo para Developer';
+      return;
+    }
+    autoBtn.removeAttribute('title');
+    stepsBtn.removeAttribute('title');
+    autoBtn.disabled = solvingInProgress || !hasAuto;
+    stepsBtn.disabled = solvingInProgress || !hasSteps;
+  }
+
+  async function executeProblemSolver(options = {}){
+    if(solvingInProgress) return;
+    if(diagInProgress){
+      appendSolverLog('Espera a que termine el diagnóstico antes de ejecutar el solucionador.', 'warn');
+      return;
+    }
+    if(!canRunProblemSolver()){
+      appendSolverLog('Solo un usuario con rol Developer puede ejecutar el solucionador de problemas.', 'warn');
+      return;
+    }
+    const plan = currentSolutionPlan;
+    if(!plan){
+      appendSolverLog('No hay un plan de solución disponible. Ejecuta el diagnóstico primero.', 'info');
+      return;
+    }
+    const autoOnly = Boolean(options.autoOnly);
+    const actions = (plan.autoActions || []).filter(action => !autoOnly || action.auto !== false);
+    if(!actions.length){
+      appendSolverLog('No hay acciones automáticas disponibles. Consulta los pasos sugeridos.', 'info');
+      return;
+    }
+    solvingInProgress = true;
+    const autoButton = el('#solverAutoBtn');
+    if(autoButton && !autoButton.dataset.originalLabel){
+      autoButton.dataset.originalLabel = autoButton.textContent;
+    }
+    if(autoButton){
+      autoButton.disabled = true;
+      autoButton.textContent = 'Resolviendo…';
+    }
+    const stepsButton = el('#solverStepsBtn');
+    if(stepsButton){
+      stepsButton.disabled = true;
+    }
+    clearSolverLog();
+    appendSolverLog('Iniciando plan de solución…', 'info');
+    try{
+      for(const action of actions){
+        appendSolverLog(action.label || 'Ejecutando acción…', 'warn');
+        await action.handler((message, tone = 'info') => appendSolverLog(message, tone));
+      }
+      appendSolverLog('Plan de solución completado. Validando con un nuevo diagnóstico…', 'ok');
+      await runDiagnostics();
+    }catch(err){
+      const message = err instanceof Error ? err.message : String(err);
+      appendSolverLog(`Error al ejecutar el plan: ${message}`, 'bad');
+    }finally{
+      solvingInProgress = false;
+      if(autoButton){
+        autoButton.textContent = autoButton.dataset.originalLabel || 'Solución automática';
+      }
+      if(stepsButton){
+        stepsButton.disabled = false;
+      }
+      updateProblemSolverPanel();
+    }
+  }
+
+  function displaySolutionSteps(){
+    if(!canRunProblemSolver()){
+      appendSolverLog('Solo un usuario con rol Developer puede consultar los pasos del solucionador.', 'warn');
+      return;
+    }
+    const plan = currentSolutionPlan;
+    if(!plan){
+      appendSolverLog('No hay pasos disponibles. Ejecuta el diagnóstico.', 'info');
+      return;
+    }
+    clearSolverLog();
+    appendSolverLog(plan.summary, plan.severity || 'info');
+    if(Array.isArray(plan.issues) && plan.issues.length){
+      appendSolverLog('Incidencias detectadas:', 'warn');
+      plan.issues.forEach(issue => appendSolverLog(`• ${issue.text}`, issue.tone || 'info'));
+    }
+    if(Array.isArray(plan.steps) && plan.steps.length){
+      appendSolverLog('Pasos sugeridos:', 'info');
+      plan.steps.forEach(step => appendSolverLog(`• ${step.text}`, step.tone || 'info'));
+    }else{
+      appendSolverLog('No hay pasos manuales pendientes.', 'ok');
+    }
+  }
+
+  function triggerAutoSolverIfNeeded(){
+    if(!canRunProblemSolver()) return;
+    const plan = currentSolutionPlan;
+    if(solvingInProgress || !plan) return;
+    const hasAuto = (plan.autoActions || []).some(action => action.auto !== false);
+    if(!hasAuto) return;
+    const runId = plan.diagnosticRunId;
+    if(!runId) return;
+    if(lastSolverAutoRunId === runId) return;
+    lastSolverAutoRunId = runId;
+    executeProblemSolver({ autoOnly: true });
+  }
+
+  function updateDuplicatesPanel(){
+    const statusEl = el('#dupStatus');
+    const listEl = el('#dupList');
+    if(!statusEl || !listEl) return;
+    listEl.innerHTML = '';
+    if(diagInProgress){
+      statusEl.textContent = 'Diagnóstico en ejecución…';
+      listEl.classList.add('hidden');
+      return;
+    }
+    if(!lastDiagnostics){
+      statusEl.textContent = 'Ejecuta el diagnóstico para habilitar esta sección.';
+      listEl.classList.add('hidden');
+      return;
+    }
+    if(lastDiagnostics.failed){
+      statusEl.textContent = 'El diagnóstico no se completó. Ejecuta nuevamente para evaluar duplicados.';
+      listEl.classList.add('hidden');
+      return;
+    }
+    const sheetsWithDuplicates = (lastDiagnostics.sheets || [])
+      .filter(sheet => (sheet?.duplicateIdTotal || 0) > 0 || (sheet?.duplicatePhoneTotal || 0) > 0);
+    if(!sheetsWithDuplicates.length){
+      statusEl.textContent = 'Sin duplicados detectados en las bases analizadas.';
+      listEl.classList.add('hidden');
+      return;
+    }
+    statusEl.textContent = 'Duplicados detectados. Revisa cada base y limpia los registros repetidos directamente en Google Sheets.';
+    listEl.classList.remove('hidden');
+    sheetsWithDuplicates.forEach(sheet => {
+      const card = document.createElement('article');
+      card.className = 'dup-card';
+      const header = document.createElement('header');
+      const title = document.createElement('h3');
+      title.textContent = sheetDisplayName(sheet.name) || sheet.name;
+      header.appendChild(title);
+      const counts = document.createElement('div');
+      counts.className = 'dup-counts';
+      if(sheet.duplicateIdTotal){
+        const span = document.createElement('span');
+        span.textContent = `IDs: ${sheet.duplicateIdTotal}`;
+        counts.appendChild(span);
+      }
+      if(sheet.duplicatePhoneTotal){
+        const span = document.createElement('span');
+        span.textContent = `Teléfonos: ${sheet.duplicatePhoneTotal}`;
+        counts.appendChild(span);
+      }
+      header.appendChild(counts);
+      card.appendChild(header);
+
+      const sample = document.createElement('div');
+      sample.className = 'dup-sample';
+      let hasSample = false;
+      if(Array.isArray(sheet.duplicateIds) && sheet.duplicateIds.length){
+        const block = document.createElement('div');
+        const label = document.createElement('strong');
+        label.textContent = 'IDs duplicados';
+        block.appendChild(label);
+        const ul = document.createElement('ul');
+        sheet.duplicateIds.slice(0,3).forEach(item => {
+          const li = document.createElement('li');
+          li.textContent = `${item.value} → filas ${item.rows.join(', ')}`;
+          ul.appendChild(li);
+        });
+        block.appendChild(ul);
+        sample.appendChild(block);
+        hasSample = true;
+      }
+      if(Array.isArray(sheet.duplicatePhones) && sheet.duplicatePhones.length){
+        const block = document.createElement('div');
+        const label = document.createElement('strong');
+        label.textContent = 'Teléfonos duplicados';
+        block.appendChild(label);
+        const ul = document.createElement('ul');
+        sheet.duplicatePhones.slice(0,3).forEach(item => {
+          const phoneLabel = Array.isArray(item.samples) && item.samples.length
+            ? item.samples.join(' / ')
+            : item.value;
+          const li = document.createElement('li');
+          li.textContent = `${phoneLabel} → filas ${item.rows.join(', ')}`;
+          ul.appendChild(li);
+        });
+        block.appendChild(ul);
+        sample.appendChild(block);
+        hasSample = true;
+      }
+      if(hasSample){
+        card.appendChild(sample);
+      }
+
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'btn primary';
+      btn.textContent = 'Limpiar';
+      btn.disabled = diagInProgress;
+      btn.addEventListener('click', ()=> handleDuplicateCleanup(sheet.name, btn));
+      card.appendChild(btn);
+
+      listEl.appendChild(card);
+    });
+  }
+
+  async function performDuplicateCleanup(sheetName){
+    if(!sheetName) throw new Error('Hoja no especificada');
+    const res = await apiFetch(`${API_URL}?action=resolveDuplicates&sheet=${encodeURIComponent(sheetName)}`);
+    if(!res.ok){
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const data = await res.json().catch(() => ({}));
+    if(data && data.error){
+      throw new Error(data.error);
+    }
+    if(data?.ok === false){
+      throw new Error(data.error || 'No se pudo completar la limpieza');
+    }
+    return data?.message || 'Proceso completado.';
+  }
+
+  async function handleDuplicateCleanup(sheetName, button){
+    if(!sheetName) return;
+    if(!canPerform('manageDuplicates')){
+      alert('No tienes permisos para eliminar duplicados.');
+      return;
+    }
+    if(diagInProgress){
+      alert('Espera a que termine el diagnóstico en curso.');
+      return;
+    }
+    const displayName = sheetDisplayName(sheetName) || sheetName;
+    const proceed = confirm(`Se eliminarán los registros duplicados detectados en "${displayName}" directamente en Google Sheets. ¿Deseas continuar?`);
+    if(!proceed) return;
+    let cleanupOk = false;
+    const originalLabel = button ? button.textContent : '';
+    if(button){
+      button.disabled = true;
+      button.textContent = 'Limpiando…';
+    }
+    try{
+      const message = await performDuplicateCleanup(sheetName);
+      cleanupOk = true;
+      alert(message);
+    }catch(err){
+      console.error('Error al eliminar duplicados', err);
+      alert('Error al eliminar duplicados: ' + err.message);
+    }finally{
+    if(button){
+      button.disabled = false;
+      button.textContent = originalLabel || 'Limpiar';
+    }
+    }
+    if(cleanupOk){
+      await runDiagnostics();
+    }
+  }
+
+  // —— Eventos ——
+  function bind(){
+    if(hasBound) return;
+    hasBound = true;
+    // Buscar (Ctrl+/)
+    const q = el('#q');
+    const updateQueryFilter = () => {
+      state.query = q.value.trim();
+      state.page = 0;
+      refresh();
+    };
+    const debouncedQueryUpdate = debounce(updateQueryFilter, 200);
+    q.addEventListener('input', () => debouncedQueryUpdate());
+    q.addEventListener('blur', () => {
+      if(typeof debouncedQueryUpdate.flush === 'function'){
+        debouncedQueryUpdate.flush();
+      }else{
+        updateQueryFilter();
+      }
+    });
+    q.addEventListener('keydown', e => {
+      if(e.key === 'Enter'){
+        if(typeof debouncedQueryUpdate.flush === 'function'){
+          debouncedQueryUpdate.flush();
+        }else{
+          updateQueryFilter();
+        }
+      }
+    });
+    window.addEventListener('keydown', e=>{ if((e.ctrlKey||e.metaKey) && e.key === '/'){ e.preventDefault(); q.focus(); } })
+
+    const appShell = el('#app');
+    const menuTriggers = els('.menu-trigger');
+    const sidebarOverlay = el('#sidebarOverlay');
+    const sidebarNav = el('#sidebar');
+    const sidebarCloseBtn = el('#sidebarClose');
+    const setSidebarOpen = open => {
+      if(appShell){
+        appShell.classList.toggle('show-sidebar', Boolean(open));
+      }
+      if(sidebarOverlay){
+        sidebarOverlay.setAttribute('aria-hidden', open ? 'false' : 'true');
+      }
+      menuTriggers.forEach(btn => btn.setAttribute('aria-expanded', open ? 'true' : 'false'));
+      if(sidebarNav){
+        const hideSidebar = window.innerWidth <= 900 && !open;
+        sidebarNav.setAttribute('aria-hidden', hideSidebar ? 'true' : 'false');
+      }
+      document.body.classList.toggle('sidebar-open', Boolean(open));
+    };
+    const toggleSidebar = () => setSidebarOpen(!(appShell && appShell.classList.contains('show-sidebar')));
+    const closeSidebar = () => {
+      if(window.innerWidth <= 900){
+        setSidebarOpen(false);
+      }else if(appShell){
+        if(!appShell.classList.contains('collapsed')){
+          appShell.classList.add('collapsed');
+        }
+        const toggleBtn = el('#menuToggle');
+        if(toggleBtn){
+          toggleBtn.setAttribute('aria-expanded','false');
+          toggleBtn.classList.add('is-collapsed');
+        }
+        applyBrandLogoState();
+        updateCollapsedBrandInteractivity();
+      }
+    };
+    const preferencesShortcut = el('#preferencesShortcut');
+    if(preferencesShortcut){
+      preferencesShortcut.addEventListener('click', event => {
+        event.preventDefault();
+        const targetLink = document.querySelector('.nav-link[data-nav="configuracion"]');
+        if(targetLink){
+          activateView('configuracion', targetLink);
+          setSidebarOpen(false);
+          const focusTarget = el('#prefBoardDensity') || el('#prefDensity');
+          if(focusTarget && typeof focusTarget.focus === 'function'){
+            focusTarget.focus();
+            if(typeof focusTarget.scrollIntoView === 'function'){
+              focusTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+          }
+        }
+      });
+    }
+    menuTriggers.forEach(btn => {
+      btn.addEventListener('click', toggleSidebar);
+      btn.setAttribute('aria-expanded','false');
+    });
+    if(sidebarOverlay){
+      sidebarOverlay.addEventListener('click', ()=>setSidebarOpen(false));
+    }
+    if(sidebarCloseBtn){
+      sidebarCloseBtn.addEventListener('click', event => {
+        event.preventDefault();
+        closeSidebar();
+      });
+    }
+    if(sidebarNav){
+      const hideSidebar = window.innerWidth <= 900;
+      sidebarNav.setAttribute('aria-hidden', hideSidebar ? 'true' : 'false');
+    }
+    const navLinks = getNavigationLinks();
+    const handleNavClick = event => {
+      event.preventDefault();
+      const link = event.currentTarget;
+      if(!link || link.classList.contains('hidden') || link.disabled) return;
+      const target = link.dataset.nav;
+      if(!target) return;
+      activateView(target, link);
+      setSidebarOpen(false);
+    };
+    const handleTabKeydown = event => {
+      const key = event.key;
+      if(key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return;
+      const tabs = getNavigationLinks().filter(link => link.getAttribute('role') === 'tab' && !link.classList.contains('hidden') && !link.disabled);
+      const current = event.currentTarget;
+      const index = tabs.indexOf(current);
+      if(index < 0 || !tabs.length) return;
+      event.preventDefault();
+      let nextIndex = index;
+      if(key === 'ArrowRight'){
+        nextIndex = (index + 1) % tabs.length;
+      }else if(key === 'ArrowLeft'){
+        nextIndex = (index - 1 + tabs.length) % tabs.length;
+      }else if(key === 'Home'){
+        nextIndex = 0;
+      }else if(key === 'End'){
+        nextIndex = tabs.length - 1;
+      }
+      const nextTab = tabs[nextIndex];
+      if(nextTab){
+        nextTab.focus();
+        nextTab.click();
+      }
+    };
+    navLinks.forEach(link => {
+      link.addEventListener('click', handleNavClick);
+      if(link.getAttribute('role') === 'tab'){
+        link.addEventListener('keydown', handleTabKeydown);
+      }
+    });
+    const messageSearchInput = el('#messageSearch');
+    if(messageSearchInput){
+      messageSearchInput.addEventListener('input', event => {
+        messageInboxState.search = sanitizeText(event.target.value);
+        applyMessageFilters({ preserveActive: true });
+        renderMessageThreads();
+        renderActiveConversation();
+        updateMessageSummary();
+      });
+    }
+    const messageThreadList = el('#messageThreadList');
+    if(messageThreadList){
+      messageThreadList.addEventListener('click', event => {
+        const button = event.target && event.target.closest ? event.target.closest('.messages-thread') : null;
+        if(!button) return;
+        const threadId = button.dataset.threadId;
+        if(threadId){
+          selectMessageThread(threadId);
+        }
+      });
+    }
+    const logoutBtn = el('#logoutBtn');
+    if(logoutBtn){
+      logoutBtn.addEventListener('click', event => {
+        event.preventDefault();
+        if(logoutBtn.disabled) return;
+        performLogout();
+      });
+    }
+    const initialNav = navLinks.find(link => link.classList.contains('active') && !link.classList.contains('hidden')) || navLinks.find(link => !link.classList.contains('hidden'));
+    if(initialNav){
+      activateView(initialNav.dataset.nav, initialNav);
+    }
+    initPermissionScopeSelectors();
+    renderPermissionReference();
+    renderAssignmentRules();
+    populateAssignmentBaseOptions();
+    populateAssignmentTargetOptions();
+    bindAssignmentEvents();
+    setAssignmentModeUI(assignmentMode);
+    const initialAssignmentBase = getAssignmentBase();
+    if(initialAssignmentBase){
+      ensureAssignmentBaseData(initialAssignmentBase).then(() => {
+        populateAssignmentLeadOptions(initialAssignmentBase);
+        populateAssignmentFilters(initialAssignmentBase);
+      }).catch(err => {
+        console.error('Error al preparar la asignación inicial', err);
+        setAssignmentStatus(resolveErrorMessage(err, 'No se pudo cargar la base seleccionada.'), 'error');
+      });
+    }
+    renderTeamTemplateToolbar();
+    const permRoleSelect = el('#permRole');
+    if(permRoleSelect){
+      permRoleSelect.addEventListener('change', () => {
+        const value = permRoleSelect.value;
+        updatePermissionRoleHint(value);
+        applyRoleScopeTemplate(value, { silent: true });
+      });
+      updatePermissionRoleHint(permRoleSelect.value);
+    }
+    const permApplyRolePreset = el('#permApplyRolePreset');
+    if(permApplyRolePreset){
+      permApplyRolePreset.addEventListener('click', () => {
+        const roleSelect = el('#permRole');
+        const role = roleSelect ? roleSelect.value : 'asesor';
+        const applied = applyRoleScopeTemplate(role, { force: true, silent: false });
+        if(applied){
+          updatePermissionRoleHint(role);
+        }
+      });
+    }
+    const permList = el('#permList');
+    if(permList){
+      permList.addEventListener('click', event => {
+        const target = event.target.closest('.perm-user');
+        if(!target || target.classList.contains('active')) return;
+        const userId = target.dataset.userId;
+        if(userId){
+          selectPermissionUser(userId);
+        }
+      });
+    }
+    const permForm = el('#permForm');
+    if(permForm){
+      permForm.addEventListener('submit', handlePermissionSave);
+      if(getUserRole() === 'admin'){
+        startPermissionCreation({ focus: false, renderList: false });
+      }
+    }
+    const permNewBtn = el('#permNewBtn');
+    if(permNewBtn){
+      permNewBtn.addEventListener('click', ()=> startPermissionCreation({ resetStatus: true }));
+    }
+    const permReloadBtn = el('#permReloadBtn');
+    if(permReloadBtn){
+      permReloadBtn.addEventListener('click', ()=> ensurePermissionsLoaded(true));
+    }
+    const permResetBtn = el('#permResetBtn');
+    if(permResetBtn){
+      permResetBtn.addEventListener('click', ()=>{
+        if(selectedPermissionUserId){
+          const user = permissionUsers.find(u => u.userId === selectedPermissionUserId);
+          if(user){
+            populatePermissionForm(user, { focus: false });
+            setPermissionStatus(`Se restauraron los datos guardados de ${user.name || user.userId}.`, 'info');
+          }else{
+            startPermissionCreation({ resetStatus: true });
+          }
+        }else{
+          startPermissionCreation({ resetStatus: true });
+        }
+      });
+    }
+    const solverAutoBtn = el('#solverAutoBtn');
+    if(solverAutoBtn){
+      solverAutoBtn.addEventListener('click', () => executeProblemSolver());
+    }
+    const solverStepsBtn = el('#solverStepsBtn');
+    if(solverStepsBtn){
+      solverStepsBtn.addEventListener('click', () => displaySolutionSteps());
+    }
+    const permDeleteBtn = el('#permDeleteBtn');
+    if(permDeleteBtn){
+      permDeleteBtn.addEventListener('click', handlePermissionDelete);
+    }
+    const teamList = el('#teamList');
+    if(teamList){
+      teamList.addEventListener('click', event => {
+        const target = event.target.closest('.team-item');
+        if(!target || target.classList.contains('active')) return;
+        const teamId = target.dataset.teamId;
+        if(teamId){
+          selectTeam(teamId);
+        }
+      });
+    }
+    const teamForm = el('#teamForm');
+    if(teamForm){
+      teamForm.addEventListener('submit', handleTeamSave);
+      if(getUserRole() === 'admin'){
+        startTeamCreation({ focus: false, renderList: false });
+      }
+    }
+    const teamNewBtn = el('#teamNewBtn');
+    if(teamNewBtn){
+      teamNewBtn.addEventListener('click', ()=> startTeamCreation({ resetStatus: true }));
+    }
+    const teamReloadBtn = el('#teamReloadBtn');
+    if(teamReloadBtn){
+      teamReloadBtn.addEventListener('click', ()=> ensureTeamsLoaded(true));
+    }
+    const teamResetBtn = el('#teamResetBtn');
+    if(teamResetBtn){
+      teamResetBtn.addEventListener('click', ()=>{
+        if(selectedTeamId){
+          const team = teams.find(t => t.teamId === selectedTeamId);
+          if(team){
+            populateTeamForm(team, { focus: false });
+            setTeamStatus(`Se restauraron los datos guardados de ${team.name || team.teamId}.`, 'info');
+          }else{
+            startTeamCreation({ resetStatus: true });
+          }
+        }else{
+          startTeamCreation({ resetStatus: true });
+        }
+      });
+    }
+    const teamCloneBtn = el('#teamCloneBtn');
+    if(teamCloneBtn){
+      teamCloneBtn.addEventListener('click', cloneSelectedTeam);
+    }
+    const teamDeleteBtn = el('#teamDeleteBtn');
+    if(teamDeleteBtn){
+      teamDeleteBtn.addEventListener('click', handleTeamDelete);
+    }
+    const mobileNavQuery = window.matchMedia('(max-width: 900px)');
+    const handleNavBreakpoint = e => { if(!e.matches){ setSidebarOpen(false); } };
+    if(typeof mobileNavQuery.addEventListener === 'function'){
+      mobileNavQuery.addEventListener('change', handleNavBreakpoint);
+    }else if(typeof mobileNavQuery.addListener === 'function'){
+      mobileNavQuery.addListener(handleNavBreakpoint);
+    }
+
+    const handleBoardBreakpoint = e => {
+      if(!e.matches){
+        state.mobileColumns = {};
+      }
+      refresh();
+    };
+    if(typeof boardMobileQuery.addEventListener === 'function'){
+      boardMobileQuery.addEventListener('change', handleBoardBreakpoint);
+    }else if(typeof boardMobileQuery.addListener === 'function'){
+      boardMobileQuery.addListener(handleBoardBreakpoint);
+    }
+
+    // Selección de hoja
+    const sheetSel = el('#sheetSelect');
+    const importSheetSel = el('#importBaseSelect');
+
+    const ensureSheetSelection = () => {
+      if(state.sheet === ALL_SHEETS_VALUE) return;
+      if(!sheets.includes(state.sheet)){
+        state.sheet = sheets[0] || '';
+      }
+    };
+
+    const handleSheetChange = async event => {
+      const select = event?.currentTarget;
+      if(!select) return;
+      const selected = select.value;
+      const isAll = selected === ALL_SHEETS_VALUE;
+      if(!isAll && (!selected || !sheets.includes(selected))){
+        syncSheetSelectorsUI();
+        return;
+      }
+      if(selected === state.sheet){
+        syncSheetSelectorsUI();
+        return;
+      }
+      state.sheet = selected;
+      setAsesorFilter([]);
+      state.campus = '';
+      state.mobileColumns = {};
+      await withGlobalLoading('Cargando base seleccionada…', () => loadLeads());
+      populateAsesores();
+      populateCampuses();
+      populateExportFilters();
+      state.page = 0;
+      refresh();
+      syncSheetSelectorsUI();
+    };
+
+    ensureSheetSelection();
+    syncSheetSelectorsUI();
+
+    if(sheetSel){
+      sheetSel.addEventListener('change', handleSheetChange);
+    }
+    if(importSheetSel){
+      importSheetSel.addEventListener('change', handleSheetChange);
+    }
+
+    // Selección de asesor
+    const asesorSel = el('#asesorSelect');
+    populateAsesores();
+    if(asesorSel){
+      asesorSel.addEventListener('change', ()=>{
+        if(asesorSel.multiple){
+          const selectedOptions = Array.from(asesorSel.selectedOptions || []);
+          const hasAll = selectedOptions.some(opt => !opt.value);
+          if(hasAll){
+            Array.from(asesorSel.options).forEach(opt => {
+              opt.selected = opt.value === '';
+            });
+            setAsesorFilter([]);
+          }else{
+            const values = selectedOptions.map(opt => opt.value).filter(Boolean);
+            setAsesorFilter(values);
+            if(!values.length && asesorSel.options.length){
+              asesorSel.options[0].selected = true;
+            }
+          }
+        }else{
+          setAsesorFilter(asesorSel.value);
+        }
+        state.page=0;
+        refresh();
+      });
+    }
+
+    // Selección de plantel
+    const campusSel = el('#campusSelect');
+    populateCampuses();
+    if(campusSel){
+      campusSel.addEventListener('change', ()=>{ state.campus = campusSel.value; state.page=0; refresh(); });
+    }
+
+    const dailyShortcuts = el('#dailyShortcuts');
+    if(dailyShortcuts){
+      dailyShortcuts.addEventListener('click', event => {
+        const button = event.target.closest('button[data-type]');
+        if(!button) return;
+        const type = button.dataset.type;
+        const value = button.dataset.value || '';
+        state.query = '';
+        const qInput = el('#q');
+        if(qInput) qInput.value = '';
+        if(type === 'campus'){
+          state.campus = state.campus === value ? '' : value;
+          populateCampuses();
+        }else if(type === 'asesor'){
+          const normalizedValue = normalizeAsesorName(value);
+          const selected = getAsesorFilter();
+          const isActive = selected.length === 1 && normalizeAsesorName(selected[0]) === normalizedValue;
+          if(isActive){
+            setAsesorFilter([]);
+          }else{
+            setAsesorFilter(value ? [value] : []);
+          }
+          populateAsesores();
+        }
+        state.page = 0;
+        refresh();
+      });
+    }
+
+    // Filtros por columna
+    els('input[data-col]').forEach(inp=>{
+      const colKey = inp.dataset.col;
+      if(colKey && state.colFilters && typeof state.colFilters[colKey] === 'string'){
+        inp.value = state.colFilters[colKey];
+      }
+      inp.addEventListener('input', ()=>{
+        const key = inp.dataset.col;
+        if(!key) return;
+        state.colFilters[key] = inp.value.trim().toLowerCase();
+        state.page=0;
+        refresh();
+      });
+    });
+
+    els('[data-view-mode]').forEach(btn => {
+      btn.addEventListener('click', ()=>{
+        setViewMode(btn.dataset.viewMode);
+      });
+    });
+
+    els('th[data-sort]').forEach(th => {
+      th.tabIndex = 0;
+      th.addEventListener('click', ()=>{
+        const key = th.dataset.sort;
+        if(!key) return;
+        if(state.sort && state.sort.key === key){
+          state.sort = { key, dir: state.sort.dir === 1 ? -1 : 1 };
+        }else{
+          state.sort = { key, dir: 1 };
+        }
+        state.page = 0;
+        refresh();
+      });
+      th.addEventListener('keypress', e => {
+        if(e.key === 'Enter' || e.key === ' '){
+          e.preventDefault();
+          th.click();
+        }
+      });
+    });
+
+    // Configuración y preferencias
+    initSettings();
+    initQuickAccessUI();
+
+    // Panel emergente
+    const panelClose = el('#panelClose');
+    if(panelClose){
+      panelClose.addEventListener('click', hidePanelOverlay);
+    }
+    const panelOverlay = el('#panelOverlay');
+    if(panelOverlay){
+      panelOverlay.addEventListener('click', e=>{
+        if(e.target === panelOverlay){
+          hidePanelOverlay();
+        }
+      });
+    }
+    const overlayBreakpoint = window.matchMedia('(max-width: 1200px)');
+    const handleOverlayBreakpoint = e => { if(e.matches){ hidePanelOverlay(); } };
+    if(typeof overlayBreakpoint.addEventListener === 'function'){
+      overlayBreakpoint.addEventListener('change', handleOverlayBreakpoint);
+    }else if(typeof overlayBreakpoint.addListener === 'function'){
+      overlayBreakpoint.addListener(handleOverlayBreakpoint);
+    }
+    document.addEventListener('keydown', e=>{
+      if(e.key === 'Escape'){
+        hidePanelOverlay();
+        const drawer = el('#drawer');
+        if(drawer && drawer.classList.contains('open')){
+          drawer.classList.remove('open');
+          drawer.ariaHidden = 'true';
+        }
+        setSidebarOpen(false);
+      }
+    });
+
+    const leadTagAddBtn = el('#leadTagAdd');
+    if(leadTagAddBtn){
+      leadTagAddBtn.addEventListener('click', () => startLeadTagCreation());
+    }
+    const leadTagForm = el('#leadTagForm');
+    if(leadTagForm){
+      leadTagForm.addEventListener('submit', handleLeadTagSubmit);
+    }
+    const leadTagCancel = el('#leadTagCancel');
+    if(leadTagCancel){
+      leadTagCancel.addEventListener('click', () => hideLeadTagForm());
+    }
+    const leadTagListEl = el('#leadTagList');
+    if(leadTagListEl){
+      leadTagListEl.addEventListener('click', handleLeadTagListClick);
+    }
+    const autoApplyBtn = el('#autoReassignApply');
+    if(autoApplyBtn){
+      autoApplyBtn.addEventListener('click', handleAutoReassignApply);
+    }
+    const autoKeepBtn = el('#autoReassignKeep');
+    if(autoKeepBtn){
+      autoKeepBtn.addEventListener('click', handleAutoReassignKeep);
+    }
+    const autoListEl = el('#autoReassignList');
+    if(autoListEl){
+      autoListEl.addEventListener('click', event => {
+        const applyControl = event.target.closest('[data-auto-apply]');
+        if(applyControl){
+          const leadId = applyControl.getAttribute('data-auto-apply');
+          if(leadId) processAutoReassignAction(leadId, 'apply');
+          return;
+        }
+        const dismissControl = event.target.closest('[data-auto-dismiss]');
+        if(dismissControl){
+          const leadId = dismissControl.getAttribute('data-auto-dismiss');
+          if(leadId) processAutoReassignAction(leadId, 'dismiss');
+          return;
+        }
+        const button = event.target.closest('[data-lead-open]');
+        if(!button) return;
+        const leadId = button.getAttribute('data-lead-open');
+        if(!leadId) return;
+        let targetLead = leads.find(item => String(item.id || '') === leadId);
+        if(!targetLead){
+          const suggestion = (autoReassignmentPlan?.suggestions || []).find(item => String(item?.leadId || '') === leadId);
+          if(suggestion && suggestion.lead){
+            targetLead = suggestion.lead;
+          }
+        }
+        if(targetLead){
+          openDetails(targetLead);
+        }
+      });
+    }
+    const autoPagerEl = el('#autoReassignPagination');
+    if(autoPagerEl){
+      autoPagerEl.addEventListener('click', event => {
+        const control = event.target.closest('[data-auto-page]');
+        if(!control) return;
+        event.preventDefault();
+        const totalPages = Number(autoPagerEl.getAttribute('data-total-pages')) || 0;
+        const action = control.dataset.autoPage;
+        if(action === 'prev'){
+          if(state.autoReassignPage <= 0) return;
+          state.autoReassignPage = Math.max(0, state.autoReassignPage - 1);
+        }else if(action === 'next'){
+          if(totalPages && state.autoReassignPage >= totalPages - 1) return;
+          state.autoReassignPage += 1;
+        }else if(action === 'page'){
+          const pageIndex = Number(control.dataset.pageIndex);
+          if(!Number.isFinite(pageIndex)) return;
+          const maxPage = totalPages ? Math.max(0, Math.min(pageIndex, totalPages - 1)) : Math.max(0, pageIndex);
+          state.autoReassignPage = maxPage;
+        }else{
+          return;
+        }
+        refresh();
+      });
+    }
+    document.addEventListener('input', event => {
+      if(event.target && event.target.matches('[data-calendar-date],[data-calendar-time]')){
+        updateCalendarStatusMessage(detailLeadContext);
+      }
+    });
+    document.addEventListener('change', event => {
+      if(event.target && event.target.matches('[data-calendar-duration]')){
+        updateCalendarStatusMessage(detailLeadContext);
+      }
+    });
+    document.addEventListener('click', event => {
+      const button = event.target && event.target.closest ? event.target.closest('[data-calendar-create]') : null;
+      if(!button) return;
+      event.preventDefault();
+      handleCalendarCreate(button);
+    });
+
+    // Tamaño de página
+    const sizeSel = el('#pageSize');
+    if(sizeSel) sizeSel.addEventListener('change', ()=>{
+      const value = Number(sizeSel.value);
+      state.pageSize = Number.isFinite(value) && value > 0 ? value : 0;
+      state.page = 0;
+      state.columnLimits = {};
+      refresh();
+    });
+
+    // Drawer
+    el('#closeDrawer').addEventListener('click', ()=>{ el('#drawer').classList.remove('open'); el('#drawer').ariaHidden='true'; });
+    el('#drawer').addEventListener('click', (e)=>{ if(e.target.id==='drawer') { el('#drawer').classList.remove('open'); el('#drawer').ariaHidden='true'; } });
+  }
+
+  function refresh(){
+    const rows = applyFilters();
+    renderDailyShortcuts(rows);
+    const {key, dir} = state.sort;
+    if(key){ rows.sort((a,b)=> (a[key]||'').localeCompare(b[key]||'') * dir ); }
+    const totals = etapasUI.reduce((acc, step)=>{ acc[step] = 0; return acc; }, {});
+    rows.forEach(row => {
+      const label = etapaGroup(row.etapa);
+      if(typeof totals[label] === 'number') totals[label]++;
+    });
+    const columnSignature = JSON.stringify({
+      query: state.query,
+      asesor: getAsesorFilter(),
+      campus: state.campus,
+      sort: state.sort,
+      filters: Object.entries(state.colFilters || {}).sort(([a],[b]) => a.localeCompare(b)),
+      sheet: state.sheet,
+      pageSize: state.pageSize
+    });
+    if(columnSignature !== state.columnLimitSignature){
+      state.columnLimitSignature = columnSignature;
+      state.columnLimits = {};
+    }
+    renderPagination(rows.length);
+    const hasPagination = Number.isFinite(state.pageSize) && state.pageSize > 0;
+    const start = hasPagination ? state.page * state.pageSize : 0;
+    const end = hasPagination ? start + state.pageSize : rows.length;
+    const pageRows = rows.slice(start, end);
+    pruneColumnLimits(pageRows);
+    renderKanban(pageRows, totals);
+    renderAutoReassignmentPanel(rows);
+  }
+
+  async function initializeApp(){
+    try{
+      await withGlobalLoading('Sincronizando bases…', () => loadSheets());
+      const hasValidSelection = state.sheet === ALL_SHEETS_VALUE || sheets.includes(state.sheet);
+      if(!hasValidSelection){
+        state.sheet = sheets[0] || '';
+      }
+      syncSheetSelectorsUI();
+      if(state.sheet){
+        await withGlobalLoading('Cargando leads…', () => loadLeads());
+      }else{
+        leads = [];
+        syncMessageInbox({ preserveActive: false, reset: true });
+      }
+    }catch(err){
+      if(!(err && err.code === 'UNAUTHORIZED')){
+        console.error('Error durante la inicialización', err);
+      }
+    }finally{
+      bind();
+      populateAsesores();
+      populateCampuses();
+      populateExportFilters();
+      applyActionPermissions();
+      refresh();
+      if(getUserRole() === 'admin'){
+        await ensurePermissionsLoaded();
+      }
+    }
+  }
+
+  function updateMobileTopbar(targetSection, sourceLink){
+    const mobileTopbar = el('#mobileTopbar');
+    if(!mobileTopbar) return;
+    const labelEl = el('#mobileViewLabel');
+    const explicitLabel = targetSection ? (targetSection.getAttribute('data-mobile-title') || '').trim() : '';
+    const labelSource = sourceLink && (sourceLink.querySelector('span') || sourceLink);
+    const fallbackLabel = labelSource ? (labelSource.textContent || '').trim() : '';
+    const labelText = explicitLabel || fallbackLabel || 'Vista actual';
+    if(labelEl){
+      labelEl.textContent = `Vista: ${labelText}`;
+    }
+    const hideAttr = targetSection ? targetSection.getAttribute('data-hide-mobile-topbar') : null;
+    const shouldHide = typeof hideAttr === 'string' && hideAttr !== '' && hideAttr !== 'false';
+    mobileTopbar.classList.toggle('hidden', Boolean(shouldHide));
+    mobileTopbar.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+  }
+
+  const menuToggle = el('#menuToggle');
+  if(menuToggle){
+    const appEl = el('#app');
+    const sidebarEl = el('#sidebar');
+    const isMobileViewport = () => window.innerWidth <= 900;
+    const ensureDesktopSidebarAria = () => {
+      if(sidebarEl && !isMobileViewport()){
+        sidebarEl.setAttribute('aria-hidden','false');
+      }
+    };
+    const syncToggleState = () => {
+      if(!appEl) return;
+      const isCollapsed = appEl.classList.contains('collapsed');
+      menuToggle.setAttribute('aria-expanded', String(!isCollapsed));
+
+      menuToggle.classList.toggle('is-collapsed', isCollapsed);
+    };
+    const toggleMenu = () => {
+      if(!appEl) return;
+      appEl.classList.toggle('collapsed');
+      syncToggleState();
+      ensureDesktopSidebarAria();
+      applyBrandLogoState();
+      updateCollapsedBrandInteractivity();
+    };
+    menuToggle.addEventListener('click', toggleMenu);
+    window.addEventListener('resize', () => {
+      ensureDesktopSidebarAria();
+
+      syncToggleState();
+      applyBrandLogoState();
+      updateCollapsedBrandInteractivity();
+    });
+    ensureDesktopSidebarAria();
+    syncToggleState();
+    applyBrandLogoState();
+    updateCollapsedBrandInteractivity();
+  }
+
+  updateDuplicatesPanel();
+  updateProblemSolverPanel();
+
+
+  // Diagnóstico
+  async function runDiagnostics(){
+    if(diagInProgress) return;
+    if(!canPerform('runDiagnostics')){
+      alert('No tienes permisos para ejecutar el diagnóstico.');
+      return;
+    }
+    const log = el('#diagLog');
+    if(!log) return;
+    const diagButton = el('#diagBtn');
+    const setLoading = (loading) => {
+      if(!diagButton) return;
+      if(loading){
+        diagButton.disabled = true;
+        if(!diagButton.dataset.originalLabel){
+          diagButton.dataset.originalLabel = diagButton.textContent;
+        }
+        diagButton.textContent = 'Analizando...';
+      }else{
+        diagButton.disabled = false;
+        if(diagButton.dataset.originalLabel){
+          diagButton.textContent = diagButton.dataset.originalLabel;
+        }
+      }
+    };
+    const addLine = (text, tone='info') => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      const color = colorForTone(tone);
+      if(color) li.style.color = color;
+      log.appendChild(li);
+      const panel = log.parentElement;
+      if(panel) panel.scrollTop = panel.scrollHeight;
+      return li;
+    };
+    const addSublist = (parent, items) => {
+      if(!parent || !items || !items.length) return;
+      const ul = document.createElement('ul');
+      ul.classList.add('diag-sublist');
+      items.forEach(item => {
+        const li = document.createElement('li');
+        const data = typeof item === 'string' ? { text: item, tone: 'info' } : item;
+        li.textContent = data.text || '';
+        const tone = data.tone || 'info';
+        const color = colorForTone(tone);
+        if(color) li.style.color = color;
+        ul.appendChild(li);
+      });
+      parent.appendChild(ul);
+    };
+
+    currentDiagnosticsRunId = Date.now();
+    diagInProgress = true;
+    lastDiagnostics = null;
+    updateDuplicatesPanel();
+    updateProblemSolverPanel();
+    setLoading(true);
+    log.innerHTML = '';
+    clearSolverLog();
+    try{
+      addLine(navigator.onLine ? 'Conexión local: en línea' : 'Conexión local: sin conexión', navigator.onLine ? 'ok' : 'bad');
+      if(!sheets.length){
+        await loadSheets();
+      }
+      const sheetName = state.sheet && sheets.includes(state.sheet)
+        ? state.sheet
+        : (sheets[0] || '');
+      if(!sheetName){
+        addLine('No hay hojas disponibles para ejecutar el diagnóstico.', 'bad');
+        lastDiagnostics = { failed: true, errors: ['No hay hojas disponibles para ejecutar el diagnóstico.'], reason: 'noSheets' };
+        return;
+      }
+
+      let response;
+      try{
+        response = await apiFetch(`${API_URL}?action=diagnostics&sheet=${encodeURIComponent(sheetName)}`);
+      }catch(err){
+        if(err && err.code === 'UNAUTHORIZED') return;
+        addLine(`Error al contactar el servicio: ${err.message}`, 'bad');
+        lastDiagnostics = {
+          failed: true,
+          errors: [`Error al contactar el servicio: ${err.message}`],
+          connectionFailed: true,
+          errorMessage: err.message,
+          checks: { connection: { ok: false, message: err.message } }
+        };
+        return;
+      }
+      const httpLabel = `Respuesta HTTP: ${response.status}${response.statusText ? ' '+response.statusText : ''}`.trim();
+      addLine(httpLabel, response.ok ? 'ok' : 'bad');
+      if(!response.ok){
+        const body = await response.text().catch(()=> '');
+        if(body) addLine(body, 'bad');
+        lastDiagnostics = {
+          failed: true,
+          errors: body ? [body] : [`HTTP ${response.status}`],
+          httpStatus: response.status
+        };
+        return;
+      }
+
+      let data;
+      try{
+        data = await response.json();
+      }catch(err){
+        addLine('No se pudo interpretar la respuesta del diagnóstico.', 'bad');
+        lastDiagnostics = { failed: true, errors: ['No se pudo interpretar la respuesta del diagnóstico.'] };
+        return;
+      }
+
+      if(data.timestamp){
+        const ts = new Date(data.timestamp);
+        if(!isNaN(ts.getTime())){
+          addLine(`Ejecutado: ${ts.toLocaleString()}`, 'info');
+        }
+      }
+
+      const sheetLabel = data.sheet || sheetName;
+      const connectionCheck = data.checks?.connection;
+      if(connectionCheck){
+        const connLine = addLine(`Google Sheets (${sheetLabel}): ${connectionCheck.ok ? 'OK' : 'Fallo'}`, connectionCheck.ok ? 'ok' : 'bad');
+        if(connectionCheck.message){
+          addSublist(connLine, [{ text: connectionCheck.message, tone: connectionCheck.ok ? 'info' : 'warn' }]);
+        }
+      }else{
+        addLine(`Google Sheets (${sheetLabel}): ${data.connection ? 'OK' : 'Fallo'}`, data.connection ? 'ok' : 'bad');
+      }
+
+      const webhookCheck = data.checks?.webhook;
+      if(webhookCheck){
+        const webhookLine = addLine(`Webhook: ${webhookCheck.ok ? 'OK' : 'Revisar'}`, webhookCheck.ok ? 'ok' : 'warn');
+        const webhookDetails = [];
+        if(webhookCheck.serviceMessage){
+          webhookDetails.push({ text: webhookCheck.serviceMessage, tone: webhookCheck.serviceOk ? 'info' : 'bad' });
+        }
+        if(webhookCheck.htmlMessage){
+          webhookDetails.push({ text: webhookCheck.htmlMessage, tone: webhookCheck.htmlOk ? 'info' : 'warn' });
+        }
+        addSublist(webhookLine, webhookDetails);
+      }
+
+      const readCheck = data.checks?.read;
+      if(readCheck){
+        const readLine = addLine(`Prueba de lectura: ${readCheck.ok ? 'OK' : 'Fallo'}`, readCheck.ok ? 'ok' : 'bad');
+        if(readCheck.message){
+          addSublist(readLine, [{ text: readCheck.message, tone: readCheck.ok ? 'info' : 'bad' }]);
+        }
+      }
+      const writeCheck = data.checks?.write;
+      if(writeCheck){
+        const writeLine = addLine(`Prueba de escritura: ${writeCheck.ok ? 'OK' : 'Fallo'}`, writeCheck.ok ? 'ok' : 'bad');
+        if(writeCheck.message){
+          addSublist(writeLine, [{ text: writeCheck.message, tone: writeCheck.ok ? 'info' : 'bad' }]);
+        }
+      }
+
+      if(data.system){
+        const sysStatus = data.system.status || 'Sin definir';
+        const sysTone = sysStatus === 'Operativo' ? 'ok' : (sysStatus === 'Con incidencias' ? 'warn' : 'info');
+        const sysLine = addLine(`Estado del sistema: ${sysStatus}`, sysTone);
+        const sysDetails = [];
+        if(data.system.timezone) sysDetails.push({ text: `Zona horaria: ${data.system.timezone}`, tone: 'info' });
+        if(typeof data.summary?.sheetsWithErrors === 'number'){
+          sysDetails.push({ text: `Hojas con incidencias: ${data.summary.sheetsWithErrors}`, tone: data.summary.sheetsWithErrors ? 'warn' : 'info' });
+        }
+        if(typeof data.summary?.invalidRows === 'number'){
+          sysDetails.push({ text: `Filas con datos inválidos: ${data.summary.invalidRows}`, tone: data.summary.invalidRows ? 'warn' : 'info' });
+        }
+        addSublist(sysLine, sysDetails);
+      }
+
+      if(data.login){
+        const loginTone = data.login.ok ? 'ok' : (data.login.enabled ? 'warn' : 'info');
+        const loginMsg = data.login.message || (data.login.ok ? 'Activo' : 'Desactivado');
+        addLine(`Inicio de sesión: ${loginMsg}`, loginTone);
+      }
+
+      if(Array.isArray(data.errors) && data.errors.length){
+        const errLi = addLine(`Errores (${data.errors.length})`, 'bad');
+        addSublist(errLi, data.errors.map(msg => ({ text: msg, tone: 'bad' })));
+      }
+      if(Array.isArray(data.warnings) && data.warnings.length){
+        const warnLi = addLine(`Alertas (${data.warnings.length})`, 'warn');
+        addSublist(warnLi, data.warnings.map(msg => ({ text: msg, tone: 'warn' })));
+      }
+
+      if(Array.isArray(data.sheets) && data.sheets.length){
+        data.sheets.forEach(sheet => {
+          const tone = !sheet.ok ? 'bad' : (sheet.hasWarnings ? 'warn' : 'ok');
+          const sheetLine = addLine(`Hoja "${sheet.name}": ${sheet.ok ? 'sin errores críticos' : 'requiere revisión'}`, tone);
+          const details = [];
+          if(sheet.name === sheetLabel) details.push({ text: 'Hoja utilizada actualmente por la aplicación.', tone: 'info' });
+          if(Array.isArray(sheet.missingColumns) && sheet.missingColumns.length){
+            details.push({ text: `Columnas faltantes: ${sheet.missingColumns.join(', ')}`, tone: 'bad' });
+          }
+          if(Array.isArray(sheet.unknownColumns) && sheet.unknownColumns.length){
+            const unknownList = sheet.unknownColumns.map(c => c.column ? `${c.name} (${c.column})` : c.name).join(', ');
+            details.push({ text: `Encabezados no reconocidos: ${unknownList}`, tone: 'warn' });
+          }
+          if(sheet.duplicateIdTotal){
+            details.push({ text: `IDs duplicados: ${sheet.duplicateIdTotal}`, tone: 'warn' });
+            sheet.duplicateIds.slice(0,5).forEach(item => {
+              details.push({ text: `· ${item.value} en filas ${item.rows.join(', ')}`, tone: 'warn' });
+            });
+            if(sheet.duplicateIdTotal > sheet.duplicateIds.length){
+              details.push({ text: '· ... se omitieron más coincidencias de ID.', tone: 'info' });
+            }
+          }
+          if(sheet.duplicatePhoneTotal){
+            details.push({ text: `Teléfonos duplicados: ${sheet.duplicatePhoneTotal}`, tone: 'warn' });
+            sheet.duplicatePhones.slice(0,5).forEach(item => {
+              const label = item.samples && item.samples.length ? item.samples.join(' / ') : item.value;
+              details.push({ text: `· ${label} en filas ${item.rows.join(', ')}`, tone: 'warn' });
+            });
+            if(sheet.duplicatePhoneTotal > sheet.duplicatePhones.length){
+              details.push({ text: '· ... se omitieron más coincidencias de teléfono.', tone: 'info' });
+            }
+          }
+          if(sheet.invalidCount){
+            details.push({ text: `Filas con datos inválidos: ${sheet.invalidCount}`, tone: 'bad' });
+            (sheet.invalidRows || []).slice(0,5).forEach(row => {
+              details.push({ text: `· Fila ${row.row}: ${row.issues.join('; ')}`, tone: 'bad' });
+            });
+            if(sheet.truncatedInvalid){
+              details.push({ text: '· ... se omitieron filas adicionales con incidencias.', tone: 'info' });
+            }
+          }
+          if(!details.length){
+            details.push({ text: 'Sin observaciones.', tone: 'info' });
+          }
+          addSublist(sheetLine, details);
+        });
+      }
+
+      if(data.aggregate){
+        const ids = Array.isArray(data.aggregate.duplicateIds) ? data.aggregate.duplicateIds : [];
+        const phones = Array.isArray(data.aggregate.duplicatePhones) ? data.aggregate.duplicatePhones : [];
+        const idsLine = addLine(`Duplicados globales de ID: ${ids.length}`, ids.length ? 'warn' : 'ok');
+        if(ids.length){
+          const items = ids.slice(0,5).map(entry => ({
+            text: `${entry.value} (${entry.count}) → ${entry.occurrences.map(o => `${o.sheet} (fila ${o.row})`).join(', ')}`,
+            tone: 'warn'
+          }));
+          if(ids.length > 5 || ids.some(entry => entry.truncated)){
+            items.push({ text: '... se omitieron coincidencias adicionales.', tone: 'info' });
+          }
+          addSublist(idsLine, items);
+        }
+        const phonesLine = addLine(`Duplicados globales de teléfono: ${phones.length}`, phones.length ? 'warn' : 'ok');
+        if(phones.length){
+          const items = phones.slice(0,5).map(entry => ({
+            text: `${entry.value} (${entry.count}) → ${entry.occurrences.map(o => `${o.sheet} (fila ${o.row})`).join(', ')}`,
+            tone: 'warn'
+          }));
+          if(phones.length > 5 || phones.some(entry => entry.truncated)){
+            items.push({ text: '... se omitieron coincidencias adicionales.', tone: 'info' });
+          }
+          addSublist(phonesLine, items);
+        }
+      }
+      lastDiagnostics = data;
+      updateDuplicatesPanel();
+      updateProblemSolverPanel();
+      triggerAutoSolverIfNeeded();
+      return data;
+    }catch(err){
+      addLine('Error inesperado durante el diagnóstico: '+err.message, 'bad');
+      lastDiagnostics = { failed: true, errors: [`Error inesperado durante el diagnóstico: ${err.message}`], errorMessage: err.message };
+    }finally{
+      setLoading(false);
+      diagInProgress = false;
+      updateDuplicatesPanel();
+      updateProblemSolverPanel();
+      triggerAutoSolverIfNeeded();
+    }
+  }
+  const diagBtn = el('#diagBtn');
+  if(diagBtn) diagBtn.addEventListener('click', runDiagnostics);
+
+  
+  // Importar
+  const FIELD_LABELS = {
+    id: 'ID',
+    nombre: 'Nombre',
+    matricula: 'Matrícula',
+    telefono: 'Teléfono',
+    correo: 'Correo',
+    campus: 'Campus',
+    modalidad: 'Modalidad',
+    programa: 'Programa',
+    etapa: 'Etapa',
+    estado: 'Estado',
+    asesor: 'Asesor',
+    comentario: 'Comentario',
+    asignacion: 'Asignación',
+    metadatos: 'Metadatos',
+    telefonoNormalizado: 'Teléfono normalizado',
+    telefonoAircall: 'Teléfono Aircall',
+    telefonoWhatsapp: 'Teléfono WhatsApp',
+    resolucion: 'Resolución',
+    crm: 'CRM',
+    toque1: 'Toque 1',
+    toque2: 'Toque 2',
+    toque3: 'Toque 3',
+    toque4: 'Toque 4',
+    motivo: 'Motivo',
+    base: 'Base',
+    asesorActual: 'Asesor actual',
+    asesorNuevo: 'Asesor nuevo'
+  };
+  const IMPORT_OUTPUT_FIELDS = ['id','nombre','matricula','telefono','correo','campus','modalidad','programa','etapa','estado','asesor','comentario','asignacion'];
+  const IMPORT_PAYLOAD_FIELDS = [...IMPORT_OUTPUT_FIELDS, 'metadatos'];
+  const BULK_OUTPUT_FIELDS = ['id','matricula','etapa','estado','comentario','asesor'];
+  const ACTIVOS_UPDATE_FIELDS = ['nombre','matricula','telefono','correo','campus','modalidad','programa'];
+  const headerAliasMap = new Map();
+  const etapaAliasMap = new Map();
+  const estadoAliasMap = new Map();
+  const FIELD_FORMATTERS = {
+    telefono: value => fmtPhone(value),
+    telefonoNormalizado: value => fmtPhone(value)
+  };
+
+  function normalizeAliasKey(value){
+    return String(value || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g,'');
+  }
+  function normalizeTextValue(value){
+    return String(value || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .replace(/\s+/g,' ')
+      .trim();
+  }
+  function registerHeaderAlias(key, aliases){
+    const list = Array.isArray(aliases) ? aliases : [aliases];
+    [key, ...list].forEach(name => {
+      const norm = normalizeAliasKey(name);
+      if(norm && !headerAliasMap.has(norm)) headerAliasMap.set(norm, key);
+    });
+  }
+  function registerEtapaAlias(value, aliases){
+    const list = Array.isArray(aliases) ? aliases : [aliases];
+    [value, ...list].forEach(name => {
+      const norm = normalizeTextValue(name);
+      if(norm && !etapaAliasMap.has(norm)) etapaAliasMap.set(norm, value);
+    });
+  }
+  function registerEstadoAlias(etapa, value, aliases){
+    const list = Array.isArray(aliases) ? aliases : [aliases];
+    [value, ...list].forEach(name => {
+      const norm = normalizeTextValue(name);
+      if(norm && !estadoAliasMap.has(norm)) estadoAliasMap.set(norm, { etapa, value });
+    });
+  }
+
+  registerHeaderAlias('id',['leadid','idcrm','idlead','folio','identificador']);
+  registerHeaderAlias('nombre',['name','alumno','prospecto','contacto','fullname']);
+  registerHeaderAlias('matricula',['matricula','matrícula','expediente','nexpediente','noexpediente','exped']);
+  registerHeaderAlias('telefono',['telefono','teléfono','telefonos','telefono1','telefono 1','telefono2','telefono 2','celular','cel','movil','whatsapp','tel','phone','numero']);
+  registerHeaderAlias('correo',['correo','correo electronico','correo electrónico','email','mail','emailaddress']);
+  registerHeaderAlias('campus',['campus','plantel','sede','campus interes','campusinteres']);
+  registerHeaderAlias('modalidad',['modalidad','modalidad academica','modalidadacademica','modalidad interes','modalidadinteres','modalidad educativa']);
+  registerHeaderAlias('programa',['programa','carrera','programa interes','programa de interes','licenciatura','posgrado','curso']);
+  registerHeaderAlias('etapa',['etapa','status','estatus','fase','fase actual','faseactual','stage','pipeline']);
+  registerHeaderAlias('estado',['estado','subestado','subestatus','resultado','estado actual','estadoactual']);
+  registerHeaderAlias('asesor',['asesor','agente','ejecutivo','owner','responsable','asesor asignado']);
+  registerHeaderAlias('comentario',['comentario','nota','notas','observaciones','comentarios','comentario asesor']);
+  registerHeaderAlias('asignacion',['asignacion','fecha asignacion','fechaasignacion','fecha de asignacion','fecha asignación','asignado','fecha contacto','fecha seguimiento']);
+  registerHeaderAlias('telefonoNormalizado',['telefono normalizado','telefononormalizado','telefono estandarizado','telefonolimpio']);
+  registerHeaderAlias('telefonoAircall',['telefono aircall','link aircall','aircall']);
+  registerHeaderAlias('telefonoWhatsapp',['telefono whatsapp','whatsapplink','link whatsapp','url whatsapp']);
+  registerHeaderAlias('resolucion',['resolucion','resolución','resolution']);
+  registerHeaderAlias('toque1',['toque1','toque 1','primer toque']);
+  registerHeaderAlias('toque2',['toque2','toque 2','segundo toque']);
+  registerHeaderAlias('toque3',['toque3','toque 3','tercer toque']);
+  registerHeaderAlias('toque4',['toque4','toque 4','cuarto toque']);
+  registerHeaderAlias('metadatos',['metadatos','metadato','metadata','datos extra','informacion extra','info extra']);
+
+  const HEADER_TOKEN_HINTS = [
+    { field: 'telefonoWhatsapp', tokens: ['whatsapp'], score: 96 },
+    { field: 'telefonoAircall', tokens: ['aircall'], score: 92 },
+    { field: 'telefonoNormalizado', tokens: ['normalizad'], score: 90 },
+    { field: 'telefono', tokens: ['tel*','cel*','movil','mobile','telefono'], score: 84 },
+    { field: 'correo', tokens: ['correo','email','mail'], score: 82 },
+    { field: 'matricula', tokens: ['matric*','control'], score: 78 },
+    { field: 'id', tokens: ['id','folio'], score: 74 },
+    { field: 'nombre', tokens: ['nombre','alumno','prospecto'], score: 72 },
+    { field: 'programa', tokens: ['programa','carrera','licenciatura','posgrado','curso'], score: 68 },
+    { field: 'campus', tokens: ['campus','plantel','sede'], score: 66 },
+    { field: 'modalidad', tokens: ['modalidad','modal','turno'], score: 64 },
+    { field: 'etapa', tokens: ['etapa','fase','status','pipeline'], score: 70 },
+    { field: 'estado', tokens: ['estado','subestado','resultado'], score: 70 },
+    { field: 'asesor', tokens: ['asesor','agente','ejecutivo','owner','responsable'], score: 66 },
+    { field: 'comentario', tokens: ['coment*','nota','observa*'], score: 64 },
+    { field: 'asignacion', tokens: ['asign*','seguimiento'], score: 62 }
+  ];
+
+  const KNOWN_ESTADOS = (() => {
+    const set = new Set();
+    Object.values(estadosByEtapa || {}).forEach(list => {
+      if(!Array.isArray(list)) return;
+      list.forEach(item => {
+        const normalized = normalizeTextValue(item);
+        if(normalized) set.add(normalized);
+      });
+    });
+    return set;
+  })();
+
+  const HEADER_SOURCE_PRIORITY = { alias: 3, header: 2, data: 1 };
+
+  function extractHeaderTokens(header){
+    return String(header || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean);
+  }
+
+  function tokenMatchesPattern(token, pattern){
+    if(!token || !pattern) return false;
+    const normalizedToken = token.toLowerCase();
+    const normalizedPattern = pattern.toLowerCase();
+    if(normalizedPattern.endsWith('*')){
+      const base = normalizedPattern.slice(0, -1);
+      return base ? normalizedToken.startsWith(base) : false;
+    }
+    return normalizedToken === normalizedPattern;
+  }
+
+  function matchesTokenHint(tokens, patterns){
+    if(!tokens.length || !patterns.length) return false;
+    return patterns.some(pattern => tokens.some(token => tokenMatchesPattern(token, pattern)));
+  }
+
+  function collectColumnSamples(header, rows, limit = 50){
+    const values = [];
+    if(!Array.isArray(rows) || !rows.length) return values;
+    for(let i = 0; i < rows.length && values.length < limit; i++){
+      const row = rows[i];
+      if(!row || typeof row !== 'object') continue;
+      const value = cleanValue(row[header]);
+      if(!value) continue;
+      values.push(value);
+    }
+    return values;
+  }
+
+  function computeRatio(values, predicate){
+    if(!values.length) return 0;
+    let matches = 0;
+    values.forEach(value => {
+      if(predicate(value)) matches += 1;
+    });
+    return matches / values.length;
+  }
+
+  function isLikelyEmail(value){
+    const str = cleanValue(value).toLowerCase();
+    if(!str) return false;
+    if(str.includes(' ')) return false;
+    const parts = str.split('@');
+    if(parts.length !== 2) return false;
+    if(parts[0].length < 2) return false;
+    if(!parts[1] || parts[1].indexOf('.') === -1) return false;
+    const domainParts = parts[1].split('.');
+    if(domainParts.some(part => !part)) return false;
+    return domainParts[domainParts.length - 1].length >= 2;
+  }
+
+  function isLikelyPhoneValue(value){
+    const phone = parsePhone(value);
+    return Boolean(phone && phone.local && phone.local.length >= 7);
+  }
+
+  function isLikelyName(value){
+    const str = cleanValue(value);
+    if(!str) return false;
+    if(/[0-9@]/.test(str)) return false;
+    const words = str.split(/\s+/).filter(Boolean);
+    if(words.length < 2) return false;
+    const validWords = words.filter(word => /^[a-záéíóúñü'´-]+$/i.test(word));
+    return validWords.length / words.length >= 0.6;
+  }
+
+  function isLikelyMatricula(value){
+    const str = cleanValue(value);
+    if(!str) return false;
+    if(isLikelyEmail(str) || isLikelyPhoneValue(str)) return false;
+    const normalized = str.replace(/[^a-z0-9]/gi,'');
+    if(!normalized) return false;
+    if(normalized.length < 4 || normalized.length > 16) return false;
+    if(/^[a-z]+$/i.test(normalized)) return false;
+    return /\d/.test(normalized);
+  }
+
+  function isLikelyDate(value){
+    const str = cleanValue(value);
+    if(!str) return false;
+    if(/\d{4}-\d{2}-\d{2}/.test(str)) return true;
+    if(/\d{2}[\/.-]\d{2}[\/.-]\d{2,4}/.test(str)) return true;
+    const parsed = Date.parse(str);
+    if(Number.isNaN(parsed)) return false;
+    const year = new Date(parsed).getFullYear();
+    return year >= 1990 && year <= 2100;
+  }
+
+  function isKnownEstado(value){
+    const normalized = normalizeTextValue(value);
+    if(!normalized) return false;
+    if(estadoAliasMap.has(normalized)) return true;
+    return KNOWN_ESTADOS.has(normalized);
+  }
+
+  function evaluateHeaderCandidate(header, rows, index){
+    const headerText = cleanValue(header);
+    if(!headerText){
+      return { header: headerText, index, key: null, score: 0, source: '' };
+    }
+    const headerNorm = normalizeAliasKey(headerText);
+    const tokens = extractHeaderTokens(headerText);
+    const samples = collectColumnSamples(headerText, rows, 60);
+    const candidateMap = new Map();
+    const addCandidate = (field, score, source) => {
+      if(!field || !FIELD_LABELS[field]) return;
+      const existing = candidateMap.get(field);
+      const entry = { field, score, source };
+      if(!existing){
+        candidateMap.set(field, entry);
+        return;
+      }
+      if(score > existing.score){
+        candidateMap.set(field, entry);
+        return;
+      }
+      if(score === existing.score && HEADER_SOURCE_PRIORITY[source] > HEADER_SOURCE_PRIORITY[existing.source]){
+        candidateMap.set(field, entry);
+      }
+    };
+
+    const aliasKey = resolveHeaderKey(headerText);
+    if(aliasKey){
+      addCandidate(aliasKey, 100, 'alias');
+    }
+
+    if(tokens.length){
+      HEADER_TOKEN_HINTS.forEach(hint => {
+        if(matchesTokenHint(tokens, hint.tokens)){
+          if(hint.field === 'asignacion'){
+            const dateRatio = computeRatio(samples, isLikelyDate);
+            if(dateRatio >= 0.2) addCandidate(hint.field, hint.score, 'header');
+          }else{
+            addCandidate(hint.field, hint.score, 'header');
+          }
+        }
+      });
+    }
+
+    if(headerNorm){
+      headerAliasMap.forEach((field, aliasNorm) => {
+        if(!aliasNorm || aliasNorm === headerNorm) return;
+        if(aliasNorm.length < 4) return;
+        if(headerNorm.includes(aliasNorm)){
+          addCandidate(field, Math.min(88, 40 + aliasNorm.length), 'header');
+        }
+      });
+      Object.entries(FIELD_LABELS).forEach(([field, label]) => {
+        const labelNorm = normalizeAliasKey(label);
+        if(!labelNorm || labelNorm === headerNorm) return;
+        if(headerNorm.includes(labelNorm)){
+          addCandidate(field, 72, 'header');
+        }
+      });
+    }
+
+    if(samples.length){
+      const emailRatio = computeRatio(samples, isLikelyEmail);
+      if(emailRatio >= 0.6){
+        addCandidate('correo', 92, 'data');
+      }else if(emailRatio >= 0.35){
+        addCandidate('correo', 78, 'data');
+      }else if(emailRatio >= 0.2){
+        addCandidate('correo', 65, 'data');
+      }
+
+      const phoneRatio = computeRatio(samples, isLikelyPhoneValue);
+      if(phoneRatio >= 0.6){
+        addCandidate('telefono', 88, 'data');
+      }else if(phoneRatio >= 0.35){
+        addCandidate('telefono', 74, 'data');
+      }else if(phoneRatio >= 0.2){
+        addCandidate('telefono', 60, 'data');
+      }
+
+      const nameRatio = computeRatio(samples, isLikelyName);
+      if(nameRatio >= 0.7){
+        addCandidate('nombre', 74, 'data');
+      }else if(nameRatio >= 0.5){
+        addCandidate('nombre', 66, 'data');
+      }
+
+      const matriculaRatio = computeRatio(samples, isLikelyMatricula);
+      if(matriculaRatio >= 0.6){
+        addCandidate('matricula', 70, 'data');
+      }else if(matriculaRatio >= 0.45){
+        addCandidate('matricula', 62, 'data');
+      }
+
+      const etapaRatio = computeRatio(samples, value => Boolean(normalizeEtapaValue(value)));
+      if(etapaRatio >= 0.5){
+        addCandidate('etapa', 78, 'data');
+      }else if(etapaRatio >= 0.3){
+        addCandidate('etapa', 68, 'data');
+      }
+
+      const estadoRatio = computeRatio(samples, isKnownEstado);
+      if(estadoRatio >= 0.5){
+        addCandidate('estado', 78, 'data');
+      }else if(estadoRatio >= 0.3){
+        addCandidate('estado', 68, 'data');
+      }
+
+      const dateRatio = computeRatio(samples, isLikelyDate);
+      if(dateRatio >= 0.6){
+        addCandidate('asignacion', 72, 'data');
+      }else if(dateRatio >= 0.4){
+        addCandidate('asignacion', 64, 'data');
+      }
+    }
+
+    let best = null;
+    candidateMap.forEach(candidate => {
+      if(!best){
+        best = candidate;
+        return;
+      }
+      if(candidate.score > best.score){
+        best = candidate;
+        return;
+      }
+      if(candidate.score === best.score && HEADER_SOURCE_PRIORITY[candidate.source] > HEADER_SOURCE_PRIORITY[best.source]){
+        best = candidate;
+      }
+    });
+
+    if(!best){
+      return { header: headerText, index, key: null, score: 0, source: '' };
+    }
+    return { header: headerText, index, key: best.field, score: best.score, source: best.source };
+  }
+
+  function buildHeaderMapping(headers, rows){
+    if(!Array.isArray(headers) || !headers.length){
+      return new Map();
+    }
+    const candidates = headers.map((header, index) => evaluateHeaderCandidate(header, rows, index));
+    const assignments = new Map();
+    const mapping = new Map();
+    candidates.forEach(candidate => {
+      if(!candidate || !candidate.key) return;
+      const existing = assignments.get(candidate.key);
+      if(!existing){
+        assignments.set(candidate.key, candidate);
+        return;
+      }
+      if(candidate.score > existing.score){
+        assignments.set(candidate.key, candidate);
+        return;
+      }
+      if(candidate.score === existing.score){
+        const priorityDiff = HEADER_SOURCE_PRIORITY[candidate.source] - HEADER_SOURCE_PRIORITY[existing.source];
+        if(priorityDiff > 0 || (priorityDiff === 0 && candidate.index < existing.index)){
+          assignments.set(candidate.key, candidate);
+        }
+      }
+    });
+    const normalizedMapping = new Map();
+    assignments.forEach(candidate => {
+      mapping.set(candidate.header, candidate.key);
+      const normalized = normalizeAliasKey(candidate.header);
+      if(normalized) normalizedMapping.set(normalized, candidate.key);
+    });
+    mapping._normalized = normalizedMapping;
+    return mapping;
+  }
+
+  registerEtapaAlias('Nuevo',['nuevo','prospecto nuevo']);
+  registerEtapaAlias('Contactado',['contactado','en seguimiento','seguimiento','labor de venta','laborventa']);
+  registerEtapaAlias('No Contactado',['no contactado','nocontactado','no-contactado','sin contacto','sinrespuesta','no se localizo']);
+  registerEtapaAlias('Inscrito',['inscrito','matriculado']);
+  registerEtapaAlias('Descartado',['descartado','descartada','no interesado','no interesada','sin interes','spam','rechazado']);
+
+  Object.entries(estadosByEtapa).forEach(([etapa, estados]) => {
+    estados.forEach(estado => registerEstadoAlias(etapa, estado));
+  });
+  registerEstadoAlias('Nuevo','Sin contactar',['nuevo']);
+  registerEstadoAlias('No Contactado','No contesta',['sin respuesta','no responde','buzon de voz','buzón de voz','cuelga','no contesta whatsapp']);
+  registerEstadoAlias('No Contactado','Mensaje no respondido',['mensaje sin responder','mensaje no contestado']);
+  registerEstadoAlias('No Contactado','Pendiente de reintento',['volver a marcar','reintentar','limite intentos contacto','limite de intentos de contacto']);
+  registerEstadoAlias('Contactado','Seguimiento activo',['seguimiento']);
+  registerEstadoAlias('Contactado','En labor de venta',['labor de venta']);
+  registerEstadoAlias('Descartado','Sin interés',['no interesado','no interesada','no desea informacion','no desea información','inscrito en otra escuela']);
+  registerEstadoAlias('Descartado','Datos incorrectos',['datos falsos','telefono incorrecto','correo incorrecto']);
+  registerEstadoAlias('Descartado','Duplicado',['duplicado','duplicada']);
+  registerEstadoAlias('Descartado','SPAM',['spam']);
+  registerEstadoAlias('Inscrito','Inscrito confirmado',['inscrito']);
+
+  function resolveHeaderKey(header){
+    const norm = normalizeAliasKey(header);
+    return norm ? (headerAliasMap.get(norm) || null) : null;
+  }
+  function mapRowToCanonical(row, headerMapping){
+    const out = {};
+    const extras = [];
+    Object.keys(row || {}).forEach(key => {
+      const value = cleanValue(row[key]);
+      if(value === '') return;
+      let canonical = null;
+      if(headerMapping){
+        canonical = headerMapping.get(key) || null;
+        if(!canonical && headerMapping._normalized){
+          const normalizedKey = normalizeAliasKey(key);
+          if(normalizedKey) canonical = headerMapping._normalized.get(normalizedKey) || null;
+        }
+      }
+      if(!canonical){
+        canonical = resolveHeaderKey(key);
+      }
+      if(canonical){
+        if(out[canonical] === undefined){
+          out[canonical] = value;
+          return;
+        }
+        extras.push({ header: key, value });
+        return;
+      }
+      extras.push({ header: key, value });
+    });
+    if(extras.length){
+      out._extras = extras.map(item => ({
+        header: String(item.header ?? '').trim(),
+        value: cleanValue(item.value)
+      }));
+    }
+    return out;
+  }
+  function hasFieldData(row, fields){
+    return fields.some(field => cleanValue(row[field] || '') !== '');
+  }
+  function escapeHtml(value){
+    return String(value ?? '')
+      .replace(/&/g,'&amp;')
+      .replace(/</g,'&lt;')
+      .replace(/>/g,'&gt;')
+      .replace(/"/g,'&quot;')
+      .replace(/'/g,'&#39;');
+  }
+  async function parseTabularFile(file){
+    if(!file) return {headers:[], rows:[]};
+    if(typeof XLSX !== 'undefined'){
+      try{
+        const buffer = await file.arrayBuffer();
+        const workbook = XLSX.read(buffer, {type:'array'});
+        const sheetName = workbook.SheetNames[0];
+        if(sheetName){
+          const sheet = workbook.Sheets[sheetName];
+          const matrix = XLSX.utils.sheet_to_json(sheet, {header:1, defval:'', blankrows:false});
+          if(matrix.length){
+            const headers = (matrix[0] || []).map(cleanValue);
+            const rows = matrix.slice(1).map(values => {
+              const obj = {};
+              headers.forEach((header, idx) => {
+                const key = header || `col${idx}`;
+                obj[key] = cleanValue(values[idx] ?? '');
+              });
+              return obj;
+            }).filter(obj => Object.values(obj).some(val => cleanValue(val)));
+            return {headers, rows};
+          }
+        }
+      }catch(err){
+        console.warn('No se pudo leer con XLSX', err);
+      }
+    }
+    const text = await file.text();
+    return parseCsvText(text);
+  }
+  function parseCsvText(text){
+    if(!text) return {headers:[], rows:[]};
+    const normalized = text.replace(/^﻿/, '');
+    const firstLine = normalized.split(/\r?\n/)[0] || '';
+    const commaCount = (firstLine.match(/,/g) || []).length;
+    const semicolonCount = (firstLine.match(/;/g) || []).length;
+    const delimiter = semicolonCount > commaCount ? ';' : ',';
+    const rows = [];
+    let field = '';
+    let row = [];
+    let inQuotes = false;
+    for(let i=0;i<normalized.length;i++){
+      const char = normalized[i];
+      if(inQuotes){
+        if(char === '"'){
+          if(normalized[i+1] === '"'){
+            field += '"';
+            i++;
+          }else{
+            inQuotes = false;
+          }
+        }else{
+          field += char;
+        }
+      }else{
+        if(char === '"'){
+          inQuotes = true;
+        }else if(char === delimiter){
+          row.push(field);
+          field = '';
+        }else if(char === '\r'){
+          row.push(field);
+          rows.push(row);
+          row = [];
+          field = '';
+          if(normalized[i+1] === '\n') i++;
+        }else if(char === '\n'){
+          row.push(field);
+          rows.push(row);
+          row = [];
+          field = '';
+        }else{
+          field += char;
+        }
+      }
+    }
+    if(field.length || row.length){
+      row.push(field);
+      rows.push(row);
+    }
+    while(rows.length && rows[rows.length-1].every(val => cleanValue(val) === '')){
+      rows.pop();
+    }
+    if(!rows.length) return {headers:[], rows:[]};
+    const headers = (rows.shift() || []).map(cleanValue);
+    const mappedRows = rows.map(values => {
+      const obj = {};
+      headers.forEach((header, idx) => {
+        const key = header || `col${idx}`;
+        obj[key] = cleanValue(values[idx] ?? '');
+      });
+      return obj;
+    }).filter(obj => Object.values(obj).some(val => cleanValue(val)));
+    return {headers, rows: mappedRows};
+  }
+  function normalizeEtapaValue(value){
+    const norm = normalizeTextValue(value);
+    if(!norm) return '';
+    if(etapaAliasMap.has(norm)) return etapaAliasMap.get(norm);
+    if(norm.includes('no contact')) return 'No Contactado';
+    if(norm.includes('contact') && !norm.includes('no')) return 'Contactado';
+    if(norm.includes('inscrit')) return 'Inscrito';
+    if(norm.includes('descart')) return 'Descartado';
+    if(norm.includes('nuevo')) return 'Nuevo';
+    return '';
+  }
+  function inferEtapaFromEstado(value){
+    const entry = estadoAliasMap.get(normalizeTextValue(value));
+    return entry ? entry.etapa : '';
+  }
+  function normalizeEstadoValue(value, etapa){
+    const entry = estadoAliasMap.get(normalizeTextValue(value));
+    if(entry){
+      if(!etapa || entry.etapa === etapa) return entry.value;
+      return entry.value;
+    }
+    return cleanValue(value);
+  }
+  function harmonizeEtapaEstado(etapaRaw, estadoRaw){
+    let etapa = normalizeEtapaValue(etapaRaw);
+    let estado = normalizeEstadoValue(estadoRaw, etapa);
+    const inferred = inferEtapaFromEstado(estado);
+    if(inferred) etapa = inferred;
+    etapa = etapa ? etapaLabel(etapa) : '';
+    if(etapa){
+      const validStates = estadosByEtapa[etapa] || [];
+      if(estado){
+        const normalized = normalizeEstadoValue(estado, etapa);
+        estado = validStates.length && validStates.indexOf(normalized) === -1 ? '' : normalized;
+      }else if(validStates.length === 1){
+        estado = validStates[0];
+      }
+    }
+    return { etapa, estado };
+  }
+  function normalizeIdentifierKey(value){
+    const str = cleanValue(value).toLowerCase().replace(/\s+/g,'');
+    return str || '';
+  }
+  function normalizeEmailKey(value){
+    const str = cleanValue(value).toLowerCase();
+    return str || '';
+  }
+  function normalizePhoneKey(value){
+    const phone = parsePhone(value);
+    return phone.local || phone.digits || '';
+  }
+  function formatMetadataLabel(key){
+    if(!key) return '';
+    if(FIELD_LABELS[key]) return FIELD_LABELS[key];
+    return String(key || '')
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/\b\w/g, ch => ch.toUpperCase());
+  }
+  function normalizeImportRow(raw, headerMapping){
+    const mapped = mapRowToCanonical(raw, headerMapping);
+    const extras = Array.isArray(mapped._extras) ? mapped._extras : [];
+    if('_extras' in mapped) delete mapped._extras;
+    const stageState = harmonizeEtapaEstado(mapped.etapa, mapped.estado);
+    const telefonoBase = mapped.telefono || mapped.telefonoNormalizado || '';
+    const row = {
+      id: mapped.id || '',
+      nombre: mapped.nombre || '',
+      matricula: mapped.matricula || '',
+      telefono: mapped.telefono || '',
+      correo: mapped.correo || '',
+      campus: mapped.campus || '',
+      modalidad: mapped.modalidad || '',
+      programa: mapped.programa || '',
+      etapa: stageState.etapa,
+      estado: stageState.estado,
+      asesor: mapped.asesor || '',
+      comentario: mapped.comentario || '',
+      asignacion: mapped.asignacion || ''
+    };
+    if(!row.telefono && telefonoBase){
+      row.telefono = telefonoBase;
+    }
+    row._phoneKey = normalizePhoneKey(telefonoBase || row.telefono);
+    row._emailKey = normalizeEmailKey(row.correo);
+    row._idKey = normalizeIdentifierKey(row.id);
+    row._matriculaKey = normalizeIdentifierKey(row.matricula);
+    const metadataEntries = [];
+    let unnamedExtraCount = 0;
+    const pushMetadata = (header, value) => {
+      const sanitizedValue = cleanValue(value);
+      if(!sanitizedValue) return;
+      let label = cleanValue(header);
+      if(!label){
+        unnamedExtraCount += 1;
+        label = `Columna extra ${unnamedExtraCount}`;
+      }
+      metadataEntries.push({ header: label, value: sanitizedValue });
+    };
+    extras.forEach(item => pushMetadata(item.header, item.value));
+    const metadataFieldExclusions = new Set([...IMPORT_OUTPUT_FIELDS, 'telefonoNormalizado','telefonoAircall','telefonoWhatsapp','metadatos']);
+    Object.keys(mapped).forEach(key => {
+      if(!key || metadataFieldExclusions.has(key)) return;
+      const value = cleanValue(mapped[key]);
+      if(!value) return;
+      pushMetadata(formatMetadataLabel(key), value);
+    });
+    let metadataValue = cleanValue(mapped.metadatos || '');
+    const metadataString = metadataEntries
+      .map(entry => `${entry.header}: ${entry.value}`)
+      .join(' | ');
+    if(metadataString){
+      metadataValue = metadataValue
+        ? `${metadataValue} | ${metadataString}`
+        : metadataString;
+    }
+    row.metadatos = metadataValue;
+    if(metadataEntries.length){
+      row._metadataEntries = metadataEntries;
+    }
+    if(!hasFieldData(row, IMPORT_OUTPUT_FIELDS)) return null;
+    return row;
+  }
+  function normalizeBulkRow(raw, headerMapping){
+    const mapped = mapRowToCanonical(raw, headerMapping);
+    const stageState = harmonizeEtapaEstado(mapped.etapa, mapped.estado);
+    const row = {
+      id: mapped.id || '',
+      matricula: mapped.matricula || '',
+      etapa: stageState.etapa,
+      estado: stageState.estado,
+      comentario: mapped.comentario || '',
+      asesor: mapped.asesor || ''
+    };
+    row._idKey = normalizeIdentifierKey(row.id);
+    row._matriculaKey = normalizeIdentifierKey(row.matricula);
+    if(!hasFieldData(row, BULK_OUTPUT_FIELDS)) return null;
+    return row;
+  }
+  function createLeadKeyStores(){
+    const stores = { phone:new Set(), email:new Set(), id:new Set(), matricula:new Set() };
+    leads.forEach(lead => {
+      const phone = normalizePhoneKey(lead.telefonoNormalizado || lead.telefono);
+      if(phone) stores.phone.add(phone);
+      const email = normalizeEmailKey(lead.correo);
+      if(email) stores.email.add(email);
+      const idKey = normalizeIdentifierKey(lead.id);
+      if(idKey) stores.id.add(idKey);
+      const matKey = normalizeIdentifierKey(lead.matricula);
+      if(matKey) stores.matricula.add(matKey);
+    });
+    return stores;
+  }
+  function splitImportRows(rows){
+    const valid = [];
+    const duplicates = [];
+    const stores = createLeadKeyStores();
+    const seen = { phone:new Set(), email:new Set(), id:new Set(), matricula:new Set() };
+    rows.forEach(row => {
+      const reasons = [];
+      if(row._phoneKey){
+        if(stores.phone.has(row._phoneKey)) reasons.push('Teléfono ya existe en la base');
+        if(seen.phone.has(row._phoneKey)) reasons.push('Teléfono duplicado en el archivo');
+      }
+      if(row._emailKey){
+        if(stores.email.has(row._emailKey)) reasons.push('Correo ya existe en la base');
+        if(seen.email.has(row._emailKey)) reasons.push('Correo duplicado en el archivo');
+      }
+      if(row._idKey){
+        if(stores.id.has(row._idKey)) reasons.push('ID ya existe en la base');
+        if(seen.id.has(row._idKey)) reasons.push('ID duplicado en el archivo');
+      }
+      if(row._matriculaKey){
+        if(stores.matricula.has(row._matriculaKey)) reasons.push('Matrícula ya existe en la base');
+        if(seen.matricula.has(row._matriculaKey)) reasons.push('Matrícula duplicada en el archivo');
+      }
+      if(reasons.length){
+        duplicates.push({ data: row, reason: [...new Set(reasons)].join(' · ') });
+      }else{
+        if(row._phoneKey) seen.phone.add(row._phoneKey);
+        if(row._emailKey) seen.email.add(row._emailKey);
+        if(row._idKey) seen.id.add(row._idKey);
+        if(row._matriculaKey) seen.matricula.add(row._matriculaKey);
+        valid.push(row);
+      }
+    });
+    return { valid, duplicates };
+  }
+  function buildLeadLookups(){
+    const byId = new Map();
+    const byMatricula = new Map();
+    leads.forEach(lead => {
+      const idKey = normalizeIdentifierKey(lead.id);
+      if(idKey && !byId.has(idKey)) byId.set(idKey, lead);
+      const matKey = normalizeIdentifierKey(lead.matricula);
+      if(matKey && !byMatricula.has(matKey)) byMatricula.set(matKey, lead);
+    });
+    return { byId, byMatricula };
+  }
+  function splitBulkRows(rows){
+    const lookups = buildLeadLookups();
+    const seen = { id:new Set(), matricula:new Set() };
+    const valid = [];
+    const issues = [];
+    rows.forEach(row => {
+      const reasons = [];
+      const idKey = row._idKey;
+      const matKey = row._matriculaKey;
+      if(!idKey && !matKey) reasons.push('ID o Matrícula requerido');
+      if(idKey && seen.id.has(idKey)) reasons.push('ID duplicado en el archivo');
+      if(matKey && seen.matricula.has(matKey)) reasons.push('Matrícula duplicada en el archivo');
+      let exists = false;
+      if(idKey && lookups.byId.has(idKey)) exists = true;
+      if(!exists && matKey && lookups.byMatricula.has(matKey)) exists = true;
+      if((idKey || matKey) && !exists) reasons.push('Registro no encontrado en la base');
+      if(!row.etapa) reasons.push('Etapa requerida');
+      if(!row.estado) reasons.push('Estado requerido');
+      if(row.etapa && row.estado){
+        const validStates = estadosByEtapa[row.etapa] || [];
+        if(validStates.length && validStates.indexOf(row.estado) === -1){
+          reasons.push(`Estado no válido para etapa ${row.etapa}`);
+        }
+      }
+      if(reasons.length){
+        issues.push({ data: row, reason: [...new Set(reasons)].join(' · ') });
+      }else{
+        if(idKey) seen.id.add(idKey);
+        if(matKey) seen.matricula.add(matKey);
+        valid.push(row);
+      }
+    });
+    return { valid, issues };
+  }
+  function projectImportRow(row){
+    const out = {};
+    IMPORT_PAYLOAD_FIELDS.forEach(field => { out[field] = cleanValue(row[field] || ''); });
+    return out;
+  }
+  function projectBulkRow(row){
+    const out = {};
+    BULK_OUTPUT_FIELDS.forEach(field => { out[field] = cleanValue(row[field] || ''); });
+    return out;
+  }
+  function clearContainer(target){
+    const node = typeof target === 'string' ? el(target) : target;
+    if(!node) return;
+    node.innerHTML = '';
+    node.classList.add('hidden');
+  }
+  function renderTable(target, rows, options = {}){
+    const element = typeof target === 'string' ? el(target) : target;
+    if(!element) return;
+    if(!rows || !rows.length){
+      clearContainer(element);
+      return;
+    }
+    const limit = options.limit || 15;
+    const fields = (options.fields && options.fields.length)
+      ? options.fields
+      : Object.keys(rows[0]).filter(key => !key.startsWith('_'));
+    const headerHtml = fields.map(field => `<th>${FIELD_LABELS[field] || field}</th>`).join('');
+    const bodyHtml = rows.slice(0, limit).map(row => {
+      const cells = fields.map(field => {
+        const formatter = FIELD_FORMATTERS[field];
+        const value = formatter ? formatter(row[field]) : row[field];
+        return `<td>${escapeHtml(value ?? '')}</td>`;
+      }).join('');
+      return `<tr>${cells}</tr>`;
+    }).join('');
+    const summaryText = options.summary
+      ? options.summary
+      : `Mostrando ${Math.min(limit, rows.length)} de ${rows.length} registros`;
+    const extra = rows.length > limit && !options.summary
+      ? `<div class="muted" style="margin-top:6px">Se muestran ${limit} de ${rows.length} registros.</div>`
+      : '';
+    element.innerHTML = `
+      <div class="preview-summary">${escapeHtml(summaryText)}</div>
+      <div class="table-wrap"><table><thead><tr>${headerHtml}</tr></thead><tbody>${bodyHtml}</tbody></table></div>
+      ${extra}
+    `;
+    element.classList.remove('hidden');
+  }
+  function setButtonBusy(button, busy, label){
+    if(!button) return;
+    if(busy){
+      if(!button.dataset.originalLabel){
+        button.dataset.originalLabel = button.textContent;
+      }
+      button.disabled = true;
+      if(label) button.textContent = label;
+    }else{
+      button.disabled = false;
+      if(button.dataset.originalLabel){
+        button.textContent = button.dataset.originalLabel;
+        delete button.dataset.originalLabel;
+      }
+    }
+  }
+
+  function setNavLinkBusy(button, busy){
+    if(!button) return;
+    const isBusy = Boolean(busy);
+    button.classList.toggle('is-busy', isBusy);
+    if('disabled' in button){
+      button.disabled = isBusy;
+    }
+    button.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    let spinner = button.querySelector('.nav-link__spinner');
+    if(isBusy){
+      if(!spinner){
+        spinner = document.createElement('span');
+        spinner.className = 'nav-link__spinner';
+        spinner.setAttribute('aria-hidden','true');
+        button.appendChild(spinner);
+      }
+    }else if(spinner){
+      spinner.remove();
+    }
+  }
+
+  let globalLoadingDepth = 0;
+  function toggleGlobalLoading(active, message){
+    const overlay = document.getElementById('globalLoading');
+    if(!overlay) return;
+    const messageEl = document.getElementById('globalLoadingMessage');
+    const text = message ? cleanValue(message) : '';
+    if(messageEl){
+      if(text){
+        messageEl.textContent = text;
+      }else if(!overlay.classList.contains('active') && !cleanValue(messageEl.textContent)){
+        messageEl.textContent = 'Procesando…';
+      }
+    }
+    if(active){
+      globalLoadingDepth++;
+      overlay.classList.remove('hidden');
+      overlay.setAttribute('aria-hidden','false');
+      overlay.setAttribute('aria-busy','true');
+      requestAnimationFrame(()=> overlay.classList.add('active'));
+    }else{
+      if(globalLoadingDepth === 0) return;
+      globalLoadingDepth = Math.max(0, globalLoadingDepth - 1);
+      if(globalLoadingDepth === 0){
+        overlay.classList.remove('active');
+        overlay.setAttribute('aria-busy','false');
+        overlay.setAttribute('aria-hidden','true');
+        setTimeout(()=>{
+          if(globalLoadingDepth === 0){
+            overlay.classList.add('hidden');
+          }
+        }, 220);
+      }
+    }
+  }
+
+  async function withGlobalLoading(message, task){
+    if(typeof task !== 'function') return;
+    toggleGlobalLoading(true, message);
+    try{
+      return await task();
+    }finally{
+      toggleGlobalLoading(false);
+    }
+  }
+
+  function buildBulkTemplateWorkbook(){
+    if(typeof XLSX === 'undefined'){
+      throw new Error('La librería XLSX no está disponible');
+    }
+    const headers = ['ID','Matrícula','Etapa','Estado','Motivo','Asesor'];
+    const maxRows = 2000;
+    const worksheet = XLSX.utils.aoa_to_sheet([headers]);
+    worksheet['!ref'] = XLSX.utils.encode_range({
+      s:{ c:0, r:0 },
+      e:{ c: headers.length - 1, r: maxRows }
+    });
+    worksheet['!cols'] = [
+      { wch: 18 },
+      { wch: 18 },
+      { wch: 18 },
+      { wch: 26 },
+      { wch: 34 },
+      { wch: 22 }
+    ];
+
+    const stateOptions = [];
+    Object.values(estadosByEtapa).forEach(list => {
+      (list || []).forEach(option => {
+        if(option && stateOptions.indexOf(option) === -1){
+          stateOptions.push(option);
+        }
+      });
+    });
+    if(!stateOptions.length) stateOptions.push('');
+
+    const listRows = [['Etapas','Estados']];
+    const rowCount = Math.max(etapasUI.length, stateOptions.length) || 1;
+    for(let i = 0; i < rowCount; i++){
+      listRows.push([
+        etapasUI[i] || '',
+        stateOptions[i] || ''
+      ]);
+    }
+    const listSheet = XLSX.utils.aoa_to_sheet(listRows);
+    listSheet['!ref'] = XLSX.utils.encode_range({
+      s:{ c:0, r:0 },
+      e:{ c:1, r: rowCount }
+    });
+    listSheet['!state'] = 'hidden';
+    listSheet['!cols'] = [
+      { wch: 18 },
+      { wch: 32 }
+    ];
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, worksheet, 'Cambios masivos');
+    XLSX.utils.book_append_sheet(wb, listSheet, 'Listas');
+
+    const stageRange = `'Listas'!$A$2:$A$${etapasUI.length + 1}`;
+    const stateRange = `'Listas'!$B$2:$B$${stateOptions.length + 1}`;
+    worksheet['!dataValidation'] = [
+      {
+        type: 'list',
+        allowBlank: 1,
+        sqref: `C2:C${maxRows + 1}`,
+        formulas: [stageRange]
+      },
+      {
+        type: 'list',
+        allowBlank: 1,
+        sqref: `D2:D${maxRows + 1}`,
+        formulas: [stateRange]
+      }
+    ];
+
+    return wb;
+  }
+
+  function downloadBulkTemplate(){
+    const wb = buildBulkTemplateWorkbook();
+    const buffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'plantilla_cambios_masivos.xlsx';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  let importData = [];
+  const importFile = el('#importFile');
+  const importPreview = el('#importPreview');
+  const dupWrap = el('#dupWrap');
+  const execBtn = el('#btnExecute');
+  const importModal = el('#importConfirmModal');
+  const importModalConfirm = el('#importModalConfirm');
+  const importModalCancel = el('#importModalCancel');
+  const importModalClose = el('#importModalClose');
+  const importModalSkipped = el('#importModalSkipped');
+  const importModalErrors = el('#importModalErrors');
+  const importModalWarnings = el('#importModalWarnings');
+  const importModalMessage = el('#importModalMessage');
+  const importModalTitle = el('#importModalTitle');
+  const importModalCounters = el('#importModalCounters');
+  let pendingImportPayload = null;
+  let pendingImportInsertable = 0;
+  let pendingImportSummary = { errors: [], warnings: [] };
+  let pendingImportSkipped = [];
+  let importModalConfirmable = false;
+  const SKIPPED_MODAL_FIELDS = ['row','id','nombre','matricula','telefono','correo','motivo'];
+
+  const summarizeValidationTotals = summary => ({
+    errors: Array.isArray(summary?.errors)
+      ? summary.errors.reduce((acc, item) => acc + (Number(item?.count) || 0), 0)
+      : 0,
+    warnings: Array.isArray(summary?.warnings)
+      ? summary.warnings.reduce((acc, item) => acc + (Number(item?.count) || 0), 0)
+      : 0
+  });
+
+  function resetPendingImportState(){
+    pendingImportPayload = null;
+    pendingImportInsertable = 0;
+    pendingImportSummary = { errors: [], warnings: [] };
+    pendingImportSkipped = [];
+    importModalConfirmable = false;
+  }
+
+  function labelForSkippedField(field){
+    if(field === 'row') return 'Fila';
+    return FIELD_LABELS[field] || field;
+  }
+
+  function renderValidationList(target, items, emptyLabel){
+    if(!target) return;
+    target.innerHTML = '';
+    const list = Array.isArray(items) ? items : [];
+    if(!list.length){
+      const li = document.createElement('li');
+      li.className = 'muted';
+      li.textContent = emptyLabel;
+      target.appendChild(li);
+      return;
+    }
+    list.forEach(item => {
+      const li = document.createElement('li');
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = String(item?.count ?? 0);
+      const text = document.createElement('span');
+      text.textContent = item?.message || '';
+      li.appendChild(badge);
+      li.appendChild(text);
+      target.appendChild(li);
+    });
+  }
+
+  function renderSkippedPreview(target, rows){
+    if(!target) return;
+    target.innerHTML = '';
+    const records = Array.isArray(rows) ? rows : [];
+    if(!records.length){
+      const empty = document.createElement('p');
+      empty.className = 'muted';
+      empty.textContent = 'No hay registros omitidos.';
+      target.appendChild(empty);
+      return;
+    }
+    const wrapper = document.createElement('div');
+    wrapper.className = 'table-wrap';
+    const table = document.createElement('table');
+    table.className = 'modal-table';
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    SKIPPED_MODAL_FIELDS.forEach(field => {
+      const th = document.createElement('th');
+      th.textContent = labelForSkippedField(field);
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    records.slice(0, 20).forEach(row => {
+      const tr = document.createElement('tr');
+      SKIPPED_MODAL_FIELDS.forEach(field => {
+        const td = document.createElement('td');
+        let value;
+        if(field === 'row'){
+          value = row?.row ?? '';
+        }else{
+          const formatter = FIELD_FORMATTERS[field];
+          value = formatter ? formatter(row?.[field]) : row?.[field];
+        }
+        td.textContent = value === undefined || value === null ? '' : String(value);
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    wrapper.appendChild(table);
+    target.appendChild(wrapper);
+    if(records.length > 20){
+      const footnote = document.createElement('div');
+      footnote.className = 'modal-footnote';
+      footnote.textContent = `Se muestran 20 de ${records.length} registros omitidos.`;
+      target.appendChild(footnote);
+    }
+  }
+
+  function updateImportModal(options = {}){
+    const { skipped = [], summary = { errors: [], warnings: [] }, insertable = 0, confirmable = false, message, title } = options;
+    importModalConfirmable = Boolean(confirmable);
+    pendingImportInsertable = Number(insertable) || 0;
+    if(importModalTitle){
+      importModalTitle.textContent = title || 'Revisión de importación';
+    }
+    if(importModalMessage){
+      importModalMessage.textContent = message || (confirmable
+        ? 'Se importarán los registros listos una vez que confirmes.'
+        : 'Revisa las incidencias detectadas antes de intentar nuevamente.');
+    }
+    renderSkippedPreview(importModalSkipped, skipped);
+    renderValidationList(importModalErrors, summary?.errors, 'Sin errores detectados.');
+    renderValidationList(importModalWarnings, summary?.warnings, 'Sin advertencias.');
+    const totals = summarizeValidationTotals(summary);
+    if(importModalCounters){
+      const parts = [
+        `Listos: ${pendingImportInsertable}`,
+        `Omitidos: ${Array.isArray(skipped) ? skipped.length : 0}`,
+        `Errores: ${totals.errors}`,
+        `Advertencias: ${totals.warnings}`
+      ];
+      importModalCounters.textContent = parts.join(' · ');
+    }
+    if(importModalConfirm){
+      importModalConfirm.classList.toggle('hidden', !importModalConfirmable);
+      importModalConfirm.disabled = !importModalConfirmable;
+    }
+    if(importModalCancel){
+      importModalCancel.textContent = confirmable ? 'Cancelar' : 'Cerrar';
+    }
+  }
+
+  function showImportModal(options){
+    if(!importModal) return;
+    updateImportModal(options);
+    importModal.classList.add('active');
+    importModal.setAttribute('aria-hidden','false');
+    document.body.classList.add('modal-open');
+  }
+
+  function closeImportModal(resetState = false){
+    if(!importModal) return;
+    importModal.classList.remove('active');
+    importModal.setAttribute('aria-hidden','true');
+    document.body.classList.remove('modal-open');
+    if(resetState){
+      resetPendingImportState();
+    }
+    setButtonBusy(importModalConfirm, false);
+  }
+
+  if(importModalCancel){
+    importModalCancel.addEventListener('click', ()=> closeImportModal(true));
+  }
+  if(importModalClose){
+    importModalClose.addEventListener('click', ()=> closeImportModal(true));
+  }
+  if(importModal){
+    importModal.addEventListener('click', event => {
+      if(event.target === importModal){
+        closeImportModal(true);
+      }
+    });
+  }
+
+  async function requestImport(confirmFlag, override){
+    const payload = {
+      action: 'importLeads',
+      sheet: override?.sheet || (state.sheet === ALL_SHEETS_VALUE ? '' : state.sheet),
+      rows: Array.isArray(override?.rows) ? override.rows : importData,
+      confirm: confirmFlag === true
+    };
+    const response = await apiFetch(API_URL, {
+      method: 'POST',
+      body: payload
+    });
+    const rawBody = await response.text().catch(()=> '');
+    if(!response.ok){
+      let message = rawBody || `HTTP ${response.status}`;
+      try{
+        const parsed = rawBody ? JSON.parse(rawBody) : null;
+        if(parsed && parsed.error){
+          message = parsed.error;
+        }
+      }catch(_ignore){}
+      throw new Error(message);
+    }
+    let parsed = null;
+    if(rawBody){
+      try{
+        parsed = JSON.parse(rawBody);
+      }catch(_ignore){}
+    }
+    if(parsed && parsed.ok === false){
+      const error = new Error(parsed.error || 'No se pudo completar la importación.');
+      error.details = parsed;
+      throw error;
+    }
+    return parsed || { ok:true, message: rawBody };
+  }
+
+  async function handleImportSuccess(result){
+    closeImportModal(true);
+    const summary = result?.summary;
+    const totals = summarizeValidationTotals(summary);
+    const messages = [];
+    if(result?.message){
+      messages.push(result.message);
+    }else{
+      messages.push('Importación completada');
+    }
+    if(totals.errors || totals.warnings){
+      messages.push(`Validaciones · Errores: ${totals.errors} · Advertencias: ${totals.warnings}`);
+    }
+    alert(messages.join('\n'));
+    importData = [];
+    clearContainer(importPreview);
+    clearContainer(dupWrap);
+    if(execBtn) execBtn.disabled = true;
+    resetPendingImportState();
+    invalidateGlobalLeadIndex();
+    await withGlobalLoading('Actualizando leads…', () => loadLeads());
+    populateAsesores();
+    populateCampuses();
+    populateExportFilters();
+    refresh();
+  }
+
+  if(importFile) importFile.addEventListener('change', ()=>{
+    importData = [];
+    clearContainer(importPreview);
+    clearContainer(dupWrap);
+    if(execBtn) execBtn.disabled = true;
+  });
+  const verifyBtn = el('#btnVerify');
+  if(verifyBtn) verifyBtn.addEventListener('click', async()=>{
+    if(!canPerform('importData')){
+      alert('No tienes permisos para importar datos.');
+      return;
+    }
+    const file = importFile?.files?.[0];
+    if(!file){ alert('Selecciona un archivo'); return; }
+    setButtonBusy(verifyBtn, true, 'Verificando...');
+    try{
+      const parsed = await parseTabularFile(file);
+      if(!parsed.rows.length){
+        alert('El archivo no contiene datos.');
+        importData = [];
+        clearContainer(importPreview);
+        clearContainer(dupWrap);
+        if(execBtn) execBtn.disabled = true;
+        return;
+      }
+      const headerMapping = buildHeaderMapping(parsed.headers, parsed.rows);
+      const normalized = parsed.rows
+        .map(row => normalizeImportRow(row, headerMapping))
+        .filter(Boolean);
+      if(!normalized.length){
+        alert('No se encontraron columnas compatibles con la base.');
+        importData = [];
+        clearContainer(importPreview);
+        clearContainer(dupWrap);
+        if(execBtn) execBtn.disabled = true;
+        return;
+      }
+      const { valid, duplicates } = splitImportRows(normalized);
+      const validRows = valid.map(projectImportRow);
+      const duplicateRows = duplicates.map(item => {
+        const projected = projectImportRow(item.data);
+        projected.motivo = item.reason;
+        return projected;
+      });
+      importData = validRows;
+      if(validRows.length){
+        renderTable(importPreview, validRows, {
+          fields: ['nombre','matricula','telefono','programa','etapa','estado'],
+          summary: `Registros listos: ${validRows.length}${duplicateRows.length ? ` · Descartados: ${duplicateRows.length}` : ''}`
+        });
+        if(execBtn) execBtn.disabled = false;
+      }else{
+        clearContainer(importPreview);
+        if(execBtn) execBtn.disabled = true;
+      }
+      if(duplicateRows.length){
+        renderTable(dupWrap, duplicateRows, {
+          fields: ['nombre','matricula','telefono','motivo'],
+          limit: 10,
+          summary: `Registros descartados: ${duplicateRows.length}`
+        });
+      }else{
+        clearContainer(dupWrap);
+      }
+      if(!validRows.length){
+        alert('No se encontraron registros nuevos después de eliminar duplicados.');
+      }
+    }catch(err){
+      console.error('Error al verificar importación', err);
+      alert('No se pudo procesar el archivo. Revisa que tenga formato CSV o XLSX.');
+      importData = [];
+      clearContainer(importPreview);
+      clearContainer(dupWrap);
+      if(execBtn) execBtn.disabled = true;
+    }finally{
+      setButtonBusy(verifyBtn, false);
+    }
+  });
+
+  let activosData = [];
+  let activosDiff = [];
+  const activosFile = el('#activosFile');
+  const activosPreview = el('#activosPreview');
+  const activosDiffWrap = el('#activosDiff');
+  const activosVerifyBtn = el('#btnActivosVerify');
+  const activosExecuteBtn = el('#btnActivosExecute');
+
+  if(activosFile) activosFile.addEventListener('change', ()=>{
+    activosData = [];
+    activosDiff = [];
+    clearContainer(activosPreview);
+    clearContainer(activosDiffWrap);
+    if(activosExecuteBtn) activosExecuteBtn.disabled = true;
+  });
+
+  function dedupeLeadList(list){
+    const set = new Set();
+    const out = [];
+    (list || []).forEach(lead => {
+      if(!lead || set.has(lead)) return;
+      set.add(lead);
+      out.push(lead);
+    });
+    return out;
+  }
+
+  function matchActivosRow(row, index){
+    const attempts = [
+      { key: row._idKey, map: index.byId },
+      { key: row._matriculaKey, map: index.byMatricula },
+      { key: row._phoneKey, map: index.byPhone }
+    ];
+    for(const attempt of attempts){
+      if(!attempt.key) continue;
+      const list = attempt.map?.get(attempt.key) || [];
+      if(!list.length) continue;
+      const unique = dedupeLeadList(list);
+      if(unique.length === 1){
+        return { status:'ok', lead: unique[0] };
+      }
+      return { status:'conflict', reason:'Coincidencias múltiples en la base' };
+    }
+    return { status:'none', reason:'No se encontró en la base' };
+  }
+
+  function buildActivosUpdates(row){
+    const updates = {};
+    ACTIVOS_UPDATE_FIELDS.forEach(field => {
+      const value = cleanValue(row[field] || '');
+      if(value) updates[field] = value;
+    });
+    return updates;
+  }
+
+  function renderActivosPreview(matches, differences){
+    if(matches.length){
+      const rows = matches.map(item => {
+        const updates = item.updates;
+        const lead = item.lead;
+        return {
+          nombre: updates.nombre || lead.nombre,
+          matricula: updates.matricula || lead.matricula,
+          telefono: updates.telefono || lead.telefono,
+          programa: updates.programa || lead.programa,
+          modalidad: updates.modalidad || lead.modalidad,
+          base: sheetDisplayName(item.sheet) || item.sheet,
+          asesorActual: lead.asesor || '',
+          asesorNuevo: 'Sistema'
+        };
+      });
+      renderTable(activosPreview, rows, {
+        fields: ['nombre','matricula','telefono','programa','modalidad','base','asesorActual','asesorNuevo'],
+        summary: `Similitudes: ${matches.length}${differences.length ? ` · Diferencias: ${differences.length}` : ''}`
+      });
+    }else{
+      clearContainer(activosPreview);
+    }
+    if(differences.length){
+      const rows = differences.map(item => ({
+        nombre: item.row?.nombre || '',
+        matricula: item.row?.matricula || '',
+        telefono: item.row?.telefono || '',
+        motivo: item.reason
+      }));
+      renderTable(activosDiffWrap, rows, {
+        fields: ['nombre','matricula','telefono','motivo'],
+        limit: 10,
+        summary: `Diferencias: ${differences.length}`
+      });
+    }else{
+      clearContainer(activosDiffWrap);
+    }
+  }
+
+  if(activosVerifyBtn) activosVerifyBtn.addEventListener('click', async()=>{
+    if(!canPerform('importData')){
+      alert('No tienes permisos para analizar activos.');
+      return;
+    }
+    const file = activosFile?.files?.[0];
+    if(!file){ alert('Selecciona un archivo'); return; }
+    setButtonBusy(activosVerifyBtn, true, 'Analizando...');
+    try{
+      const parsed = await parseTabularFile(file);
+      if(!parsed.rows.length){
+        alert('El archivo no contiene datos.');
+        activosData = [];
+        activosDiff = [];
+        clearContainer(activosPreview);
+        clearContainer(activosDiffWrap);
+        if(activosExecuteBtn) activosExecuteBtn.disabled = true;
+        return;
+      }
+      const headerMapping = buildHeaderMapping(parsed.headers, parsed.rows);
+      const normalized = parsed.rows
+        .map(row => normalizeImportRow(row, headerMapping))
+        .filter(Boolean);
+      if(!normalized.length){
+        alert('No se encontraron columnas compatibles para comparar activos.');
+        activosData = [];
+        activosDiff = [];
+        clearContainer(activosPreview);
+        clearContainer(activosDiffWrap);
+        if(activosExecuteBtn) activosExecuteBtn.disabled = true;
+        return;
+      }
+      const index = await ensureGlobalLeadIndex();
+      const matches = [];
+      const differences = [];
+      const seen = { id:new Set(), matricula:new Set(), phone:new Set() };
+      normalized.forEach(row => {
+        const reasons = [];
+        if(row._idKey){
+          if(seen.id.has(row._idKey)) reasons.push('ID duplicado en el archivo');
+          else seen.id.add(row._idKey);
+        }
+        if(row._matriculaKey){
+          if(seen.matricula.has(row._matriculaKey)) reasons.push('Matrícula duplicada en el archivo');
+          else seen.matricula.add(row._matriculaKey);
+        }
+        if(row._phoneKey){
+          if(seen.phone.has(row._phoneKey)) reasons.push('Teléfono duplicado en el archivo');
+          else seen.phone.add(row._phoneKey);
+        }
+        if(!row._idKey && !row._matriculaKey && !row._phoneKey){
+          reasons.push('Sin identificadores (ID, Matrícula o Teléfono)');
+        }
+        if(reasons.length){
+          differences.push({ row, reason: [...new Set(reasons)].join(' · ') });
+          return;
+        }
+        const match = matchActivosRow(row, index);
+        if(match.status === 'ok'){
+          const updates = buildActivosUpdates(row);
+          matches.push({
+            row,
+            lead: match.lead,
+            sheet: match.lead.base,
+            updates,
+            phoneKey: row._phoneKey || '',
+            matriculaKey: row._matriculaKey || '',
+            idKey: row._idKey || ''
+          });
+        }else{
+          differences.push({ row, reason: match.reason });
+        }
+      });
+      activosData = matches;
+      activosDiff = differences;
+      renderActivosPreview(matches, differences);
+      if(activosExecuteBtn) activosExecuteBtn.disabled = !matches.length;
+      if(!matches.length){
+        alert('No se encontraron coincidencias en la base.');
+      }
+    }catch(err){
+      console.error('Error al analizar activos', err);
+      alert('No se pudo procesar el archivo de activos.');
+      activosData = [];
+      activosDiff = [];
+      clearContainer(activosPreview);
+      clearContainer(activosDiffWrap);
+      if(activosExecuteBtn) activosExecuteBtn.disabled = true;
+    }finally{
+      setButtonBusy(activosVerifyBtn, false);
+    }
+  });
+
+  function buildActivosPayloadEntry(entry){
+    const updates = {};
+    ACTIVOS_UPDATE_FIELDS.forEach(field => {
+      const value = entry.updates[field];
+      if(value) updates[field] = value;
+    });
+    return {
+      sheet: entry.sheet,
+      id: entry.lead.id || '',
+      idKey: entry.idKey || normalizeIdentifierKey(entry.lead.id),
+      matriculaKey: entry.matriculaKey || normalizeIdentifierKey(entry.lead.matricula),
+      phoneKey: entry.phoneKey || normalizePhoneKey(entry.lead.telefonoNormalizado || entry.lead.telefono),
+      updates
+    };
+  }
+
+  if(activosExecuteBtn) activosExecuteBtn.addEventListener('click', async()=>{
+    if(!canPerform('syncActivos')){
+      alert('No tienes permisos para actualizar activos.');
+      return;
+    }
+    if(!activosData.length){ alert('No hay coincidencias verificadas.'); return; }
+    setButtonBusy(activosExecuteBtn, true, 'Actualizando...');
+    try{
+      const payload = {
+        action: 'syncActivos',
+        rows: activosData.map(buildActivosPayloadEntry)
+      };
+      const response = await apiFetch(API_URL, {
+        method: 'POST',
+        body: payload
+      });
+      const rawBody = await response.text().catch(()=> '');
+      if(!response.ok){
+        let message = rawBody || `HTTP ${response.status}`;
+        try{
+          const parsed = rawBody ? JSON.parse(rawBody) : null;
+          if(parsed && parsed.error){
+            message = parsed.error;
+          }
+        }catch(_ignore){}
+        throw new Error(message);
+      }
+      let successMessage = 'Actualización completada.';
+      if(rawBody){
+        try{
+          const parsed = JSON.parse(rawBody);
+          if(parsed && parsed.ok){
+            const parts = [`Registros actualizados: ${parsed.updated || 0}`];
+            if(parsed.unmatched && parsed.unmatched.length){
+              parts.push(`No encontrados: ${parsed.unmatched.length}`);
+            }
+            successMessage = parts.join(' · ');
+          }else if(parsed && parsed.error){
+            throw new Error(parsed.error);
+          }
+        }catch(errJson){
+          console.warn('Respuesta inesperada al actualizar activos', errJson);
+        }
+      }
+      alert(successMessage);
+      activosData = [];
+      activosDiff = [];
+      clearContainer(activosPreview);
+      clearContainer(activosDiffWrap);
+      if(activosExecuteBtn) activosExecuteBtn.disabled = true;
+      invalidateGlobalLeadIndex();
+      await withGlobalLoading('Actualizando leads…', () => loadLeads());
+      populateAsesores();
+      populateCampuses();
+      populateExportFilters();
+      refresh();
+    }catch(err){
+      console.error('Error al actualizar activos', err);
+      alert(`Error al actualizar activos: ${err.message || err}`);
+    }finally{
+      setButtonBusy(activosExecuteBtn, false);
+    }
+  });
+
+  let bulkData = [];
+  const bulkFile = el('#bulkFile');
+  const bulkPreview = el('#bulkPreview');
+  const bulkIssuesWrap = el('#bulkDupWrap');
+  const bulkExecBtn = el('#btnBulkExecute');
+  if(bulkFile) bulkFile.addEventListener('change', ()=>{
+    bulkData = [];
+    clearContainer(bulkPreview);
+    clearContainer(bulkIssuesWrap);
+    if(bulkExecBtn) bulkExecBtn.disabled = true;
+  });
+  const bulkVerifyBtn = el('#btnBulkVerify');
+  if(bulkVerifyBtn) bulkVerifyBtn.addEventListener('click', async()=>{
+    if(!canPerform('importData')){
+      alert('No tienes permisos para validar cambios masivos.');
+      return;
+    }
+    const file = bulkFile?.files?.[0];
+    if(!file){ alert('Selecciona un archivo'); return; }
+    setButtonBusy(bulkVerifyBtn, true, 'Verificando...');
+    try{
+      const parsed = await parseTabularFile(file);
+      if(!parsed.rows.length){
+        alert('El archivo no contiene datos.');
+        bulkData = [];
+        clearContainer(bulkPreview);
+        clearContainer(bulkIssuesWrap);
+        if(bulkExecBtn) bulkExecBtn.disabled = true;
+        return;
+      }
+      const headerMapping = buildHeaderMapping(parsed.headers, parsed.rows);
+      const normalized = parsed.rows
+        .map(row => normalizeBulkRow(row, headerMapping))
+        .filter(Boolean);
+      if(!normalized.length){
+        alert('No se encontraron columnas válidas para cambios masivos.');
+        bulkData = [];
+        clearContainer(bulkPreview);
+        clearContainer(bulkIssuesWrap);
+        if(bulkExecBtn) bulkExecBtn.disabled = true;
+        return;
+      }
+      const { valid, issues } = splitBulkRows(normalized);
+      const validRows = valid.map(projectBulkRow);
+      const issueRows = issues.map(item => {
+        const projected = projectBulkRow(item.data);
+        projected.motivo = item.reason;
+        return projected;
+      });
+      bulkData = validRows;
+      if(validRows.length){
+        renderTable(bulkPreview, validRows, {
+          fields: ['id','matricula','etapa','estado','comentario'],
+          summary: `Registros listos: ${validRows.length}${issueRows.length ? ` · Con incidencias: ${issueRows.length}` : ''}`
+        });
+        if(bulkExecBtn) bulkExecBtn.disabled = false;
+      }else{
+        clearContainer(bulkPreview);
+        if(bulkExecBtn) bulkExecBtn.disabled = true;
+      }
+      if(issueRows.length){
+        renderTable(bulkIssuesWrap, issueRows, {
+          fields: ['id','matricula','etapa','estado','motivo'],
+          limit: 10,
+          summary: `Registros con incidencias: ${issueRows.length}`
+        });
+      }else{
+        clearContainer(bulkIssuesWrap);
+      }
+      if(!validRows.length){
+        alert('No se encontró ningún registro válido para actualizar.');
+      }
+    }catch(err){
+      console.error('Error al verificar cambios masivos', err);
+      alert('No se pudo procesar el archivo de cambios masivos.');
+      bulkData = [];
+      clearContainer(bulkPreview);
+      clearContainer(bulkIssuesWrap);
+      if(bulkExecBtn) bulkExecBtn.disabled = true;
+    }finally{
+      setButtonBusy(bulkVerifyBtn, false);
+    }
+  });
+
+  const bulkTemplateBtn = el('#btnBulkTemplate');
+  if(bulkTemplateBtn) bulkTemplateBtn.addEventListener('click', ()=>{
+    try{
+      downloadBulkTemplate();
+    }catch(err){
+      console.error('Error al generar plantilla', err);
+      alert('No se pudo generar la plantilla. Vuelve a intentarlo.');
+    }
+  });
+
+  if(execBtn) execBtn.addEventListener('click', async()=>{
+    if(!canPerform('importData')){ alert('No tienes permisos para importar datos.'); return; }
+    if(!importData.length){ alert('No hay datos verificados'); return; }
+    const activeSheet = state.sheet === ALL_SHEETS_VALUE ? '' : state.sheet;
+    if(!activeSheet){ alert('Selecciona una base antes de importar.'); return; }
+    setButtonBusy(execBtn, true, 'Verificando...');
+    try{
+      const result = await requestImport(false, { sheet: activeSheet });
+      if(result?.requiresConfirmation){
+        pendingImportPayload = {
+          sheet: activeSheet,
+          rows: importData.map(row => ({ ...row }))
+        };
+        pendingImportSummary = {
+          errors: Array.isArray(result?.summary?.errors) ? result.summary.errors : [],
+          warnings: Array.isArray(result?.summary?.warnings) ? result.summary.warnings : []
+        };
+        pendingImportSkipped = Array.isArray(result?.skipped) ? result.skipped : [];
+        showImportModal({
+          confirmable: true,
+          insertable: Number(result?.insertable || importData.length || 0),
+          skipped: pendingImportSkipped,
+          summary: pendingImportSummary,
+          message: result?.message || `Se importarán ${Number(result?.insertable || importData.length || 0)} registros válidos una vez que confirmes.`
+        });
+        return;
+      }
+      await handleImportSuccess(result);
+    }catch(err){
+      console.error('Error al importar', err);
+      const details = err?.details;
+      if(details){
+        resetPendingImportState();
+        showImportModal({
+          confirmable: false,
+          insertable: Number(details?.insertable || 0),
+          skipped: Array.isArray(details?.skipped) ? details.skipped : [],
+          summary: details?.summary || { errors: [], warnings: [] },
+          message: details?.error || err.message || 'No se pudo completar la importación.'
+        });
+      }else{
+        alert(`Error al importar: ${err.message || err}`);
+      }
+    }finally{
+      setButtonBusy(execBtn, false);
+    }
+  });
+
+  if(importModalConfirm) importModalConfirm.addEventListener('click', async()=>{
+    if(!importModalConfirmable || !pendingImportPayload){
+      closeImportModal(true);
+      return;
+    }
+    setButtonBusy(importModalConfirm, true, 'Confirmando...');
+    try{
+      const result = await requestImport(true, pendingImportPayload);
+      await handleImportSuccess(result);
+    }catch(err){
+      console.error('Error al confirmar importación', err);
+      const details = err?.details;
+      if(details){
+        resetPendingImportState();
+        showImportModal({
+          confirmable: false,
+          insertable: Number(details?.insertable || 0),
+          skipped: Array.isArray(details?.skipped) ? details.skipped : [],
+          summary: details?.summary || { errors: [], warnings: [] },
+          message: details?.error || err.message || 'No se pudo completar la importación.'
+        });
+      }else{
+        alert(`Error al importar: ${err.message || err}`);
+      }
+    }finally{
+      setButtonBusy(importModalConfirm, false);
+    }
+  });
+
+  if(bulkExecBtn) bulkExecBtn.addEventListener('click', ()=>{
+    if(!canPerform('importData')){
+      alert('No tienes permisos para ejecutar cambios masivos.');
+      return;
+    }
+    if(!bulkData.length){ alert('No hay cambios verificados'); return; }
+    alert(`${bulkData.length} registros verificados. Envía los datos al backend desde aquí cuando esté disponible.`);
+  });
+  // Exportar
+  function populateExportFilters(){
+    const dataBase = el('#expDataBase');
+    const dataAsesor = el('#expDataAsesor');
+    const dataEtapa = el('#expDataEtapa');
+    const dataEstado = el('#expDataEstado');
+    const reportBase = el('#expReportBase');
+    const reportAsesor = el('#expReportAsesor');
+    const resolBase = el('#expResolBase');
+    const resolAsesor = el('#expResolAsesor');
+    if(!dataBase && !reportBase && !resolBase && !dataAsesor && !reportAsesor && !resolAsesor && !dataEtapa && !dataEstado) return;
+
+    const populateSelect = (select, placeholder, values, labelFn) => {
+      if(!select) return;
+      const previous = select.value;
+      select.innerHTML = '';
+      if(typeof placeholder === 'string'){
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = placeholder;
+        select.appendChild(option);
+      }
+      values.forEach(value => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = typeof labelFn === 'function' ? labelFn(value) : value;
+        select.appendChild(option);
+      });
+      if(previous){
+        select.value = previous;
+        if(select.value !== previous) select.value = '';
+      }else{
+        select.value = '';
+      }
+    };
+
+    const bases = [...new Set(leads.map(r => r.base).filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    const baseLabel = base => sheetDisplayName(base) || base;
+    populateSelect(dataBase, 'Bases', bases, baseLabel);
+    populateSelect(reportBase, 'Base', bases, baseLabel);
+    populateSelect(resolBase, 'Base', bases, baseLabel);
+
+    const asesores = [...new Set(
+      leads
+        .map(r => r.asesor)
+        .filter(a => a && !a.toLowerCase().includes('sistema'))
+    )].sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    populateSelect(dataAsesor, 'Todos los asesores', asesores);
+    populateSelect(reportAsesor, 'Todos los asesores', asesores);
+    populateSelect(resolAsesor, 'Todos los asesores', asesores);
+
+    const etapas = [...new Set(leads.map(r => r.etapa).filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    populateSelect(dataEtapa, 'Etapa', etapas);
+
+    const estadoSet = new Set(
+      leads
+        .map(r => r.estado)
+        .filter(Boolean)
+    );
+    if(!estadoSet.size){
+      Object.values(estadosByEtapa).forEach(list => {
+        list.forEach(item => estadoSet.add(item));
+      });
+    }
+    const estadosOrdenados = Array.from(estadoSet)
+      .sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    populateSelect(dataEstado, 'Todos los estados', estadosOrdenados);
+
+    const selTipo = el('#expReportTipo');
+    if(selTipo) selTipo.value = '';
+    const selCRM = el('#expResolCRM');
+    if(selCRM) selCRM.value = '';
+  }
+
+  function exportData(rows,name){
+    const headers=['Matricula','Nombre','Telefono','Correo','ID','Etapa'];
+    const csv=[headers.join(',')].concat(rows.map(r=>[r.matricula||'',r.nombre,r.telefono,r.correo,r.id,r.etapa].join(','))).join('\n');
+    const blob=new Blob([csv],{type:'text/csv'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a'); a.href=url; a.download=name; a.click(); URL.revokeObjectURL(url);
+  }
+  const formatCsvField = value => {
+    const text = cleanValue(value);
+    if(!text) return '';
+    return /[",\n]/.test(text) ? `"${text.replace(/"/g,'""')}"` : text;
+  };
+  function downloadCsvFromRows(rows, columns, filename){
+    if(!Array.isArray(rows) || !rows.length) return;
+    const cols = Array.isArray(columns) && columns.length
+      ? columns
+      : Object.keys(rows[0] || {}).map(key => ({ key, label: key }));
+    const header = cols.map(col => formatCsvField(col.label)).join(',');
+    const lines = rows.map(row => cols.map(col => formatCsvField(row?.[col.key])).join(','));
+    const csv = [header].concat(lines).join('\n');
+    const blob = new Blob([csv],{type:'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename || 'reporte.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+  async function exportReport(params){
+    const qs = new URLSearchParams({
+      action:'report',
+      asesor:params.asesor||'',
+      base:params.base||'',
+      etapa:params.etapa||'',
+      estado:params.estado||'',
+      fi:params.fi||'',
+      ff:params.ff||'',
+      type:params.tipo||''
+    });
+    try{
+      const res = await apiFetch(`${API_URL}?${qs.toString()}`);
+      if(!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if(data && data.error){
+        throw new Error(data.error);
+      }
+      if((params.tipo || '').toLowerCase() === 'losg'){
+        const source = Array.isArray(data?.logs)
+          ? data.logs
+          : Array.isArray(data?.data?.logs)
+            ? data.data.logs
+            : Array.isArray(data?.data)
+              ? data.data
+              : Array.isArray(data?.records)
+                ? data.records
+                : Array.isArray(data?.rows)
+                  ? data.rows
+                  : (data?.data && typeof data.data === 'object')
+                    ? Object.values(data.data)
+                    : [];
+        const normalizedLogs = source.map(normalizeLosgEntry).filter(Boolean);
+        if(!normalizedLogs.length){
+          alert('No se encontraron registros de actividad para el periodo seleccionado.');
+          return;
+        }
+        const columns = [
+          { key:'fecha', label:'Fecha' },
+          { key:'usuario', label:'Usuario' },
+          { key:'correo', label:'Correo' },
+          { key:'rol', label:'Rol' },
+          { key:'total_accesos', label:'Accesos totales' },
+          { key:'primer_acceso', label:'Primer acceso' },
+          { key:'ultimo_acceso', label:'Último acceso' },
+          { key:'accesos_moviles', label:'Accesos móviles' },
+          { key:'accesos_escritorio', label:'Accesos escritorio' },
+          { key:'dispositivos', label:'Dispositivos' },
+          { key:'horarios', label:'Horarios de conexión' },
+          { key:'importaciones', label:'Importaciones' },
+          { key:'exportaciones', label:'Exportaciones' },
+          { key:'cambios_masivos', label:'Cambios masivos' },
+          { key:'diagnosticos', label:'Diagnósticos ejecutados' },
+          { key:'resultado_diagnostico', label:'Resultado diagnóstico' },
+          { key:'permisos_asignados', label:'Permisos asignados' },
+          { key:'planteles_asignados', label:'Planteles asignados' }
+        ];
+        downloadCsvFromRows(normalizedLogs, columns, 'reporte_losg.csv');
+        return;
+      }
+      const rows = Object.entries(data.data||{}).map(([k,v])=>({item:k,cantidad:v}));
+      const headers=['Item','Cantidad'];
+      const csv=[headers.join(',')].concat(rows.map(r=>[r.item,r.cantidad].join(','))).join('\n');
+      const blob=new Blob([csv],{type:'text/csv'});
+      const url=URL.createObjectURL(blob);
+      const a=document.createElement('a'); a.href=url; a.download=`reporte_${params.tipo||'general'}.csv`; a.click(); URL.revokeObjectURL(url);
+    }catch(err){
+      alert('Error al generar reporte');
+    }
+  }
+  function exportResolutions(rows,name){
+    const headers=['ID','Nombre','Asesor','Base','CRM','Resolución','Etapa','Estado','Asignación'];
+    const csv=[headers.join(',')].concat(rows.map(r=>[
+      r.id||'',
+      r.nombre||'',
+      r.asesor||'',
+      (sheetDisplayName(r.base)||r.base||''),
+      r.crm||'',
+      r.resolucion||'',
+      r.etapa||'',
+      r.estado||'',
+      r.asignacion||''
+    ].join(','))).join('\n');
+    const blob=new Blob([csv],{type:'text/csv'});
+    const url=URL.createObjectURL(blob);
+    const a=document.createElement('a'); a.href=url; a.download=name; a.click(); URL.revokeObjectURL(url);
+  }
+  const getValue = selector => {
+    const control = el(selector);
+    return control ? control.value : '';
+  };
+  const normalizeCRMValue = value => {
+    const text = cleanValue(value);
+    if(text && typeof text.normalize === 'function'){
+      return text.normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase();
+    }
+    return text.toLowerCase();
+  };
+  const parseDateToEpoch = value => {
+    if(value instanceof Date){
+      const time = value.valueOf();
+      return Number.isNaN(time) ? null : time;
+    }
+    if(typeof value === 'number' && Number.isFinite(value)){
+      return value;
+    }
+    const text = cleanValue(value);
+    if(!text){
+      return null;
+    }
+    const numeric = Number(text);
+    if(Number.isFinite(numeric)){
+      return numeric;
+    }
+    let normalized = text.replace(/\//g, '-').trim();
+    if(/^\d{4}-\d{2}-\d{2}$/.test(normalized)){
+      normalized = `${normalized}T00:00:00`;
+    }else if(/^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}/.test(normalized)){
+      normalized = normalized.replace(' ', 'T');
+    }
+    const parsed = new Date(normalized);
+    if(!Number.isNaN(parsed.valueOf())){
+      return parsed.valueOf();
+    }
+    const fallback = new Date(text);
+    if(!Number.isNaN(fallback.valueOf())){
+      return fallback.valueOf();
+    }
+    return null;
+  };
+  const getAssignmentEpoch = row => {
+    if(!row || typeof row !== 'object'){
+      return null;
+    }
+    if(Object.prototype.hasOwnProperty.call(row, '_assignmentEpoch')){
+      return row._assignmentEpoch;
+    }
+    const epoch = parseDateToEpoch(row.asignacion);
+    Object.defineProperty(row, '_assignmentEpoch', {
+      value: epoch,
+      writable: true,
+      configurable: true,
+      enumerable: false
+    });
+    return epoch;
+  };
+  function handleDataExport(){
+    if(!canPerform('exportData')){ alert('No tienes permisos para exportar información.'); return; }
+    const params = {
+      asesor: getValue('#expDataAsesor'),
+      base: getValue('#expDataBase'),
+      etapa: getValue('#expDataEtapa'),
+      estado: getValue('#expDataEstado'),
+      fi: getValue('#expDataStart'),
+      ff: getValue('#expDataEnd')
+    };
+    let rows = leads.slice();
+    if(params.asesor) rows = rows.filter(r => r.asesor === params.asesor);
+    if(params.base) rows = rows.filter(r => r.base === params.base);
+    if(params.etapa) rows = rows.filter(r => r.etapa === params.etapa || r.estado === params.etapa);
+    if(params.estado) rows = rows.filter(r => r.estado === params.estado);
+    const startEpoch = parseDateToEpoch(params.fi);
+    const endEpoch = parseDateToEpoch(params.ff);
+    if(startEpoch !== null){
+      rows = rows.filter(r => {
+        const epoch = getAssignmentEpoch(r);
+        return epoch !== null && epoch >= startEpoch;
+      });
+    }
+    if(endEpoch !== null){
+      rows = rows.filter(r => {
+        const epoch = getAssignmentEpoch(r);
+        return epoch !== null && epoch <= endEpoch;
+      });
+    }
+    exportData(rows,'datos.csv');
+  }
+  async function handleReportExport(){
+    if(!canPerform('exportData')){ alert('No tienes permisos para exportar información.'); return; }
+    const params = {
+      asesor: getValue('#expReportAsesor'),
+      base: getValue('#expReportBase'),
+      etapa: '',
+      estado: '',
+      fi: getValue('#expReportStart'),
+      ff: getValue('#expReportEnd'),
+      tipo: getValue('#expReportTipo')
+    };
+    if(!params.tipo){
+      alert('Selecciona un tipo de reporte');
+      return;
+    }
+    const reportBtn = el('#btnExportReport');
+    setButtonBusy(reportBtn, true, 'Generando...');
+    try{
+      await withGlobalLoading('Generando reporte…', () => exportReport(params));
+    }finally{
+      setButtonBusy(reportBtn, false);
+    }
+  }
+  function handleResolutionExport(){
+    if(!canPerform('exportData')){ alert('No tienes permisos para exportar información.'); return; }
+    const params = {
+      crm: getValue('#expResolCRM'),
+      asesor: getValue('#expResolAsesor'),
+      base: getValue('#expResolBase'),
+      fi: getValue('#expResolStart'),
+      ff: getValue('#expResolEnd')
+    };
+    let rows = leads.slice();
+    if(params.crm){
+      const targetCRM = normalizeCRMValue(params.crm);
+      rows = rows.filter(r => normalizeCRMValue(r.crm) === targetCRM);
+    }
+    if(params.asesor) rows = rows.filter(r => r.asesor === params.asesor);
+    if(params.base) rows = rows.filter(r => r.base === params.base);
+    const startEpoch = parseDateToEpoch(params.fi);
+    const endEpoch = parseDateToEpoch(params.ff);
+    if(startEpoch !== null){
+      rows = rows.filter(r => {
+        const epoch = getAssignmentEpoch(r);
+        return epoch !== null && epoch >= startEpoch;
+      });
+    }
+    if(endEpoch !== null){
+      rows = rows.filter(r => {
+        const epoch = getAssignmentEpoch(r);
+        return epoch !== null && epoch <= endEpoch;
+      });
+    }
+    exportResolutions(rows,'resoluciones.csv');
+  }
+  const expDataBtn=el('#btnExportData');
+  const expReportBtn=el('#btnExportReport');
+  const expResolutionBtn=el('#btnExportResolution');
+  if(expDataBtn) expDataBtn.addEventListener('click', handleDataExport);
+  if(expReportBtn) expReportBtn.addEventListener('click', handleReportExport);
+  if(expResolutionBtn) expResolutionBtn.addEventListener('click', handleResolutionExport);
+
+  // —— Nota de conexión ——
+  // Los datos se cargan desde Google Sheets mediante la URL de Apps Script definida en API_URL.
+
+  attachForgotPasswordHandler();
+
+  const resetCancelBtn = document.getElementById('resetCancel');
+  if(resetCancelBtn){
+    resetCancelBtn.addEventListener('click', () => {
+      const resetEmailInput = document.getElementById('resetEmail');
+      if(resetEmailInput){
+        lastLoginEmail = resetEmailInput.value || lastLoginEmail;
+      }
+      showSignInView();
+    });
+  }
+
+  const resetForm = document.getElementById('resetForm');
+  if(resetForm){
+    resetForm.addEventListener('submit', async event => {
+      event.preventDefault();
+      const emailInput = document.getElementById('resetEmail');
+      const userIdInput = document.getElementById('resetUserId');
+      const email = (emailInput?.value || '').trim().toLowerCase();
+      const userId = (userIdInput?.value || '').trim();
+      if(!email || !userId){
+        setResetStatus('Ingresa correo e ID de usuario.', 'error');
+        return;
+      }
+      setResetBusy(true);
+      setResetStatus('');
+      try{
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          body: JSON.stringify({ action: 'requestPasswordReset', email, userId })
+        });
+        let data = null;
+        try{
+          data = await response.json();
+        }catch(_err){
+          data = null;
+        }
+        if(!response.ok || !data || data.error){
+          const message = data && data.error ? data.error : `Error al generar la contraseña (${response.status})`;
+          throw new Error(message);
+        }
+        const tempPassword = data.tempPassword || '';
+        const baseMessage = data.message || 'Contraseña temporal generada.';
+        const message = tempPassword ? `${baseMessage} Contraseña temporal: ${tempPassword}` : baseMessage;
+        setResetStatus(message, 'success');
+        updateResetHint('Copia la contraseña temporal y da clic en "Volver a iniciar sesión" para utilizarla.');
+        lastLoginEmail = email;
+        pendingResetCredentials = {
+          email,
+          password: tempPassword,
+          message: 'Contraseña temporal generada. Ingresa y cámbiala desde Configuración.'
+        };
+      }catch(err){
+        setResetStatus(resolveErrorMessage(err, 'No se pudo generar la contraseña temporal.'), 'error');
+      }finally{
+        setResetBusy(false);
+      }
+    });
+  }
+
+  const connectionCheckBtn = document.getElementById('connectionCheckBtn');
+  if(connectionCheckBtn){
+    connectionCheckBtn.classList.add('hidden');
+
+    const versionTargets = document.querySelectorAll('.site-footer__version, .login-meta__version');
+    let secretClickCount = 0;
+    let secretClickTimer = null;
+    const SECRET_CLICK_RESET_DELAY_MS = 800;
+
+    const resetSecretClickCounter = () => {
+      secretClickCount = 0;
+      if(secretClickTimer){
+        clearTimeout(secretClickTimer);
+        secretClickTimer = null;
+      }
+    };
+
+    const handleVersionSecretClick = () => {
+      secretClickCount += 1;
+      if(secretClickCount === 1){
+        secretClickTimer = setTimeout(resetSecretClickCounter, SECRET_CLICK_RESET_DELAY_MS);
+      }
+      if(secretClickCount >= 3){
+        connectionCheckBtn.classList.remove('hidden');
+        resetSecretClickCounter();
+      }
+    };
+
+    versionTargets.forEach(node => {
+      node.addEventListener('click', handleVersionSecretClick);
+    });
+
+    connectionCheckBtn.addEventListener('click', () => {
+      checkAppsScriptConnection();
+    });
+  }
+
+  const loginForm = document.getElementById('loginForm');
+  if(loginForm){
+    loginForm.addEventListener('submit', async event => {
+      event.preventDefault();
+      const emailInput = document.getElementById('loginEmail');
+      const passwordInput = document.getElementById('loginPassword');
+      const email = (emailInput?.value || '').trim().toLowerCase();
+      const password = (passwordInput?.value || '').trim();
+      if(!email || !password){
+        setLoginError('Ingresa correo y contraseña.');
+        return;
+      }
+      setConnectionStatus('');
+      setLoginBusy(true);
+      setLoginError('');
+      try{
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          body: JSON.stringify({ action: 'login', email, password })
+        });
+        let data = null;
+        try{
+          data = await response.json();
+        }catch(_err){
+          data = null;
+        }
+        if(!response.ok || !data || data.error){
+          const message = data && data.error ? data.error : `Error de inicio de sesión (${response.status})`;
+          throw new Error(message);
+        }
+        await onAuthenticated(data.token, data.user, { persist: true });
+        loginForm.reset();
+      }catch(err){
+        setLoginError(resolveErrorMessage(err, 'No se pudo iniciar sesión.'));
+      }finally{
+        setLoginBusy(false);
+      }
+    });
+  }
+
+  restoreSession();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a stand-alone HTML export of the CRM interface without the Integraciones vista or related scripts
- keep KPI, leads, messaging, administración and configuración panels so the base fría and KPI flows remain available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c4a33404832c8b40611580a5cd4c